### PR TITLE
Correctly set intent classifier custom entity parser in ProbabilisticIntentParser

### DIFF
--- a/snips_nlu/intent_parser/probabilistic_intent_parser.py
+++ b/snips_nlu/intent_parser/probabilistic_intent_parser.py
@@ -75,6 +75,9 @@ class ProbabilisticIntentParser(IntentParser):
                 self.config.intent_classifier_config)
         self.intent_classifier.builtin_entity_parser = \
             self.builtin_entity_parser
+        self.intent_classifier.custom_entity_parser = \
+            self.custom_entity_parser
+
         if force_retrain or not self.intent_classifier.fitted:
             self.intent_classifier.fit(dataset)
 


### PR DESCRIPTION
**Description**:
- The ProbabilisticIntentParser should set  its `intent_classifier.custom_entity_parser` when it's fitted the same way as the `intent_classifier.builtin_entity_parser`