### PR TITLE
Improve preprocessing of utterances during intent classification training

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ required = [
     "sklearn-crfsuite==0.3.6",
     "semantic_version==2.6.0",
     "snips_nlu_utils==0.6.1",
-    "snips_nlu_ontology==0.56.1",
+    "snips_nlu_ontology==0.57.0",
     "num2words==0.5.6",
     "pygments==2.2.0",
 ]

--- a/snips_nlu/dataset.py
+++ b/snips_nlu/dataset.py
@@ -87,7 +87,7 @@ def validate_and_format_intent(intent, entities):
 
 
 def get_text_from_chunks(chunks):
-    return ''.join(chunk[TEXT] for chunk in chunks)
+    return "".join(chunk[TEXT] for chunk in chunks)
 
 
 def has_any_capitalization(entity_utterances, language):

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -7,7 +7,7 @@ import numpy as np
 from future.utils import iteritems
 from sklearn.linear_model import SGDClassifier
 
-from snips_nlu.constants import LANGUAGE, DATA, TEXT
+from snips_nlu.constants import LANGUAGE
 from snips_nlu.dataset import validate_and_format_dataset
 from snips_nlu.intent_classifier.featurizer import Featurizer
 from snips_nlu.intent_classifier.intent_classifier import IntentClassifier

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -7,12 +7,12 @@ import numpy as np
 from future.utils import iteritems
 from sklearn.linear_model import SGDClassifier
 
-from snips_nlu.constants import LANGUAGE
+from snips_nlu.constants import LANGUAGE, DATA, TEXT
 from snips_nlu.dataset import validate_and_format_dataset
 from snips_nlu.intent_classifier.featurizer import Featurizer
 from snips_nlu.intent_classifier.intent_classifier import IntentClassifier
 from snips_nlu.intent_classifier.log_reg_classifier_utils import (
-    get_regularization_factor, build_training_data)
+    get_regularization_factor, build_training_data, text_to_utterance)
 from snips_nlu.pipeline.configs import LogRegIntentClassifierConfig
 from snips_nlu.result import intent_classification_result
 from snips_nlu.utils import check_random_state, NotTrained, \
@@ -122,7 +122,9 @@ class LogRegIntentClassifier(IntentClassifier):
                 return None
             return intent_classification_result(self.intent_list[0], 1.0)
 
-        X = self.featurizer.transform([text])  # pylint: disable=C0103
+        # pylint: disable=C0103
+        X = self.featurizer.transform([text_to_utterance(text)])
+        # pylint: enable=C0103
         proba_vec = self._predict_proba(X, intents_filter=intents_filter)
         intents_probas = sorted(zip(self.intent_list, proba_vec[0]),
                                 key=lambda p: -p[1])

--- a/snips_nlu/intent_classifier/log_reg_classifier_utils.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier_utils.py
@@ -84,9 +84,10 @@ def generate_noise_utterances(augmented_utterances, num_intents,
     std_utterances_length = np.std(utterances_lengths)
     noise_it = get_noise_it(noise, mean_utterances_length,
                             std_utterances_length, random_state)
-    # Remove duplicate 'unknowword unknowword'
-    return [UNKNOWNWORD_REGEX.sub(UNKNOWNWORD, next(noise_it))
-            for _ in range(noise_size)]
+    # Remove duplicate 'unknownword unknownword'
+    return [
+        text_to_utterance(UNKNOWNWORD_REGEX.sub(UNKNOWNWORD, next(noise_it)))
+        for _ in range(noise_size)]
 
 
 def add_unknown_word_to_utterances(augmented_utterances, replacement_string,
@@ -140,8 +141,6 @@ def build_training_data(dataset, language, data_augmentation_config,
     noisy_utterances = generate_noise_utterances(
         augmented_utterances, len(intents), data_augmentation_config, language,
         random_state)
-    augmented_utterances = [get_text_from_chunks(u[DATA])
-                            for u in augmented_utterances]
 
     augmented_utterances += noisy_utterances
     utterance_classes += [noise_class for _ in noisy_utterances]
@@ -157,3 +156,7 @@ def build_training_data(dataset, language, data_augmentation_config,
             intent_mapping[intent_class] = intent
 
     return augmented_utterances, np.array(utterance_classes), intent_mapping
+
+
+def text_to_utterance(text):
+    return {DATA: [{TEXT: text}]}

--- a/snips_nlu/slot_filler/features_utils.py
+++ b/snips_nlu/slot_filler/features_utils.py
@@ -11,6 +11,8 @@ _NGRAMS_CACHE = LimitedSizeDict(size_limit=1000)
 
 
 def get_all_ngrams(tokens):
+    if not tokens:
+        return []
     key = "<||>".join(tokens)
     if key not in _NGRAMS_CACHE:
         ngrams = compute_all_ngrams(tokens, len(tokens))


### PR DESCRIPTION
**Description**
This PR improves how builtin entities are handled in intent classification at train time and inference time.

*Train time*
Builtin entities values found by the builtin entity parser are not dropped from the training data when they don't correspond to a slot, while slot values are dropped. This prevent from learning specific values such as `tomorrow`, `42`, while keeping other unrelated values such as `morning` (or `night`) in a `GoodMorning` (or `GoodNight`) intent with no slot. 
In both cases, a builtin entity feature using placeholder is used.

*Inference Time*
Builtin entities values found by the builtin entity parser are used in addition to the builtin entity feature.