### PR TITLE
Fix issues with features

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ required = [
     "scikit-learn==0.19.1",
     "sklearn-crfsuite==0.3.6",
     "semantic_version==2.6.0",
-    "snips_nlu_utils==0.6.0",
+    "snips_nlu_utils==0.6.1",
     "snips_nlu_ontology==0.54.2",
     "num2words==0.5.6"
 ]

--- a/snips_nlu/slot_filler/crf_slot_filler.py
+++ b/snips_nlu/slot_filler/crf_slot_filler.py
@@ -53,7 +53,7 @@ class CRFSlotFiller(SlotFiller):
         super(CRFSlotFiller, self).__init__(config)
         self.crf_model = None
         self.features_factories = [get_feature_factory(conf) for conf in
-                                   config.feature_factory_configs]
+                                   self.config.feature_factory_configs]
         self._features = None
         self.language = None
         self.intent = None

--- a/snips_nlu/slot_filler/feature_factory.py
+++ b/snips_nlu/slot_filler/feature_factory.py
@@ -5,7 +5,7 @@ from abc import ABCMeta, abstractmethod
 from builtins import map, object
 from future.utils import with_metaclass, iteritems
 from snips_nlu_ontology.builtin_entities import get_supported_entities
-from snips_nlu_utils import normalize
+from snips_nlu_utils import get_shape, normalize
 
 from snips_nlu.builtin_entities import get_builtin_entities
 from snips_nlu.constants import (
@@ -18,7 +18,7 @@ from snips_nlu.resources import get_gazetteer, get_word_clusters, \
 from snips_nlu.slot_filler.crf_utils import TaggingScheme, get_scheme_prefix
 from snips_nlu.slot_filler.feature import Feature
 from snips_nlu.slot_filler.features_utils import (
-    get_word_chunk, get_shape, get_all_ngrams, initial_string_from_tokens,
+    get_word_chunk, get_all_ngrams, initial_string_from_tokens,
     entity_filter, get_intent_custom_entities)
 
 

--- a/snips_nlu/slot_filler/feature_factory.py
+++ b/snips_nlu/slot_filler/feature_factory.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
 from abc import ABCMeta, abstractmethod
+from builtins import map, object, str
 
-from builtins import map, object
 from future.utils import with_metaclass, iteritems
 from snips_nlu_ontology.builtin_entities import get_supported_entities
 from snips_nlu_utils import get_shape, normalize
@@ -167,7 +167,7 @@ class LengthFactory(SingleFeatureFactory):
     name = "length"
 
     def compute_feature(self, tokens, token_index):
-        return len(tokens[token_index].value)
+        return str(len(tokens[token_index].value))
 
 
 class NgramFactory(SingleFeatureFactory):

--- a/snips_nlu/slot_filler/feature_factory.py
+++ b/snips_nlu/slot_filler/feature_factory.py
@@ -196,9 +196,9 @@ class NgramFactory(SingleFeatureFactory):
         self.use_stemming = self.args["use_stemming"]
         self.common_words_gazetteer_name = self.args[
             "common_words_gazetteer_name"]
+        self.gazetteer = None
         self._language = None
         self.language = self.args.get("language_code")
-        self.gazetteer = None
 
     @property
     def language(self):

--- a/snips_nlu/slot_filler/features_utils.py
+++ b/snips_nlu/slot_filler/features_utils.py
@@ -18,19 +18,6 @@ def get_all_ngrams(tokens):
     return _NGRAMS_CACHE[key]
 
 
-def get_shape(string):
-    if string.islower():
-        shape = "xxx"
-    elif string.isupper():
-        shape = "XXX"
-    # Hack for Rust parallelism (we could use istitle but it does not exists)
-    elif len(string) > 1 and string[0].isupper() and string[1:].islower():
-        shape = "Xxx"
-    else:
-        shape = "xX"
-    return shape
-
-
 def get_word_chunk(word, chunk_size, chunk_start, reverse=False):
     if chunk_size < 1:
         raise ValueError("chunk size should be >= 1")

--- a/snips_nlu/tests/test_crf_features.py
+++ b/snips_nlu/tests/test_crf_features.py
@@ -241,7 +241,7 @@ class TestCRFFeatures(SnipsTest):
         # Then
         self.assertIsInstance(factory, LengthFactory)
         self.assertEqual(features[0].base_name, "length")
-        self.assertEqual(res, 5)
+        self.assertEqual(res, "5")
 
     def test_ngram_factory(self):
         # Given

--- a/snips_nlu/tests/test_features_utils.py
+++ b/snips_nlu/tests/test_features_utils.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from snips_nlu.constants import NGRAM, TOKEN_INDEXES
-from snips_nlu.slot_filler.features_utils import get_all_ngrams, get_shape
+from snips_nlu.slot_filler.features_utils import get_all_ngrams
 from snips_nlu.tests.utils import SnipsTest
 
 
@@ -35,19 +35,3 @@ class TestFeaturesUtils(SnipsTest):
         ]
 
         self.assertListEqual(expected_ngrams, ngrams)
-
-    def test_get_shape(self):
-        # Given
-        data = [
-            ("tragédie", "xxx"),
-            ("Tragédie", "Xxx"),
-            ("TRAGÉDIE", "XXX"),
-            ("traGédie", "xX")
-        ]
-
-        for text, expected_capitalization in data:
-            # When
-            capitalization = get_shape(text)
-
-            # Then
-            self.assertEqual(capitalization, expected_capitalization)


### PR DESCRIPTION
**Description**
This PR fixes various issues with CRF slot filler features:
- use `get_shape` function from `snips-nlu-utils` in order to avoid discrepancy with the Rust pipeline
- fix a bug which caused the common words gazetteer of the ngram feature to be always `None`
- transform the length feature to a string instead of an int