### PR TITLE
Limit the number of combination made in variations

### DIFF
--- a/snips_nlu/string_variations.py
+++ b/snips_nlu/string_variations.py
@@ -8,8 +8,8 @@ from builtins import range
 from builtins import str
 from builtins import zip
 from future.utils import iteritems
-from snips_nlu_utils import normalize
 from num2words import num2words
+from snips_nlu_utils import normalize
 
 from snips_nlu.builtin_entities import get_builtin_entities
 from snips_nlu.constants import (
@@ -32,6 +32,8 @@ AND_REGEXES = {
         re.IGNORECASE)
     for language, utterances in iteritems(AND_UTTERANCES)
 }
+
+MAX_ENTITY_VARIATIONS = 10
 
 
 def build_variated_query(string, ranges_and_utterances):
@@ -60,6 +62,8 @@ def and_variations(string, language):
     matches = sorted(matches, key=lambda x: x.start())
     values = [({START: m.start(), END: m.end()}, AND_UTTERANCES[language])
               for m in matches]
+    if len(AND_UTTERANCES[language]) ** len(values) > MAX_ENTITY_VARIATIONS:
+        return set()
     combinations = itertools.product(range(len(AND_UTTERANCES[language])),
                                      repeat=len(values))
     for c in combinations:
@@ -79,6 +83,8 @@ def punctuation_variations(string, language):
     values = [({START: m.start(), END: m.end()}, (m.group(0), ""))
               for m in matches]
 
+    if 2 ** len(values) > MAX_ENTITY_VARIATIONS:
+        return set()
     combinations = itertools.product(range(2), repeat=len(matches))
     for c in combinations:
         ranges_and_utterances = [(values[i][0], values[i][1][ix])
@@ -122,6 +128,8 @@ def numbers_variations(string, language):
               zip(number_entities, digit_values, alpha_values)
               if a is not None]
 
+    if 2 ** len(values) > MAX_ENTITY_VARIATIONS:
+        return set()
     combinations = itertools.product(range(2), repeat=len(values))
     for c in combinations:
         ranges_and_utterances = [(values[i][0], values[i][1][ix])

--- a/snips_nlu/string_variations.py
+++ b/snips_nlu/string_variations.py
@@ -51,21 +51,25 @@ def build_variated_query(string, ranges_and_utterances):
 
 def and_variations(string, language):
     and_regex = AND_REGEXES.get(language, None)
-    variations = set()
     if and_regex is None:
-        return variations
+        return set()
 
     matches = [m for m in and_regex.finditer(string)]
     if not matches:
-        return variations
+        return set()
 
     matches = sorted(matches, key=lambda x: x.start())
-    values = [({START: m.start(), END: m.end()}, AND_UTTERANCES[language])
+    and_utterances = AND_UTTERANCES[language]
+    values = [({START: m.start(), END: m.end()}, and_utterances)
               for m in matches]
-    if len(AND_UTTERANCES[language]) ** len(values) > MAX_ENTITY_VARIATIONS:
+
+    n_values = len(values)
+    n_and_utterances = len(and_utterances)
+    if n_and_utterances ** n_values > MAX_ENTITY_VARIATIONS:
         return set()
-    combinations = itertools.product(range(len(AND_UTTERANCES[language])),
-                                     repeat=len(values))
+
+    combinations = itertools.product(range(n_and_utterances), repeat=n_values)
+    variations = set()
     for c in combinations:
         ranges_and_utterances = [(values[i][0], values[i][1][ix])
                                  for i, ix in enumerate(c)]
@@ -74,18 +78,20 @@ def and_variations(string, language):
 
 
 def punctuation_variations(string, language):
-    variations = set()
     matches = [m for m in get_punctuation_regex(language).finditer(string)]
     if not matches:
-        return variations
+        return set()
 
     matches = sorted(matches, key=lambda x: x.start())
     values = [({START: m.start(), END: m.end()}, (m.group(0), ""))
               for m in matches]
 
-    if 2 ** len(values) > MAX_ENTITY_VARIATIONS:
+    n_values = len(values)
+    if 2 ** n_values > MAX_ENTITY_VARIATIONS:
         return set()
-    combinations = itertools.product(range(2), repeat=len(matches))
+
+    combinations = itertools.product(range(2), repeat=n_values)
+    variations = set()
     for c in combinations:
         ranges_and_utterances = [(values[i][0], values[i][1][ix])
                                  for i, ix in enumerate(c)]
@@ -109,9 +115,8 @@ def alphabetic_value(number_entity, language):
 
 
 def numbers_variations(string, language):
-    variations = set()
     if not supports_num2words(language):
-        return variations
+        return set()
 
     number_entities = get_builtin_entities(
         string, language, scope=[SNIPS_NUMBER])
@@ -119,7 +124,7 @@ def numbers_variations(string, language):
     number_entities = sorted(number_entities,
                              key=lambda x: x[RES_MATCH_RANGE][START])
     if not number_entities:
-        return variations
+        return set()
 
     digit_values = [digit_value(e) for e in number_entities]
     alpha_values = [alphabetic_value(e, language) for e in number_entities]
@@ -128,9 +133,12 @@ def numbers_variations(string, language):
               zip(number_entities, digit_values, alpha_values)
               if a is not None]
 
-    if 2 ** len(values) > MAX_ENTITY_VARIATIONS:
+    n_values = len(values)
+    if 2 ** n_values > MAX_ENTITY_VARIATIONS:
         return set()
-    combinations = itertools.product(range(2), repeat=len(values))
+
+    combinations = itertools.product(range(2), repeat=n_values)
+    variations = set()
     for c in combinations:
         ranges_and_utterances = [(values[i][0], values[i][1][ix])
                                  for i, ix in enumerate(c)]


### PR DESCRIPTION
Entity variation must be limited to a maximum of variations otherwise it can run for a very long time:
- added a `MAX_ENTITY_VARIATIONS` parameters
- for variation functions which generate variation by first computing combination, variations are not computed if the number of combinations are greater than `MAX_ENTITY_VARIATIONS`