### PR TITLE
Add method to persist all processing units into bytearray

### DIFF
--- a/snips_nlu/nlu_engine/nlu_engine.py
+++ b/snips_nlu/nlu_engine/nlu_engine.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import json
 import logging
-import shutil
 from builtins import str
 from collections import defaultdict
 from copy import deepcopy
@@ -24,8 +23,7 @@ from snips_nlu.resources import load_resources_from_dir, persist_resources
 from snips_nlu.result import empty_result, is_empty, parsing_result
 from snips_nlu.utils import (NotTrained, check_persisted_path,
                              get_slot_name_mappings, json_string,
-                             log_elapsed_time, log_result, temp_dir,
-                             unzip_archive)
+                             log_elapsed_time, log_result)
 
 logger = logging.getLogger(__name__)
 
@@ -238,44 +236,6 @@ class SnipsNLUEngine(ProcessingUnit):
             intent_parsers.append(intent_parser)
         nlu_engine.intent_parsers = intent_parsers
         return nlu_engine
-
-    def to_byte_array(self):
-        """Serialize the :class:`SnipsNLUEngine` instance into a bytearray
-
-        This method persists the engine in a temporary directory, zip the
-        directory and return the zipped file as binary data.
-
-        Returns:
-            bytearray: the engine as bytearray data
-        """
-
-        with temp_dir() as tmp_dir:
-            engine_dir = tmp_dir / "trained_engine"
-            self.persist(engine_dir)
-            archive_base_name = tmp_dir / "trained_engine"
-            archive_name = archive_base_name.with_suffix(".zip")
-            shutil.make_archive(base_name=str(archive_base_name),
-                                format="zip", root_dir=str(tmp_dir),
-                                base_dir="trained_engine")
-            with archive_name.open(mode="rb") as f:
-                engine_bytes = f.read()
-        return engine_bytes
-
-    @classmethod
-    def from_byte_array(cls, engine_bytes):
-        """Load a :class:`SnipsNLUEngine` instance from a bytearray
-
-        Args:
-            engine_bytes (bytearray): A bytearray representing a zipped nlu
-                engine.
-        """
-        with temp_dir() as tmp_dir:
-            archive_path = tmp_dir / "trained_engine.zip"
-            with archive_path.open(mode="wb") as f:
-                f.write(engine_bytes)
-            unzip_archive(archive_path, str(tmp_dir))
-            engine = cls.from_path(tmp_dir / "trained_engine")
-        return engine
 
 
 def _get_dataset_metadata(dataset):

--- a/snips_nlu/pipeline/processing_unit.py
+++ b/snips_nlu/pipeline/processing_unit.py
@@ -71,7 +71,7 @@ class ProcessingUnit(with_metaclass(ABCMeta, object)):
                                 format="zip", root_dir=str(tmp_dir),
                                 base_dir=cleaned_unit_name)
             with archive_name.open(mode="rb") as f:
-                processing_unit_bytes = f.read()
+                processing_unit_bytes = bytearray(f.read())
         return processing_unit_bytes
 
     @classmethod

--- a/snips_nlu/pipeline/processing_unit.py
+++ b/snips_nlu/pipeline/processing_unit.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 from abc import ABCMeta, abstractmethod
 from builtins import object
 from pathlib import Path
@@ -6,7 +7,7 @@ from pathlib import Path
 from future.utils import with_metaclass
 
 from snips_nlu.pipeline.configs import ProcessingUnitConfig
-from snips_nlu.utils import classproperty, json_string
+from snips_nlu.utils import classproperty, json_string, temp_dir, unzip_archive
 
 
 class ProcessingUnit(with_metaclass(ABCMeta, object)):
@@ -49,6 +50,55 @@ class ProcessingUnit(with_metaclass(ABCMeta, object)):
     @classmethod
     def from_path(cls, path):
         raise NotImplementedError
+
+    def to_byte_array(self):
+        """Serialize the :class:`ProcessingUnit` instance into a bytearray
+
+        This method persists the processing unit in a temporary directory, zip
+        the directory and return the zipped file as binary data.
+
+        Returns:
+            bytearray: the processing unit as bytearray data
+        """
+
+        cleaned_unit_name = _sanitize_unit_name(self.unit_name)
+        with temp_dir() as tmp_dir:
+            processing_unit_dir = tmp_dir / cleaned_unit_name
+            self.persist(processing_unit_dir)
+            archive_base_name = tmp_dir / cleaned_unit_name
+            archive_name = archive_base_name.with_suffix(".zip")
+            shutil.make_archive(base_name=str(archive_base_name),
+                                format="zip", root_dir=str(tmp_dir),
+                                base_dir=cleaned_unit_name)
+            with archive_name.open(mode="rb") as f:
+                processing_unit_bytes = f.read()
+        return processing_unit_bytes
+
+    @classmethod
+    def from_byte_array(cls, unit_bytes):
+        """Load a :class:`ProcessingUnit` instance from a bytearray
+
+        Args:
+            unit_bytes (bytearray): A bytearray representing a zipped
+                processing unit.
+        """
+        cleaned_unit_name = _sanitize_unit_name(cls.unit_name)
+        with temp_dir() as tmp_dir:
+            archive_path = (tmp_dir / cleaned_unit_name).with_suffix(".zip")
+            with archive_path.open(mode="wb") as f:
+                f.write(unit_bytes)
+            unzip_archive(archive_path, str(tmp_dir))
+            processing_unit = cls.from_path(tmp_dir / cleaned_unit_name)
+        return processing_unit
+
+
+def _sanitize_unit_name(unit_name):
+    return unit_name\
+        .lower()\
+        .strip()\
+        .replace(" ", "")\
+        .replace("/", "")\
+        .replace("\\", "")
 
 
 def _get_unit_type(unit_name):

--- a/snips_nlu/slot_filler/crf_slot_filler.py
+++ b/snips_nlu/slot_filler/crf_slot_filler.py
@@ -33,7 +33,7 @@ from snips_nlu.utils import (DifferedLoggingMessage, NotTrained,
                              UnupdatableDict, check_random_state,
                              get_slot_name_mapping, json_string,
                              log_elapsed_time, mkdir_p, ranges_overlap,
-                             check_persisted_path)
+                             check_persisted_path, temp_dir, unzip_archive)
 
 logger = logging.getLogger(__name__)
 

--- a/snips_nlu/slot_filler/crf_slot_filler.py
+++ b/snips_nlu/slot_filler/crf_slot_filler.py
@@ -30,10 +30,10 @@ from snips_nlu.slot_filler.feature import TOKEN_NAME
 from snips_nlu.slot_filler.feature_factory import get_feature_factory
 from snips_nlu.slot_filler.slot_filler import SlotFiller
 from snips_nlu.utils import (DifferedLoggingMessage, NotTrained,
-                             UnupdatableDict, check_random_state,
-                             get_slot_name_mapping, json_string,
-                             log_elapsed_time, mkdir_p, ranges_overlap,
-                             check_persisted_path, temp_dir, unzip_archive)
+                             UnupdatableDict, check_persisted_path,
+                             check_random_state, get_slot_name_mapping,
+                             json_string, log_elapsed_time, mkdir_p,
+                             ranges_overlap)
 
 logger = logging.getLogger(__name__)
 

--- a/snips_nlu/tests/test_crf_slot_filler.py
+++ b/snips_nlu/tests/test_crf_slot_filler.py
@@ -411,6 +411,24 @@ class TestCRFSlotFiller(FixtureTest):
         crf_path = Path(slot_filler.crf_model.modelfile.name)
         self.assertFileContent(crf_path, "foo bar")
 
+    def test_should_be_serializable_into_bytearray(self):
+        # Given
+        dataset = BEVERAGE_DATASET
+        slot_filler = CRFSlotFiller().fit(dataset, "MakeTea")
+
+        # When
+        slot_filler_bytes = slot_filler.to_byte_array()
+        loaded_slot_filler = CRFSlotFiller.from_byte_array(slot_filler_bytes)
+        slots = loaded_slot_filler.get_slots("make me two cups of tea")
+
+        # Then
+        expected_slots = [
+            unresolved_slot(match_range={START: 8, END: 11},
+                            value='two',
+                            entity='snips/number',
+                            slot_name='number_of_cups')]
+        self.assertListEqual(expected_slots, slots)
+
     def test_should_compute_features(self):
         # Given
         features_factories = [

--- a/snips_nlu/tests/test_deterministic_intent_parser.py
+++ b/snips_nlu/tests/test_deterministic_intent_parser.py
@@ -15,7 +15,8 @@ from snips_nlu.intent_parser.deterministic_intent_parser import (
     _replace_tokenized_out_characters)
 from snips_nlu.pipeline.configs import DeterministicIntentParserConfig
 from snips_nlu.result import intent_classification_result, unresolved_slot
-from snips_nlu.tests.utils import FixtureTest, SAMPLE_DATASET, TEST_PATH
+from snips_nlu.tests.utils import FixtureTest, SAMPLE_DATASET, TEST_PATH, \
+    BEVERAGE_DATASET
 
 
 class TestDeterministicIntentParser(FixtureTest):
@@ -383,6 +384,20 @@ class TestDeterministicIntentParser(FixtureTest):
 
             # Then
             self.assertListEqual(expected_slots, parsing[RES_SLOTS])
+
+    def test_should_be_serializable_into_bytearray(self):
+        # Given
+        dataset = BEVERAGE_DATASET
+        intent_parser = DeterministicIntentParser().fit(dataset)
+
+        # When
+        intent_parser_bytes = intent_parser.to_byte_array()
+        loaded_intent_parser = DeterministicIntentParser.from_byte_array(
+            intent_parser_bytes)
+        result = loaded_intent_parser.parse("make me two cups of coffee")
+
+        # Then
+        self.assertEqual("MakeCoffee", result[RES_INTENT][RES_INTENT_NAME])
 
     def test_should_parse_naughty_strings(self):
         # Given

--- a/snips_nlu/tests/test_log_reg_intent_classifier.py
+++ b/snips_nlu/tests/test_log_reg_intent_classifier.py
@@ -179,6 +179,21 @@ class TestLogRegIntentClassifier(FixtureTest):
         expected_intent = "MakeTea"
         self.assertEqual(expected_intent, result[RES_INTENT_NAME])
 
+    def test_should_be_serializable_into_bytearray(self):
+        # Given
+        dataset = BEVERAGE_DATASET
+        intent_classifier = LogRegIntentClassifier().fit(dataset)
+
+        # When
+        intent_classifier_bytes = intent_classifier.to_byte_array()
+        loaded_classifier = LogRegIntentClassifier.from_byte_array(
+            intent_classifier_bytes)
+        result = loaded_classifier.get_intent("make me two cups of tea")
+
+        # Then
+        expected_intent = "MakeTea"
+        self.assertEqual(expected_intent, result[RES_INTENT_NAME])
+
     @patch("snips_nlu.intent_classifier.log_reg_classifier"
            ".build_training_data")
     def test_empty_vocabulary_should_fit_and_return_none_intent(

--- a/snips_nlu/tests/test_probabilistic_intent_parser.py
+++ b/snips_nlu/tests/test_probabilistic_intent_parser.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from mock import patch
 
+from snips_nlu.constants import RES_INTENT, RES_INTENT_NAME
 from snips_nlu.dataset import validate_and_format_dataset
 from snips_nlu.intent_classifier import IntentClassifier, \
     LogRegIntentClassifier
@@ -220,6 +221,20 @@ class TestProbabilisticIntentParser(FixtureTest):
         self.assertIsNotNone(parser.intent_classifier)
         self.assertListEqual(sorted(parser.slot_fillers),
                              ["MakeCoffee", "MakeTea"])
+
+    def test_should_be_serializable_into_bytearray(self):
+        # Given
+        dataset = BEVERAGE_DATASET
+        intent_parser = ProbabilisticIntentParser().fit(dataset)
+
+        # When
+        intent_parser_bytes = intent_parser.to_byte_array()
+        loaded_intent_parser = ProbabilisticIntentParser.from_byte_array(
+            intent_parser_bytes)
+        result = loaded_intent_parser.parse("make me two cups of tea")
+
+        # Then
+        self.assertEqual("MakeTea", result[RES_INTENT][RES_INTENT_NAME])
 
     def test_fitting_should_be_reproducible_after_serialization(self):
         # Given


### PR DESCRIPTION
**Description**
This allows every processing units, and not only a `SnipsNLUEngine`, to be persisted into (and loaded from) a bytearray:
- `SnipsNLUEngine`
- `DeterministicIntentParser`
- `ProbabilisticIntentParser`
- `CRFSlotFiller`
- `LogRegIntentClassifier`