### PR TITLE
Deactivate caching of builtin entity parsing at inference time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ required = [
     "sklearn-crfsuite==0.3.6",
     "semantic_version==2.6.0",
     "snips_nlu_utils==0.6.1",
-    "snips_nlu_ontology==0.55.0",
+    "snips_nlu_ontology==0.56.1",
     "num2words==0.5.6",
     "pygments==2.2.0",
 ]

--- a/snips_nlu/builtin_entities.py
+++ b/snips_nlu/builtin_entities.py
@@ -17,8 +17,10 @@ class BuiltinEntityParser(object):
         self.supported_entities = get_supported_entities(language)
         self._cache = LimitedSizeDict(size_limit=1000)
 
-    def parse(self, text, scope=None):
+    def parse(self, text, scope=None, use_cache=True):
         text = text.lower()  # Rustling only works with lowercase
+        if not use_cache:
+            return self.parser.parse(text, scope)
         cache_key = (text, str(scope))
         if cache_key not in self._cache:
             parser_result = self.parser.parse(text, scope)
@@ -39,9 +41,9 @@ def get_builtin_entity_parser(language):
     return _RUSTLING_PARSERS[language]
 
 
-def get_builtin_entities(text, language, scope=None):
+def get_builtin_entities(text, language, scope=None, use_cache=True):
     parser = get_builtin_entity_parser(language)
-    return parser.parse(text, scope=scope)
+    return parser.parse(text, scope=scope, use_cache=use_cache)
 
 
 def is_builtin_entity(entity_label):

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 
 import numpy as np
 import scipy.sparse as sp
-
 from future.utils import iteritems
 from sklearn.feature_extraction.text import TfidfTransformer, TfidfVectorizer
 from sklearn.feature_selection import chi2
@@ -236,7 +235,8 @@ def _preprocess_utterance(utterance, language,
     entities_features = _get_dataset_entities_features(
         normalized_stemmed_tokens, entity_utterances_to_features_names)
 
-    builtin_entities = get_builtin_entities(utterance, language)
+    builtin_entities = get_builtin_entities(utterance, language,
+                                            use_cache=True)
     entities_ranges = (
         e[RES_MATCH_RANGE] for e in
         sorted(builtin_entities, key=lambda e: e[RES_MATCH_RANGE][START])

--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -375,7 +375,7 @@ def _get_entity_name_placeholder(entity_label, language):
 
 
 def _replace_builtin_entities(text, language):
-    builtin_entities = get_builtin_entities(text, language)
+    builtin_entities = get_builtin_entities(text, language, use_cache=True)
     if not builtin_entities:
         return dict(), text
 

--- a/snips_nlu/nlu_engine/utils.py
+++ b/snips_nlu/nlu_engine/utils.py
@@ -9,7 +9,10 @@ from snips_nlu.result import custom_slot, builtin_slot
 
 # pylint:disable=redefined-builtin
 def resolve_slots(input, slots, dataset_entities, language, scope):
-    builtin_entities = get_builtin_entities(input, language, scope)
+    # Do not use cached entities here as datetimes must be computed using
+    # current context
+    builtin_entities = get_builtin_entities(input, language, scope,
+                                            use_cache=False)
     resolved_slots = []
     for slot in slots:
         entity_name = slot[RES_ENTITY]
@@ -25,7 +28,8 @@ def resolve_slots(input, slots, dataset_entities, language, scope):
                     break
             if not found:
                 builtin_matches = get_builtin_entities(raw_value, language,
-                                                       scope=[entity_name])
+                                                       scope=[entity_name],
+                                                       use_cache=False)
                 if builtin_matches:
                     resolved_slot = builtin_slot(slot,
                                                  builtin_matches[0][VALUE])

--- a/snips_nlu/slot_filler/crf_slot_filler.py
+++ b/snips_nlu/slot_filler/crf_slot_filler.py
@@ -6,10 +6,10 @@ import logging
 import math
 import os
 import tempfile
+from builtins import range
 from copy import copy
 from itertools import groupby, product
 
-from builtins import range
 from future.utils import iteritems
 from sklearn_crfsuite import CRF
 
@@ -262,9 +262,10 @@ class CRFSlotFiller(SlotFiller):
     def _augment_slots(self, text, tokens, tags, builtin_slots_names):
         scope = set(self.slot_name_mapping[slot]
                     for slot in builtin_slots_names)
-        builtin_entities = [be for entity_kind in scope
-                            for be in get_builtin_entities(text, self.language,
-                                                           [entity_kind])]
+        builtin_entities = [
+            be for entity_kind in scope for be in get_builtin_entities(
+                text, self.language, [entity_kind], use_cache=True)
+        ]
         # We remove builtin entities which conflicts with custom slots
         # extracted by the CRF
         builtin_entities = _filter_overlapping_builtins(

--- a/snips_nlu/slot_filler/feature_factory.py
+++ b/snips_nlu/slot_filler/feature_factory.py
@@ -495,7 +495,7 @@ class BuiltinEntityMatchFactory(CRFFeatureFactory):
             end = tokens[token_index].end
 
             builtin_entities = get_builtin_entities(
-                text, self.language, scope=[builtin_entity])
+                text, self.language, scope=[builtin_entity], use_cache=True)
             builtin_entities = [ent for ent in builtin_entities
                                 if entity_filter(ent, start, end)]
             for ent in builtin_entities:

--- a/snips_nlu/string_variations.py
+++ b/snips_nlu/string_variations.py
@@ -119,7 +119,7 @@ def numbers_variations(string, language):
         return set()
 
     number_entities = get_builtin_entities(
-        string, language, scope=[SNIPS_NUMBER])
+        string, language, scope=[SNIPS_NUMBER], use_cache=True)
 
     number_entities = sorted(number_entities,
                              key=lambda x: x[RES_MATCH_RANGE][START])


### PR DESCRIPTION
**Description**
Builtin entity parsing should not be cached unconditionally. Indeed, caching datetime builtin entities is a bad idea as they are often computed relatively to the current context.
Hence, caching is done during train time but deactivated at inference time when resolving values.