### PR TITLE
Leverage builtin entities to improve intent classification

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -5,8 +5,8 @@ import io
 import json
 import os
 import sys
-
 from builtins import bytes, input
+
 from snips_nlu_metrics import (
     compute_cross_val_metrics, compute_train_test_metrics)
 
@@ -86,6 +86,9 @@ def parse_cross_val_args(args):
     parser.add_argument("-t", "--train-size-ratio", type=float, metavar="",
                         help="Fraction of the data that we want to use for "
                              "training (between 0 and 1)")
+    parser.add_argument(
+        "-esm", "--exclude-slot-metrics", action="store_true",
+        help="Exclude slot metrics and slot errors in the output")
     parser.add_argument("-i", "--include-errors", action="store_true",
                         help="Include parsing errors in the output")
     return parser.parse_args(args)
@@ -96,6 +99,7 @@ def main_cross_val_metrics():
 
     dataset_path = args.pop("dataset_path")
     output_path = args.pop("output_path")
+    exclude_slot_metrics = args.get("exclude_slot_metrics", False)
 
     def progression_handler(progress):
         print("%d%%" % int(progress * 100))
@@ -103,6 +107,7 @@ def main_cross_val_metrics():
     metrics_args = dict(
         dataset=dataset_path,
         engine_class=SnipsNLUEngine,
+        include_slot_metrics=not exclude_slot_metrics,
         progression_handler=progression_handler
     )
     if args.get("nb_folds") is not None:
@@ -131,6 +136,9 @@ def parse_train_test_args(args):
     parser.add_argument("train_dataset_path", type=str)
     parser.add_argument("test_dataset_path", type=str)
     parser.add_argument("output_path", type=str)
+    parser.add_argument(
+        "-esm", "--exclude-slot-metrics", action="store_true",
+        help="Exclude slot metrics and slot errors in the output")
     parser.add_argument("-i", "--include-errors", action="store_true",
                         help="Include parsing errors in the output")
     return parser.parse_args(args)
@@ -142,11 +150,13 @@ def main_train_test_metrics():
     train_dataset_path = args.pop("train_dataset_path")
     test_dataset_path = args.pop("test_dataset_path")
     output_path = args.pop("output_path")
+    exclude_slot_metrics = args.get("exclude_slot_metrics", False)
 
     metrics_args = dict(
         train_dataset=train_dataset_path,
         test_dataset=test_dataset_path,
-        engine_class=SnipsNLUEngine
+        engine_class=SnipsNLUEngine,
+        include_slot_metrics=not exclude_slot_metrics
     )
 
     include_errors = args.get("include_errors", False)

--- a/debug/debug.py
+++ b/debug/debug.py
@@ -52,13 +52,12 @@ def debug_inference(engine_path):
 
 def main_debug():
     parser = argparse.ArgumentParser(description="Debug snippets")
-    parser.add_argument("mode", type=bytes,
-                        choices=["training", "inference"],
+    parser.add_argument("mode", choices=["training", "inference"],
                         help="'training' to debug training and 'inference to "
                              "debug inference'")
-    parser.add_argument("path", type=bytes,
+    parser.add_argument("path",
                         help="Path to the dataset or trained assistant")
-    parser.add_argument("--config-path", type=bytes,
+    parser.add_argument("--config-path",
                         help="Path to the assistant configuration")
     args = vars(parser.parse_args())
     mode = args.pop("mode")

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -59,7 +59,7 @@ class LogRegIntentClassifier(IntentClassifier):
         random_state = check_random_state(self.config.random_seed)
         filtered_dataset = remove_builtin_slots(dataset)
         data_augmentation_config = self.config.data_augmentation_config
-        utterances, y, intent_list = build_training_data(
+        utterances, classes, intent_list = build_training_data(
             filtered_dataset, language, data_augmentation_config, random_state)
 
         self.intent_list = intent_list
@@ -70,7 +70,8 @@ class LogRegIntentClassifier(IntentClassifier):
             language,
             data_augmentation_config.unknown_words_replacement_string,
             self.config.featurizer_config)
-        self.featurizer = self.featurizer.fit(filtered_dataset, utterances, y)
+        self.featurizer = self.featurizer.fit(filtered_dataset, utterances,
+                                              classes)
         if self.featurizer is None:
             return self
 
@@ -78,7 +79,7 @@ class LogRegIntentClassifier(IntentClassifier):
         alpha = get_regularization_factor(filtered_dataset)
         self.classifier = SGDClassifier(random_state=random_state,
                                         alpha=alpha, **LOG_REG_ARGS)
-        self.classifier.fit(X, y)
+        self.classifier.fit(X, classes)
         return self
 
     def get_intent(self, text, intents_filter=None):

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -9,8 +9,8 @@ from snips_nlu.constants import LANGUAGE
 from snips_nlu.dataset import validate_and_format_dataset
 from snips_nlu.intent_classifier.featurizer import Featurizer
 from snips_nlu.intent_classifier.intent_classifier import IntentClassifier
-from snips_nlu.intent_classifier.log_reg_classifier_utils import \
-    remove_builtin_slots, get_regularization_factor, build_training_data
+from snips_nlu.intent_classifier.log_reg_classifier_utils import (
+    get_regularization_factor, build_training_data)
 from snips_nlu.pipeline.configs import LogRegIntentClassifierConfig
 from snips_nlu.result import intent_classification_result
 from snips_nlu.utils import check_random_state, NotTrained
@@ -57,10 +57,10 @@ class LogRegIntentClassifier(IntentClassifier):
         dataset = validate_and_format_dataset(dataset)
         language = dataset[LANGUAGE]
         random_state = check_random_state(self.config.random_seed)
-        filtered_dataset = remove_builtin_slots(dataset)
+
         data_augmentation_config = self.config.data_augmentation_config
         utterances, classes, intent_list = build_training_data(
-            filtered_dataset, language, data_augmentation_config, random_state)
+            dataset, language, data_augmentation_config, random_state)
 
         self.intent_list = intent_list
         if len(self.intent_list) <= 1:
@@ -70,13 +70,12 @@ class LogRegIntentClassifier(IntentClassifier):
             language,
             data_augmentation_config.unknown_words_replacement_string,
             self.config.featurizer_config)
-        self.featurizer = self.featurizer.fit(filtered_dataset, utterances,
-                                              classes)
+        self.featurizer = self.featurizer.fit(dataset, utterances, classes)
         if self.featurizer is None:
             return self
 
         X = self.featurizer.transform(utterances)  # pylint: disable=C0103
-        alpha = get_regularization_factor(filtered_dataset)
+        alpha = get_regularization_factor(dataset)
         self.classifier = SGDClassifier(random_state=random_state,
                                         alpha=alpha, **LOG_REG_ARGS)
         self.classifier.fit(X, classes)

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import json
 from builtins import bytes
 
+import numpy as np
 from future.utils import iteritems
 from mock import patch, mock
 
@@ -56,7 +57,7 @@ class TestIntentClassifierFeaturizer(SnipsTest):
             "bird birdy",
             "beautiful bird"
         ]
-        classes = [0, 0, 0, 1, 1]
+        classes = np.array([0, 0, 0, 1, 1])
 
         featurizer.fit(dataset, queries, classes)
 
@@ -293,13 +294,13 @@ class TestIntentClassifierFeaturizer(SnipsTest):
             "Bird bïrdy",
             "beauTiful éntity 1 bIrd Éntity_2"
         ]
-        labels = [0, 0, 1, 1]
+        labels = np.array([0, 0, 1, 1])
 
         featurizer = Featurizer(language, None).fit(
             dataset, queries, labels)
 
         # When
-        queries = featurizer.preprocess_queries(queries)
+        queries = featurizer.preprocess_utterances(queries)
 
         # Then
         expected_queries = [
@@ -331,7 +332,7 @@ class TestIntentClassifierFeaturizer(SnipsTest):
             language, unknown_words_replacement_string=replacement_string,
             config=FeaturizerConfig())
         queries = ["hello dude"]
-        y = [1]
+        y = np.array([1])
 
         # When
         featurizer.fit(dataset, queries, y)

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -217,7 +217,7 @@ class TestIntentClassifierFeaturizer(SnipsTest):
     @patch("snips_nlu.intent_classifier.featurizer.stem")
     @patch("snips_nlu.intent_classifier.featurizer."
            "CLUSTER_USED_PER_LANGUAGES", {LANGUAGE_EN: "brown_clusters"})
-    def test_preprocess_queries(self, mocked_stem, mocked_word_cluster):
+    def test_preprocess_utterances(self, mocked_stem, mocked_word_cluster):
         # Given
         language = LANGUAGE_EN
 
@@ -288,7 +288,7 @@ class TestIntentClassifierFeaturizer(SnipsTest):
 
         dataset = validate_and_format_dataset(dataset)
 
-        queries = [
+        utterances = [
             "hÉllo wOrld Éntity_2",
             "beauTiful World entity 1",
             "Bird bïrdy",
@@ -296,23 +296,26 @@ class TestIntentClassifierFeaturizer(SnipsTest):
         ]
         labels = np.array([0, 0, 1, 1])
 
-        featurizer = Featurizer(language, None).fit(
-            dataset, queries, labels)
+        featurizer = Featurizer(language, None).fit(dataset, utterances,
+                                                    labels)
 
         # When
-        queries = featurizer.preprocess_utterances(queries)
+        utterances = featurizer.preprocess_utterances(utterances)
 
         # Then
-        expected_queries = [
-            "hello world entity_2 entityfeatureentity_2",
-            "beauty world ent 1 entityfeatureentity_1 entityfeatureentity_2 "
+        expected_utterances = [
+            "hello world entity_ builtinentityfeaturesnipsnumber "
+            "entityfeatureentity_2",
+            "beauty world ent builtinentityfeaturesnipsnumber "
+            "entityfeatureentity_1 entityfeatureentity_2 "
             "cluster_1 cluster_3",
             "bird bird",
-            "beauty ent 1 bird entity_2 entityfeatureentity_1 "
+            "beauty ent bird entity_ builtinentityfeaturesnipsnumber "
+            "builtinentityfeaturesnipsnumber entityfeatureentity_1 "
             "entityfeatureentity_2 entityfeatureentity_2 cluster_1"
         ]
 
-        self.assertListEqual(queries, expected_queries)
+        self.assertListEqual(utterances, expected_utterances)
 
     def test_featurizer_should_exclude_replacement_string(self):
         # Given


### PR DESCRIPTION
**Description**
This PR brings some improvement to the intent classification by leveraging the presence of builtin entities in the training data. 
The strategy consists in preprocessing utterances by looking for builtin entities within the utterances, and add markers for each each entity found while removing the builtin entity substring from the utterance. This allows to capture the fact that a builtin entity is present in an utterance, and prevents from learning specific builtin entities occurence such as `42`.

I have run some intent classification metrics in order to confirm that this improved significantly the performances.