### PR TITLE
Make version specifiers of dependencies more flexible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,44 +13,38 @@ with io.open(os.path.join(root, "snips_nlu", "__about__.py"),
     about = dict()
     exec(f.read(), about)
 
-
 with io.open(os.path.join(root, "README.rst"), encoding="utf8") as f:
     readme = f.read()
 
-nlu_metrics_version = "0.12.0"
-
 required = [
-    "enum34==1.1.6",
-    "pathlib==1.0.1",
+    "enum34>=1.1,<2.0",
     "numpy==1.14.0",
-    "scipy==1.0.0",
-    "scikit-learn==0.19.1",
-    "sklearn-crfsuite==0.3.6",
-    "semantic_version==2.6.0",
-    "snips_nlu_utils==0.6.1",
+    "scipy>=1.0,<2.0",
+    "scikit-learn>=0.19,<0.20",
+    "sklearn-crfsuite>=0.3.6,<0.4",
+    "semantic_version>=2.6,<3.0",
+    "snips_nlu_utils>=0.6.1,<0.7",
     "snips_nlu_ontology==0.57.2",
-    "num2words==0.5.6",
-    "plac==0.9.6",
-    "requests==2.18.4"
+    "num2words>=0.5.6,<0.6",
+    "plac>=0.9.6,<1.0",
+    "requests>=2.0,<3.0",
+    "pathlib==1.0.1; python_version < '3.4'",
 ]
 
 extras_require = {
     "doc": [
-        "sphinx==1.7.1",
-        "sphinxcontrib-napoleon==0.6.1",
-        "sphinx-rtd-theme==0.2.4"
+        "sphinx>=1.7,<2.0",
+        "sphinxcontrib-napoleon>=0.6.1,<0.7",
+        "sphinx-rtd-theme>=0.2.4,<0.3"
     ],
     "metrics": [
-        "snips_nlu_metrics==%s" % nlu_metrics_version,
+        "snips_nlu_metrics>=0.13,<0.14",
     ],
     "test": [
-        "mock==2.0.0",
-        "snips_nlu_metrics==%s" % nlu_metrics_version,
-        "pylint==1.8.2",
-        "coverage==4.4.2"
-    ],
-    "integration_test": [
-        "snips_nlu_metrics==%s" % nlu_metrics_version,
+        "mock>=2.0,<3.0",
+        "snips_nlu_metrics>=0.13,<0.14",
+        "pylint>=1.8,<2.0",
+        "coverage>=4.4.2,<5.0"
     ]
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ setenv=
 basepython = python3.6
 skip_install = true
 commands =
-    pip install -e ".[test,integration_test]"
+    pip install -e ".[test]"
     snips-nlu download snips_nlu_de-0.2.0 --direct
     snips-nlu download snips_nlu_en-0.2.0 --direct
     snips-nlu download snips_nlu_es-0.2.0 --direct


### PR DESCRIPTION
**Description**
Use lowerbound and upperbound for version specifiers when defining dependencies in `setup.py` in order to reduce conflicts between dependencies, and avoid dependency hell.