### PR TITLE
Fix the generation of crf_slot_fillers files names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.16.4] - 2018-08-30
+### Fixed
+- Issue with the `CrfSlotFiller` file names in the `ProbabilisticIntentParser` serialization  
 
 ## [0.16.3] - 2018-08-22
 ### Fixed
@@ -132,6 +135,7 @@ several commands.
 - Fix compiling issue with `bindgen` dependency when installing from source
 - Fix issue in `CRFSlotFiller` when handling builtin entities
 
+[0.16.4]: https://github.com/snipsco/snips-nlu/compare/0.16.3...0.16.4
 [0.16.3]: https://github.com/snipsco/snips-nlu/compare/0.16.2...0.16.3
 [0.16.2]: https://github.com/snipsco/snips-nlu/compare/0.16.1...0.16.2
 [0.16.1]: https://github.com/snipsco/snips-nlu/compare/0.16.0...0.16.1

--- a/snips_nlu/__about__.py
+++ b/snips_nlu/__about__.py
@@ -11,7 +11,7 @@ __author__ = "Clement Doumouro, Adrien Ball"
 __email__ = "clement.doumouro@snips.ai, adrien.ball@snips.ai"
 __license__ = "Apache License, Version 2.0"
 
-__version__ = "0.16.3"
+__version__ = "0.16.4"
 __model_version__ = "0.16.0"
 
 __download_url__ = "https://github.com/snipsco/snips-nlu-language-resources/releases/download"

--- a/snips_nlu/intent_parser/probabilistic_intent_parser.py
+++ b/snips_nlu/intent_parser/probabilistic_intent_parser.py
@@ -131,17 +131,15 @@ class ProbabilisticIntentParser(IntentParser):
         """Persist the object at the given path"""
         path = Path(path)
         path.mkdir()
+        sorted_slot_fillers = sorted(iteritems(self.slot_fillers))
         slot_fillers = []
-        for intent, slot_filler in iteritems(self.slot_fillers):
-            slot_filler_name = "slot_filler_%s" % intent
+        for i, (intent, slot_filler) in enumerate(sorted_slot_fillers):
+            slot_filler_name = "slot_filler_%s" % i
             slot_filler.persist(path / slot_filler_name)
             slot_fillers.append({
                 "intent": intent,
                 "slot_filler_name": slot_filler_name
             })
-
-        # Only needed to improve testability
-        slot_fillers = sorted(slot_fillers, key=lambda sf: sf["intent"])
 
         if self.intent_classifier is not None:
             self.intent_classifier.persist(path / "intent_classifier")

--- a/snips_nlu/tests/test_probabilistic_intent_parser.py
+++ b/snips_nlu/tests/test_probabilistic_intent_parser.py
@@ -149,11 +149,11 @@ class TestProbabilisticIntentParser(FixtureTest):
             "slot_fillers": [
                 {
                     "intent": "MakeCoffee",
-                    "slot_filler_name": "slot_filler_MakeCoffee"
+                    "slot_filler_name": "slot_filler_0"
                 },
                 {
                     "intent": "MakeTea",
-                    "slot_filler_name": "slot_filler_MakeTea"
+                    "slot_filler_name": "slot_filler_1"
                 }
             ]
         }
@@ -168,10 +168,10 @@ class TestProbabilisticIntentParser(FixtureTest):
             self.tmp_file_path / "intent_classifier" / "metadata.json",
             metadata_intent_classifier)
         self.assertJsonContent(
-            self.tmp_file_path / "slot_filler_MakeCoffee" / "metadata.json",
+            self.tmp_file_path / "slot_filler_0" / "metadata.json",
             metadata_slot_filler)
         self.assertJsonContent(
-            self.tmp_file_path / "slot_filler_MakeTea" / "metadata.json",
+            self.tmp_file_path / "slot_filler_1" / "metadata.json",
             metadata_slot_filler)
 
     def test_should_be_deserializable(self):


### PR DESCRIPTION
**Description**:
Fixes https://github.com/snipsco/snips-nlu/issues/656 : 
- Generate a valid crf slot filler file names (files that don't risk to conflict with the OS): `slot_filler_x`