### PR TITLE
Fix the creation of slot names to entity mapping

### DIFF
--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -20,9 +20,9 @@ from snips_nlu.preprocessing import tokenize, tokenize_light
 from snips_nlu.result import (
     empty_result, intent_classification_result, parsing_result,
     unresolved_slot)
-from snips_nlu.utils import (NotTrained, check_persisted_path, json_string,
-                             log_elapsed_time, log_result, ranges_overlap,
-                             regex_escape)
+from snips_nlu.utils import (
+    NotTrained, check_persisted_path, get_slot_name_mappings, json_string,
+    log_elapsed_time, log_result, ranges_overlap, regex_escape)
 
 GROUP_NAME_PREFIX = "group"
 GROUP_NAME_SEPARATOR = "_"
@@ -86,7 +86,7 @@ class DeterministicIntentParser(IntentParser):
         self.group_names_to_slot_names = dict()
         joined_entity_utterances = _get_joined_entity_utterances(
             dataset, self.language)
-        self.slot_names_to_entities = _get_slot_names_mapping(dataset)
+        self.slot_names_to_entities = get_slot_name_mappings(dataset)
         for intent_name, intent in iteritems(dataset[INTENTS]):
             utterances = intent[UTTERANCES]
             patterns, self.group_names_to_slot_names = _generate_patterns(
@@ -158,7 +158,7 @@ class DeterministicIntentParser(IntentParser):
         slots = []
         for group_name in found_result.groupdict():
             slot_name = self.group_names_to_slot_names[group_name]
-            entity = self.slot_names_to_entities[slot_name]
+            entity = self.slot_names_to_entities[intent][slot_name]
             rng = (found_result.start(group_name),
                    found_result.end(group_name))
             if builtin_entities_ranges_mapping is not None:

--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -298,18 +298,6 @@ def _generate_new_index(slots_name_to_labels):
     return index
 
 
-def _get_slot_names_mapping(dataset):
-    slot_names_to_entities = dict()
-    for intent in itervalues(dataset[INTENTS]):
-        for utterance in intent[UTTERANCES]:
-            for chunk in utterance[DATA]:
-                if SLOT_NAME in chunk:
-                    slot_name = chunk[SLOT_NAME]
-                    entity = chunk[ENTITY]
-                    slot_names_to_entities[slot_name] = entity
-    return slot_names_to_entities
-
-
 def _query_to_pattern(query, joined_entity_utterances,
                       group_names_to_slot_names, language):
     pattern = []

--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -6,7 +6,7 @@ import re
 from builtins import str
 from pathlib import Path
 
-from future.utils import iteritems, itervalues
+from future.utils import iteritems
 
 from snips_nlu.builtin_entities import (get_builtin_entities,
                                         is_builtin_entity)

--- a/snips_nlu/tests/test_deterministic_intent_parser.py
+++ b/snips_nlu/tests/test_deterministic_intent_parser.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from builtins import range
-
 from mock import patch
 
 from snips_nlu.constants import (
@@ -551,10 +550,14 @@ class TestDeterministicIntentParser(FixtureTest):
                 ]
             },
             "slot_names_to_entities": {
-                "dummy_slot_name": "dummy_entity_1",
-                "dummy slot nàme": "dummy_entity_1",
-                "dummy_slot_name3": "dummy_entity_2",
-                "dummy_slot_name2": "dummy_entity_2"
+                "dummy_intent_1": {
+                    "dummy_slot_name": "dummy_entity_1",
+                    "dummy_slot_name3": "dummy_entity_2",
+                    "dummy_slot_name2": "dummy_entity_2"
+                },
+                "dummy_intent_2": {
+                    "dummy slot nàme": "dummy_entity_1"
+                }
             }
         }
         metadata = {"unit_name": "deterministic_intent_parser"}


### PR DESCRIPTION
# Bug description

We're using a duplicate and erroneous function to compute the mapping from slot name to entity name in the `DeterministicIntentParser`.

If there are two slots with the same name in the input dataset the DeterministicIntentParser only find one of them when parsing.