### PR TITLE
Improve installation description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,15 @@ Installing
 
     pip install snips-nlu
 
+.. note::
+
+   Currently we have built binaries (wheels) for ``snips-nlu`` and its
+   dependencies for MacOS and Linux x86_64. If you use different
+   architectures/os you will need to build these dependencies from sources
+   which means you will need to install
+   `setuptools_rust <https://github.com/PyO3/setuptools-rust>`_ and
+   `Rust <https://www.rust-lang.org/en-US/install.html>`_.
+
 
 A simple example
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -24,15 +24,13 @@ Installing
 
     pip install snips-nlu
 
-.. note::
-
-   Currently we have built binaries (wheels) for ``snips-nlu`` and its
-   dependencies for MacOS and Linux x86_64. If you use different
-   architectures/os you will need to build these dependencies from sources
-   which means you will need to install
-   `setuptools_rust <https://github.com/PyO3/setuptools-rust>`_ and
-   `Rust <https://www.rust-lang.org/en-US/install.html>`_.
-
+We currently have pre-built binaries (wheels) for ``snips-nlu`` and its
+dependencies for MacOS and Linux x86_64. If you use a different
+architecture/os you will need to build these dependencies from sources
+which means you will need to install
+`setuptools_rust <https://github.com/PyO3/setuptools-rust>`_ and
+`Rust <https://www.rust-lang.org/en-US/install.html>`_ before running the
+``pip install snips-nlu`` command.
 
 A simple example
 ----------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -23,14 +23,13 @@ Snips NLU can be installed via pip with the following command:
     pip install snips-nlu
 
 
-.. note::
-
-   Currently we have built binaries (wheels) for ``snips-nlu`` and its
-   dependencies for MacOS and Linux x86_64. If you use different
-   architectures/os you will need to build these dependencies from sources
-   which means you will need to install
-   `setuptools_rust <https://github.com/PyO3/setuptools-rust>`_ and
-   `Rust <https://www.rust-lang.org/en-US/install.html>`_.
+We currently have pre-built binaries (wheels) for ``snips-nlu`` and its
+dependencies for MacOS and Linux x86_64. If you use a different
+architecture/os you will need to build these dependencies from sources
+which means you will need to install
+`setuptools_rust <https://github.com/PyO3/setuptools-rust>`_ and
+`Rust <https://www.rust-lang.org/en-US/install.html>`_ before running the
+``pip install snips-nlu`` command.
 
 Extra dependencies
 ------------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -22,6 +22,16 @@ Snips NLU can be installed via pip with the following command:
 
     pip install snips-nlu
 
+
+.. note::
+
+   Currently we have built binaries (wheels) for ``snips-nlu`` and its
+   dependencies for MacOS and Linux x86_64. If you use different
+   architectures/os you will need to build these dependencies from sources
+   which means you will need to install
+   `setuptools_rust <https://github.com/PyO3/setuptools-rust>`_ and
+   `Rust <https://www.rust-lang.org/en-US/install.html>`_.
+
 Extra dependencies
 ------------------
 


### PR DESCRIPTION
I added some notes about the `setuptools_rust` / `rust` installation that you need to have before building from sources