### PR TITLE
Add a CLI to download all builtin entity resources by language

### DIFF
--- a/snips_nlu/__main__.py
+++ b/snips_nlu/__main__.py
@@ -7,7 +7,8 @@ import plac
 from snips_nlu.cli import (
     cross_val_metrics, download, download_all_languages, generate_dataset,
     link, train_test_metrics)
-from snips_nlu.cli.download_entity import download_builtin_entity
+from snips_nlu.cli.download_entity import (
+    download_builtin_entity, download_language_builtin_entities)
 from snips_nlu.cli.inference import parse
 from snips_nlu.cli.training import train
 from snips_nlu.cli.utils import PrettyPrintLevel, pretty_print
@@ -20,6 +21,7 @@ def main():
         "download": download,
         "download-all-languages": download_all_languages,
         "download-entity": download_builtin_entity,
+        "download-language-entities": download_language_builtin_entities,
         "link": link,
         "generate-dataset": generate_dataset,
         "cross-val-metrics": cross_val_metrics,

--- a/snips_nlu/cli/download_entity.py
+++ b/snips_nlu/cli/download_entity.py
@@ -3,7 +3,10 @@ from __future__ import print_function, unicode_literals
 import sys
 
 import plac
-from snips_nlu_ontology import get_builtin_entity_shortname
+
+from future.builtins import str
+from snips_nlu_ontology import (
+    get_builtin_entity_shortname, get_supported_gazetteer_entities)
 
 from snips_nlu import __about__
 from snips_nlu.cli.download import download_from_resource_name
@@ -38,6 +41,29 @@ def download_builtin_entity(entity_name, language, *pip_args):
 
     _download_and_link_entity(
         long_resource_name, entity_name, language, compatibility, pip_args)
+
+
+@plac.annotations(
+    language=("Language of the builtin entity", "positional", None, str),
+    pip_args=("Additional arguments to be passed to `pip install` when "
+              "installing the builtin entity package"))
+# pylint: disable=keyword-arg-before-vararg
+def download_language_builtin_entities(language, *pip_args):
+    """Download all gazetteer entity resources for a given language as well as
+    basic language resources for this language"""
+    download_from_resource_name(language, pip_args, verbose=False)
+
+    shortcuts = get_json(__about__.__shortcuts__, "Resource shortcuts")
+    for entity_name in get_supported_gazetteer_entities(language):
+        check_resources_alias(entity_name, shortcuts)
+
+        compatibility = get_compatibility()
+        resource_name_lower = entity_name.lower()
+        long_resource_name = shortcuts.get(resource_name_lower,
+                                           resource_name_lower)
+
+        _download_and_link_entity(
+            long_resource_name, entity_name, language, compatibility, pip_args)
 
 
 # pylint: enable=keyword-arg-before-vararg

--- a/snips_nlu/cli/link.py
+++ b/snips_nlu/cli/link.py
@@ -41,7 +41,7 @@ def link_resources(origin, link_name, force, resources_path):
             else Path(resources_path)
     if not resources_path.exists():
         raise OSError("%s not found" % str(resources_path))
-    link_path = DATA_PATH / link_name
+    link_path = DATA_PATH / str(link_name)
     if link_path.is_symlink() and not force:
         raise OSError("Symlink already exists: %s" % str(link_path))
     elif link_path.is_symlink():


### PR DESCRIPTION
**Description**:
- Add a simple CLI to download all the builtin entity resources (gazetteer parsers) by languages, here is an example on how to download all `fr` entity resources:
```
snips-nlu download-language-entities fr
```