### PR TITLE
Remove unit_name from processing unit serialization

### DIFF
--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -227,7 +227,6 @@ class LogRegIntentClassifier(IntentClassifier):
             t_ = self.classifier.t_
 
         return {
-            "unit_name": self.unit_name,
             "config": self.config.to_dict(),
             "coeffs": coeffs,
             "intercept": intercept,

--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -212,7 +212,6 @@ class DeterministicIntentParser(IntentParser):
     def to_dict(self):
         """Returns a json-serializable dict"""
         return {
-            "unit_name": self.unit_name,
             "config": self.config.to_dict(),
             "language_code": self.language,
             "patterns": self.patterns,

--- a/snips_nlu/intent_parser/probabilistic_intent_parser.py
+++ b/snips_nlu/intent_parser/probabilistic_intent_parser.py
@@ -146,7 +146,6 @@ class ProbabilisticIntentParser(IntentParser):
             self.intent_classifier.persist(path / "intent_classifier")
 
         model = {
-            "unit_name": self.unit_name,
             "config": self.config.to_dict(),
             "slot_fillers": slot_fillers
         }

--- a/snips_nlu/pipeline/configs/intent_parser.py
+++ b/snips_nlu/pipeline/configs/intent_parser.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from copy import deepcopy
 
 from snips_nlu.pipeline.configs import ProcessingUnitConfig

--- a/snips_nlu/pipeline/configs/nlu_engine.py
+++ b/snips_nlu/pipeline/configs/nlu_engine.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from builtins import map
 from copy import deepcopy
 

--- a/snips_nlu/pipeline/processing_unit.py
+++ b/snips_nlu/pipeline/processing_unit.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 import shutil
 from abc import ABCMeta, abstractmethod

--- a/snips_nlu/slot_filler/crf_slot_filler.py
+++ b/snips_nlu/slot_filler/crf_slot_filler.py
@@ -330,7 +330,6 @@ class CRFSlotFiller(SlotFiller):
             crf_model_file = str(destination.name)
 
         model = {
-            "unit_name": self.unit_name,
             "language_code": self.language,
             "intent": self.intent,
             "crf_model_file": crf_model_file,

--- a/snips_nlu/tests/test_crf_slot_filler.py
+++ b/snips_nlu/tests/test_crf_slot_filler.py
@@ -291,7 +291,6 @@ class TestCRFSlotFiller(FixtureTest):
         self.assertJsonContent(metadata_path, {"unit_name": "crf_slot_filler"})
 
         expected_slot_filler_dict = {
-            "unit_name": "crf_slot_filler",
             "crf_model_file": None,
             "language_code": None,
             "config": config.to_dict(),
@@ -411,7 +410,6 @@ class TestCRFSlotFiller(FixtureTest):
             tagging_scheme=TaggingScheme.BILOU,
             feature_factory_configs=expected_feature_factories)
         expected_slot_filler_dict = {
-            "unit_name": "crf_slot_filler",
             "crf_model_file": expected_crf_file,
             "language_code": "en",
             "config": expected_config.to_dict(),

--- a/snips_nlu/tests/test_deterministic_intent_parser.py
+++ b/snips_nlu/tests/test_deterministic_intent_parser.py
@@ -506,7 +506,6 @@ class TestDeterministicIntentParser(FixtureTest):
 
         # Then
         expected_dict = {
-            "unit_name": "deterministic_intent_parser",
             "config": {
                 "unit_name": "deterministic_intent_parser",
                 "max_queries": 42,
@@ -549,7 +548,6 @@ class TestDeterministicIntentParser(FixtureTest):
 
         # Then
         expected_dict = {
-            "unit_name": "deterministic_intent_parser",
             "config": {
                 "unit_name": "deterministic_intent_parser",
                 "max_queries": 42,

--- a/snips_nlu/tests/test_log_reg_intent_classifier.py
+++ b/snips_nlu/tests/test_log_reg_intent_classifier.py
@@ -108,7 +108,6 @@ class TestLogRegIntentClassifier(FixtureTest):
         intent_list = sorted(SAMPLE_DATASET[INTENTS])
         intent_list.append(None)
         expected_dict = {
-            "unit_name": "log_reg_intent_classifier",
             "config": LogRegIntentClassifierConfig().to_dict(),
             "coeffs": coeffs,
             "intercept": intercept,

--- a/snips_nlu/tests/test_probabilistic_intent_parser.py
+++ b/snips_nlu/tests/test_probabilistic_intent_parser.py
@@ -94,7 +94,6 @@ class TestProbabilisticIntentParser(FixtureTest):
 
         # Then
         expected_parser_dict = {
-            "unit_name": "probabilistic_intent_parser",
             "config": {
                 "unit_name": "probabilistic_intent_parser",
                 "slot_filler_config": CRFSlotFillerConfig().to_dict(),
@@ -153,7 +152,6 @@ class TestProbabilisticIntentParser(FixtureTest):
             "intent_classifier_config": {"unit_name": "test_intent_classifier"}
         }
         expected_parser_dict = {
-            "unit_name": "probabilistic_intent_parser",
             "config": expected_parser_config,
             "slot_fillers": [
                 {


### PR DESCRIPTION
**Description**:
Remove `unit_name` field from processing unit serialization since it's already persisted in the metadata when the `ProcessingUnit.persist_metadata` method is called