### PR TITLE
handle automatically_extensible property using dataset generation tool

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -104,7 +104,7 @@ to the actual value ``A value with a "," in it``.
 
 .. Note::
 
-    By default entities are generated as *automatically extensible* ie the recognition will accept additional values than the ones listed in the entity file.
+    By default entities are generated as :ref:`automatically extensible <auto_extensible>`, i.e. the recognition will accept additional values than the ones listed in the entity file.
     This behavior can be changed by adding at the beginning of the entity file the following:
 
     .. code-block:: bash

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -102,6 +102,15 @@ double quotes ``"``. If the value contains double quotes, it must be doubled
 to be escaped like this:  ``"A value with a "","" in it"`` which corresponds
 to the actual value ``A value with a "," in it``.
 
+.. Note::
+
+    By default entities are generated as *automatically extensible* ie the recognition will accept additional values than the ones listed in the entity file.
+    This behavior can be changed by adding at the beginning of the entity file the following:
+
+    .. code-block:: bash
+
+       # automatically_extensible=false
+
 We are now ready to generate our dataset:
 
 .. code-block:: bash

--- a/snips_nlu/cli/dataset/entities.py
+++ b/snips_nlu/cli/dataset/entities.py
@@ -68,8 +68,6 @@ class CustomEntity(Entity):
                     if m:
                         autoextent = not m.group(1).lower() == 'false'
                         continue
-                if value.startswith('#'):
-                    continue
                 if len(row) > 1:
                     synonyms = row[1:]
                 else:

--- a/snips_nlu/cli/dataset/entities.py
+++ b/snips_nlu/cli/dataset/entities.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import csv
+import re
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
 
@@ -56,16 +57,25 @@ class CustomEntity(Entity):
             if six.PY2:
                 it = list(utf_8_encoder(it))
             reader = csv.reader(list(it))
+            autoextent = True
             for row in reader:
                 if six.PY2:
                     row = [cell.decode("utf-8") for cell in row]
                 value = row[0]
+                m = re.match(
+                    r'^#\sautomatically_extensible=(true|false)\s*$',
+                    row[0], re.IGNORECASE)
+                if m:
+                    autoextent = not m.group(1).lower() == 'false'
+                    continue
+                if value.startswith('#'):
+                    continue
                 if len(row) > 1:
                     synonyms = row[1:]
                 else:
                     synonyms = []
                 utterances.append(EntityUtterance(value, synonyms))
-        return cls(entity_name, utterances, automatically_extensible=True,
+        return cls(entity_name, utterances, autoextent,
                    use_synonyms=True)
 
     @property

--- a/snips_nlu/cli/dataset/entities.py
+++ b/snips_nlu/cli/dataset/entities.py
@@ -13,7 +13,7 @@ from snips_nlu.builtin_entities import is_builtin_entity
 from snips_nlu.constants import (
     VALUE, SYNONYMS, AUTOMATICALLY_EXTENSIBLE, USE_SYNONYMS, DATA)
 
-AUTO_EXTENSIBLE_REGEX = re.compile(r'^#\sautomatically_extensible=(true|false)\s*$')
+AUTO_EXT_REGEX = re.compile(r'^#\sautomatically_extensible=(true|false)\s*$')
 
 class Entity(with_metaclass(ABCMeta, object)):
     def __init__(self, name):
@@ -64,7 +64,7 @@ class CustomEntity(Entity):
                     row = [cell.decode("utf-8") for cell in row]
                 value = row[0]
                 if reader.line_num == 1:
-                    m = AUTO_EXTENSIBLE_REGEX.match(row[0])
+                    m = AUTO_EXT_REGEX.match(row[0])
                     if m:
                         autoextent = not m.group(1).lower() == 'false'
                         continue

--- a/snips_nlu/cli/dataset/examples/entity_location_autoextent_false.txt
+++ b/snips_nlu/cli/dataset/examples/entity_location_autoextent_false.txt
@@ -1,0 +1,4 @@
+# automatically_extensible=false
+new york,big apple
+paris,city of lights
+london

--- a/snips_nlu/tests/test_cli.py
+++ b/snips_nlu/tests/test_cli.py
@@ -181,6 +181,40 @@ class TestCLI(SnipsTest):
         }
         self.assertDictEqual(expected_entity_dict, entity_dict)
 
+    def test_should_generate_entity_from_file_with_autoextensible(self):
+        # Given
+        examples_path = PACKAGE_PATH / "cli" / "dataset" / "examples"
+        entity_file = examples_path / "entity_location_autoextent_false.txt"
+
+        # When
+        entity_dataset = CustomEntity.from_file(entity_file)
+        entity_dict = entity_dataset.json
+
+        # Then
+        expected_entity_dict = {
+            "automatically_extensible": False,
+            "data": [
+                {
+                    "synonyms": [
+                        "big apple"
+                    ],
+                    "value": "new york"
+                },
+                {
+                    "synonyms": [
+                        "city of lights"
+                    ],
+                    "value": "paris"
+                },
+                {
+                    "synonyms": [],
+                    "value": "london"
+                }
+            ],
+            "use_synonyms": True
+        }
+        self.assertDictEqual(expected_entity_dict, entity_dict)
+
     def test_should_generate_dataset_from_files(self):
         # Given
         examples_path = PACKAGE_PATH / "cli" / "dataset" / "examples"


### PR DESCRIPTION
As discussed in discord and as mentioned in #632, here is a PR allowing to define automatically_extensible property on entities when using the generation tool.

In a txt file representing an entity, if a line contains `# automatically_extensible=false` then the entity will be considered as non extensible 