### PR TITLE
Remove deprecated config parameter

### DIFF
--- a/samples/configs/config_de.json
+++ b/samples/configs/config_de.json
@@ -160,7 +160,6 @@
           "algorithm": "lbfgs"
         },
         "tagging_scheme": 1,
-        "exhaustive_permutations_threshold": 64,
         "data_augmentation_config": {
           "min_utterances": 200,
           "capitalization_ratio": 0.2

--- a/samples/configs/config_en.json
+++ b/samples/configs/config_en.json
@@ -137,7 +137,6 @@
           "algorithm": "lbfgs"
         },
         "tagging_scheme": 1,
-        "exhaustive_permutations_threshold": 64,
         "data_augmentation_config": {
           "min_utterances": 200,
           "capitalization_ratio": 0.2

--- a/samples/configs/config_es.json
+++ b/samples/configs/config_es.json
@@ -124,7 +124,6 @@
           "algorithm": "lbfgs"
         },
         "tagging_scheme": 1,
-        "exhaustive_permutations_threshold": 64,
         "data_augmentation_config": {
           "min_utterances": 200,
           "capitalization_ratio": 0.2

--- a/samples/configs/config_fr.json
+++ b/samples/configs/config_fr.json
@@ -124,7 +124,6 @@
           "algorithm": "lbfgs"
         },
         "tagging_scheme": 1,
-        "exhaustive_permutations_threshold": 64,
         "data_augmentation_config": {
           "min_utterances": 200,
           "capitalization_ratio": 0.2

--- a/samples/configs/config_ja.json
+++ b/samples/configs/config_ja.json
@@ -160,7 +160,6 @@
           "algorithm": "lbfgs"
         },
         "tagging_scheme": 1,
-        "exhaustive_permutations_threshold": 64,
         "data_augmentation_config": {
           "min_utterances": 200,
           "capitalization_ratio": 0.2

--- a/samples/configs/config_ko.json
+++ b/samples/configs/config_ko.json
@@ -160,7 +160,6 @@
           "algorithm": "lbfgs"
         },
         "tagging_scheme": 1,
-        "exhaustive_permutations_threshold": 64,
         "data_augmentation_config": {
           "min_utterances": 200,
           "capitalization_ratio": 0.2

--- a/snips_nlu/pipeline/configs/slot_filler.py
+++ b/snips_nlu/pipeline/configs/slot_filler.py
@@ -19,8 +19,6 @@ class CRFSlotFillerConfig(ProcessingUnitConfig):
         crf_args (dict, optional): Allow to overwrite the parameters of the CRF
             defined in *sklearn_crfsuite*, see :class:`sklearn_crfsuite.CRF`
             (default={"c1": .1, "c2": .1, "algorithm": "lbfgs"})
-        exhaustive_permutations_threshold (int, optional):
-            TODO: properly document this
         data_augmentation_config (dict or :class:`.SlotFillerDataAugmentationConfig`, optional):
             Specify how to augment data before training the CRF, see the
             corresponding config object for more details.
@@ -33,7 +31,6 @@ class CRFSlotFillerConfig(ProcessingUnitConfig):
     # pylint: disable=super-init-not-called
     def __init__(self, feature_factory_configs=None,
                  tagging_scheme=None, crf_args=None,
-                 exhaustive_permutations_threshold=4 ** 3,
                  data_augmentation_config=None, random_seed=None):
         if tagging_scheme is None:
             from snips_nlu.slot_filler.crf_utils import TaggingScheme
@@ -48,8 +45,6 @@ class CRFSlotFillerConfig(ProcessingUnitConfig):
         self._tagging_scheme = None
         self.tagging_scheme = tagging_scheme
         self.crf_args = crf_args
-        self.exhaustive_permutations_threshold = \
-            exhaustive_permutations_threshold
         self._data_augmentation_config = None
         self.data_augmentation_config = data_augmentation_config
         self.random_seed = random_seed
@@ -98,8 +93,6 @@ class CRFSlotFillerConfig(ProcessingUnitConfig):
             "feature_factory_configs": self.feature_factory_configs,
             "crf_args": self.crf_args,
             "tagging_scheme": self.tagging_scheme.value,
-            "exhaustive_permutations_threshold":
-                self.exhaustive_permutations_threshold,
             "data_augmentation_config":
                 self.data_augmentation_config.to_dict(),
             "random_seed": self.random_seed

--- a/snips_nlu/tests/test_config.py
+++ b/snips_nlu/tests/test_config.py
@@ -98,7 +98,6 @@ class TestConfig(SnipsTest):
                 "c2": .3,
                 "algorithm": "lbfgs"
             },
-            "exhaustive_permutations_threshold": 42,
             "data_augmentation_config":
                 SlotFillerDataAugmentationConfig().to_dict(),
             "random_seed": 43

--- a/snips_nlu/tests/test_crf_slot_filler.py
+++ b/snips_nlu/tests/test_crf_slot_filler.py
@@ -566,8 +566,7 @@ class TestCRFSlotFiller(SnipsTest):
             else:
                 raise ValueError("Unexpected tag sequence: %s" % tags_)
 
-        slot_filler_config = CRFSlotFillerConfig(
-            random_seed=42, exhaustive_permutations_threshold=2)
+        slot_filler_config = CRFSlotFillerConfig(random_seed=42)
         slot_filler = CRFSlotFiller(config=slot_filler_config)
         slot_filler.language = LANGUAGE_EN
         slot_filler.intent = "intent1"


### PR DESCRIPTION
The `exhaustive_permutation_threshold` parameter is no longer needed