### PR TITLE
cache gazetter steaming words to faster load models that use NgramFactory features

### DIFF
--- a/snips_nlu/slot_filler/feature_factory.py
+++ b/snips_nlu/slot_filler/feature_factory.py
@@ -168,6 +168,9 @@ class LengthFactory(SingleFeatureFactory):
         return str(len(tokens[token_index].value))
 
 
+gazetteer_stem_cache = {}
+
+
 class NgramFactory(SingleFeatureFactory):
     """Feature: the n-gram consisting of the considered token and potentially
     the following ones
@@ -211,7 +214,10 @@ class NgramFactory(SingleFeatureFactory):
                 gazetteer = get_gazetteer(self.language,
                                           self.common_words_gazetteer_name)
                 if self.use_stemming:
-                    gazetteer = set(stem(w, self.language) for w in gazetteer)
+                    key = (self.language, self.common_words_gazetteer_name, self.use_stemming)
+                    if key not in gazetteer_stem_cache:
+                        gazetteer_stem_cache[key] = set(stem(w, self.language) for w in gazetteer)
+                    gazetteer = gazetteer_stem_cache[key]
                 self.gazetteer = gazetteer
 
     @property


### PR DESCRIPTION
Hi team,

In a project that I'm working on, we have a dynamic number of models, and we can't cache them all on each python process.

So we have to load them dynamically often. Loading a sample model, which has 6 features of NgramFactory, (290ms of 300ms total load time for model) is taken stemming common_words_gazetteer_name from gazetter.  (using from_dict / to_dict )

So if we cache the stemmed words, loading models becomes extremly fast. This pull request in our case removes 60K calls to `stem(lang, word)` which takes 90% of domain load time for our model.

Is this something you'd be interested to have in core ?

ps: 
1. I didn't even create the model and don't know how `snips` works, just profiled and fixed.
2. The code sucks, I'll make it better if you are interested.

Regards,
Dorian