### PR TITLE
Fix synonym varitions mapping

### DIFF
--- a/snips_nlu/cli/generate_dataset.py
+++ b/snips_nlu/cli/generate_dataset.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import print_function, unicode_literals
 
 import json
 

--- a/snips_nlu/cli/inference.py
+++ b/snips_nlu/cli/inference.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 
 import json
 from builtins import input

--- a/snips_nlu/cli/training.py
+++ b/snips_nlu/cli/training.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 
 import json
 from pathlib import Path

--- a/snips_nlu/dataset.py
+++ b/snips_nlu/dataset.py
@@ -174,10 +174,10 @@ def validate_and_format_custom_entity(entity, queries_entities, language):
         [v for vars in itervalues(variations) for v in vars])
     non_colliding_variations = {
         value: [
-            v for v in vars if
+            v for v in variations if
             v not in all_original_values and variation_counter[v] == 1
         ]
-        for value, vars in iteritems(variations)
+        for value, variations in iteritems(variations)
     }
 
     for entry in entity[DATA]:

--- a/snips_nlu/dataset.py
+++ b/snips_nlu/dataset.py
@@ -190,7 +190,7 @@ def validate_and_format_custom_entity(entity, queries_entities, language):
         ent: get_string_variations(ent, language) for ent in queries_entities
     }
     for original_ent, variations in iteritems(queries_entities_variations):
-        if not original_ent or original_ent in formatted_entity:
+        if not original_ent or original_ent in validated_utterances:
             continue
         validated_utterances[original_ent] = original_ent
         for variation in variations:

--- a/snips_nlu/dataset.py
+++ b/snips_nlu/dataset.py
@@ -1,9 +1,10 @@
 from __future__ import division, unicode_literals
 
 import json
-from builtins import str
+from collections import Counter
 from copy import deepcopy
 
+from builtins import str
 from future.utils import iteritems, itervalues
 from snips_nlu_ontology import get_all_languages
 
@@ -97,14 +98,21 @@ def has_any_capitalization(entity_utterances, language):
     return False
 
 
-def add_variation_if_needed(utterances, variation, utterance, language):
-    if not variation:
-        return utterances
-    all_variations = get_string_variations(variation, language)
-    for v in all_variations:
-        if v not in utterances:
-            utterances[v] = utterance
+def add_entity_variations(utterances, entity_variations, entity_value):
+    utterances[entity_value] = entity_value
+    for variation in entity_variations[entity_value]:
+        if variation:
+            utterances[variation] = entity_value
     return utterances
+
+
+def _extract_entity_values(entity):
+    values = set()
+    for ent in entity[DATA]:
+        values.add(ent[VALUE])
+        if entity[USE_SYNONYMS]:
+            values.update(set(ent[SYNONYMS]))
+    return values
 
 
 def validate_and_format_custom_entity(entity, queries_entities, language):
@@ -139,33 +147,59 @@ def validate_and_format_custom_entity(entity, queries_entities, language):
     formatted_entity[CAPITALIZE] = has_any_capitalization(queries_entities,
                                                           language)
 
-    # Normalize
-    validated_data = dict()
+    validated_utterances = dict()
+    # Map original values an synonyms
+    for data in entity[DATA]:
+        ent_value = data[VALUE]
+        if not ent_value:
+            continue
+        validated_utterances[ent_value] = ent_value
+        if use_synonyms:
+            for s in data[SYNONYMS]:
+                if s and s not in validated_utterances:
+                    validated_utterances[s] = ent_value
+
+    # Add variations if not colliding
+    all_original_values = _extract_entity_values(entity)
+    variations = dict()
+    for data in entity[DATA]:
+        ent_value = data[VALUE]
+        values_to_variate = {ent_value}
+        if use_synonyms:
+            values_to_variate.update(set(data[SYNONYMS]))
+        variations[ent_value] = set(
+            v for value in values_to_variate
+            for v in get_string_variations(value, language))
+    variation_counter = Counter(
+        [v for vars in itervalues(variations) for v in vars])
+    non_colliding_variations = {
+        value: [
+            v for v in vars if
+            v not in all_original_values and variation_counter[v] == 1
+        ]
+        for value, vars in iteritems(variations)
+    }
+
     for entry in entity[DATA]:
         entry_value = entry[VALUE]
-        validated_data = add_variation_if_needed(
-            validated_data, entry_value, entry_value, language)
+        validated_utterances = add_entity_variations(
+            validated_utterances, non_colliding_variations, entry_value)
 
-        if use_synonyms:
-            for s in entry[SYNONYMS]:
-                validated_data = add_variation_if_needed(
-                    validated_data, s, entry_value, language)
-
-    formatted_entity[UTTERANCES] = validated_data
-    # Merge queries_entities
-    for value in queries_entities:
-        formatted_entity = add_entity_value_if_missing(
-            value, formatted_entity, language)
-
+    # Merge queries entities
+    queries_entities_variations = {
+        ent: get_string_variations(ent, language) for ent in queries_entities
+    }
+    for original_ent, variations in iteritems(queries_entities_variations):
+        if not original_ent or original_ent in formatted_entity:
+            continue
+        validated_utterances[original_ent] = original_ent
+        for variation in variations:
+            if variation and variation not in validated_utterances:
+                validated_utterances[variation] = original_ent
+    formatted_entity[UTTERANCES] = validated_utterances
     return formatted_entity
 
 
 def validate_and_format_builtin_entity(entity, queries_entities):
     validate_type(entity, dict)
     return {UTTERANCES: set(queries_entities)}
-
-
-def add_entity_value_if_missing(value, entity, language):
-    entity[UTTERANCES] = add_variation_if_needed(entity[UTTERANCES], value,
-                                                 value, language)
-    return entity

--- a/snips_nlu/tests/test_cli.py
+++ b/snips_nlu/tests/test_cli.py
@@ -23,6 +23,7 @@ class TestCLI(SnipsTest):
 
     # pylint: disable=protected-access
     def setUp(self):
+        super(TestCLI, self).setUp()
         if not self.fixture_dir.exists():
             self.fixture_dir.mkdir()
 

--- a/snips_nlu/tests/test_dataset.py
+++ b/snips_nlu/tests/test_dataset.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from builtins import str
-
 from mock import mock
 
 from snips_nlu.constants import (
@@ -37,8 +36,8 @@ class TestDataset(SnipsTest):
         # When/Then
         with self.assertRaises(KeyError) as ctx:
             validate_and_format_dataset(dataset)
-        self.assertEqual(str(ctx.exception.args[0]),
-                         "Expected chunk to have key: 'slot_name'")
+        self.assertEqual("Expected chunk to have key: 'slot_name'",
+                         str(ctx.exception.args[0]))
 
     def test_unknown_entity_should_raise_exception(self):
         # Given
@@ -72,8 +71,7 @@ class TestDataset(SnipsTest):
         # When/Then
         with self.assertRaises(KeyError) as ctx:
             validate_and_format_dataset(dataset)
-        self.assertEqual(str(ctx.exception.args[0]),
-                         "Expected entities to have key: 'unknown_entity'")
+        self.assertEqual("Expected entities to have key: 'unknown_entity'", str(ctx.exception.args[0]))
 
     def test_missing_entity_key_should_raise_exception(self):
         # Given
@@ -92,8 +90,7 @@ class TestDataset(SnipsTest):
         # When/Then
         with self.assertRaises(KeyError) as ctx:
             validate_and_format_dataset(dataset)
-        self.assertEqual(str(ctx.exception.args[0]),
-                         "Expected entity to have key: 'use_synonyms'")
+        self.assertEqual("Expected entity to have key: 'use_synonyms'", str(ctx.exception.args[0]))
 
     def test_invalid_language_should_raise_exception(self):
         # Given
@@ -107,7 +104,7 @@ class TestDataset(SnipsTest):
         # When/Then
         with self.assertRaises(ValueError) as ctx:
             validate_and_format_dataset(dataset)
-        self.assertEqual(str(ctx.exception.args[0]), "Unknown language: 'eng'")
+        self.assertEqual("Unknown language: 'eng'", str(ctx.exception.args[0]))
 
     @mock.patch("snips_nlu.dataset.get_string_variations")
     def test_should_format_dataset_by_adding_synonyms(
@@ -158,7 +155,7 @@ class TestDataset(SnipsTest):
         dataset = validate_and_format_dataset(dataset)
 
         # Then
-        self.assertDictEqual(dataset, expected_dataset)
+        self.assertDictEqual(expected_dataset, dataset)
 
     @mock.patch("snips_nlu.dataset.get_string_variations")
     def test_should_format_dataset_by_adding_entity_values(
@@ -269,7 +266,7 @@ class TestDataset(SnipsTest):
         dataset = validate_and_format_dataset(dataset)
 
         # Then
-        self.assertEqual(dataset, expected_dataset)
+        self.assertEqual(expected_dataset, dataset)
 
     @mock.patch("snips_nlu.dataset.get_string_variations")
     def test_should_add_missing_reference_entity_values_when_not_use_synonyms(
@@ -377,7 +374,7 @@ class TestDataset(SnipsTest):
         dataset = validate_and_format_dataset(dataset)
 
         # Then
-        self.assertEqual(dataset, expected_dataset)
+        self.assertEqual(expected_dataset, dataset)
 
     def test_should_not_require_data_for_builtin_entities(self):
         # Given
@@ -521,7 +518,7 @@ class TestDataset(SnipsTest):
         dataset = validate_and_format_dataset(dataset)
 
         # Then
-        self.assertEqual(dataset, expected_dataset)
+        self.assertEqual(expected_dataset, dataset)
 
     @mock.patch("snips_nlu.dataset.get_string_variations")
     def test_should_add_capitalize_field(
@@ -691,7 +688,7 @@ class TestDataset(SnipsTest):
         dataset = validate_and_format_dataset(dataset)
 
         # Then
-        self.assertDictEqual(dataset, expected_dataset)
+        self.assertDictEqual(expected_dataset, dataset)
 
     @mock.patch("snips_nlu.dataset.get_string_variations")
     def test_should_normalize_synonyms(
@@ -749,6 +746,7 @@ class TestDataset(SnipsTest):
                     "utterances": {
                         "ëntity": "ëNtity",
                         "Ëntity": "ëNtity",
+                        "ëNtity": "ëNtity"
                     },
                     "automatically_extensible": True,
                     "capitalize": False
@@ -763,7 +761,7 @@ class TestDataset(SnipsTest):
         dataset = validate_and_format_dataset(dataset)
 
         # Then
-        self.assertDictEqual(dataset, expected_dataset)
+        self.assertDictEqual(expected_dataset, dataset)
 
     @mock.patch("snips_nlu.dataset.get_string_variations")
     def test_dataset_should_handle_synonyms(
@@ -809,3 +807,65 @@ class TestDataset(SnipsTest):
 
         # Then
         self.assertDictEqual(dataset[ENTITIES], expected_entities)
+
+    def test_should_not_avoid_synomyms_variations_collision(self):
+        # Given
+        dataset = {
+            "intents": {
+                "dummy_but_tricky_intent": {
+                    "utterances": [
+                        {
+                            "data": [
+                                {
+                                    "text": "dummy_value",
+                                    "entity": "dummy_but_tricky_entity",
+                                    "slot_name": "dummy_but_tricky_slot"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "entities": {
+                "dummy_but_tricky_entity": {
+                    "data": [
+                        {
+                            "value": "a",
+                            "synonyms": [
+                                "favorïte"
+                            ]
+                        },
+                        {
+                            "value": "b",
+                            "synonyms": [
+                                "favorite"
+                            ]
+                        }
+                    ],
+                    "use_synonyms": True,
+                    "automatically_extensible": False
+                }
+            },
+            "language": "en",
+            "snips_nlu_version": "0.15.0"
+        }
+
+        # When
+        dataset = validate_and_format_dataset(dataset)
+
+        # Then
+        entity = dataset["entities"]["dummy_but_tricky_entity"]
+        expected_utterances = {
+            "A": "a",
+            "B": "b",
+            "DummyValue": "dummy_value",
+            "Dummy_Value": "dummy_value",
+            "Favorïte": "a",
+            "a": "a",
+            "b": "b",
+            "dummy_value": "dummy_value",
+            "dummyvalue": "dummy_value",
+            "favorite": "b",
+            "favorïte": "a"
+        }
+        self.assertDictEqual(expected_utterances, entity["utterances"])

--- a/snips_nlu/tests/utils.py
+++ b/snips_nlu/tests/utils.py
@@ -23,8 +23,7 @@ PERFORMANCE_DATASET_PATH = TEST_PATH / "resources" / "performance_dataset.json"
 
 class SnipsTest(TestCase):
 
-    def __init__(self, methodName='runTest'):
-        super(SnipsTest, self).__init__(methodName)
+    def setUp(self):
         for l in get_all_languages():
             load_resources(l)
 
@@ -68,6 +67,7 @@ class FixtureTest(SnipsTest):
 
     # pylint: disable=protected-access
     def setUp(self):
+        super(FixtureTest, self).setUp()
         if not self.fixture_dir.exists():
             self.fixture_dir.mkdir()
 


### PR DESCRIPTION
# Bug description

When trained on a dataset like the following the synonyms are not mapped correctly:
```python
dataset = {
            "intents": {
                "dummy_but_tricky_intent": {
                    "utterances": [
                        {
                            "data": [
                                {
                                    "text": "dummy_value",
                                    "entity": "dummy_but_tricky_entity",
                                    "slot_name": "dummy_but_tricky_slot"
                                }
                            ]
                        }
                    ]
                }
            },
            "entities": {
                "dummy_but_tricky_entity": {
                    "data": [
                        {
                            "value": "a",
                            "synonyms": [
                                "favorïte"
                            ]
                        },
                        {
                            "value": "b",
                            "synonyms": [
                                "favorite"
                            ]
                        }
                    ],
                    "use_synonyms": True,
                    "automatically_extensible": False
                }
            },
            "language": "en",
            "snips_nlu_version": "0.15.0"
        }
```

Indeed the dataset in output of `validate_and_format_dataset` will have the following mapping in the `utterances` section:
```
"favorïte": "a",
"favorite": "a"
```
instead of:
```
"favorïte": "a",
"favorite": "b"
```

This is because we process the entities values sequentially and add their variation sequentially.
Thus, `favorïte` is normalized to `favorite` and mapped to `a`. Then when arriving to `favorite` we don't remap the value because it's already in the mapping

# Fix
Fixed this issue by first mapping all original values. Then generate all the entities variations and adding only variations that are not in original value and that do not collide with other value variations.