### PR TITLE
Replace "parser_threshold" by "matching_strictness"

### DIFF
--- a/docs/source/data_model.rst
+++ b/docs/source/data_model.rst
@@ -266,7 +266,7 @@ entity in your dataset as follows:
             "synonyms": []
           }
         ],
-        "parser_threshold": 1.0
+        "matching_strictness": 1.0
       }
     }
 
@@ -363,6 +363,6 @@ not your custom entity is automatically extensible:
         "automatically_extensible": true,
         "use_synonyms": true,
         "data": [],
-        "parser_threshold": 1.0
+        "matching_strictness": 1.0
       }
     }

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -136,7 +136,7 @@ Now, the ``"entities"`` part of the generated json looks like that:
               "value": "garden"
             }
           ],
-          "parser_threshold": 1.0,
+          "matching_strictness": 1.0,
           "use_synonyms": true
         },
         "snips/temperature": {}
@@ -186,7 +186,7 @@ and that we want our assistant to cover. Additionally, we add some
               "value": "garden"
             }
           ],
-          "parser_threshold": 1.0,
+          "matching_strictness": 1.0,
           "use_synonyms": true
         },
         "snips/temperature": {}

--- a/sample_datasets/beverage_dataset.json
+++ b/sample_datasets/beverage_dataset.json
@@ -13,7 +13,7 @@
           ]
         }
       ],
-      "parser_threshold": 1.0,
+      "matching_strictness": 1.0,
       "use_synonyms": true
     },
     "snips/number": {}

--- a/sample_datasets/flights_dataset.json
+++ b/sample_datasets/flights_dataset.json
@@ -16,7 +16,7 @@
           "synonyms": ["new york", "big apple"]
         }
       ],
-      "parser_threshold": 1.0,
+      "matching_strictness": 1.0,
       "use_synonyms": true
     },
     "snips/datetime": {}

--- a/sample_datasets/lights_dataset.json
+++ b/sample_datasets/lights_dataset.json
@@ -3,7 +3,7 @@
     "color": {
       "automatically_extensible": true,
       "data": [],
-      "parser_threshold": 1.0,
+      "matching_strictness": 1.0,
       "use_synonyms": true
     },
     "room": {
@@ -18,7 +18,7 @@
           "synonyms": []
         }
       ],
-      "parser_threshold": 1.0,
+      "matching_strictness": 1.0,
       "use_synonyms": true
     }
   },

--- a/snips_nlu/cli/dataset/entities.py
+++ b/snips_nlu/cli/dataset/entities.py
@@ -9,9 +9,9 @@ from pathlib import Path
 import six
 from future.utils import with_metaclass
 
-from snips_nlu.constants import (AUTOMATICALLY_EXTENSIBLE, DATA,
-                                 PARSER_THRESHOLD, SYNONYMS, USE_SYNONYMS,
-                                 VALUE)
+from snips_nlu.constants import (
+    AUTOMATICALLY_EXTENSIBLE, DATA, MATCHING_STRICTNESS, SYNONYMS,
+    USE_SYNONYMS, VALUE)
 from snips_nlu.entity_parser.builtin_entity_parser import is_builtin_entity
 
 AUTO_EXT_REGEX = re.compile(r'^#\sautomatically_extensible=(true|false)\s*$')
@@ -38,12 +38,12 @@ class CustomEntity(Entity):
     """
 
     def __init__(self, name, utterances, automatically_extensible,
-                 use_synonyms, parser_threshold=1.0):
+                 use_synonyms, matching_strictness=1.0):
         super(CustomEntity, self).__init__(name)
         self.utterances = utterances
         self.automatically_extensible = automatically_extensible
         self.use_synonyms = use_synonyms
-        self.parser_threshold = parser_threshold
+        self.matching_strictness = matching_strictness
 
     @classmethod
     def from_file(cls, filepath):
@@ -86,7 +86,7 @@ class CustomEntity(Entity):
             AUTOMATICALLY_EXTENSIBLE: self.automatically_extensible,
             USE_SYNONYMS: self.use_synonyms,
             DATA: [u.json for u in self.utterances],
-            PARSER_THRESHOLD: self.parser_threshold
+            MATCHING_STRICTNESS: self.matching_strictness
         }
 
 

--- a/snips_nlu/constants.py
+++ b/snips_nlu/constants.py
@@ -45,7 +45,7 @@ START = "start"
 END = "end"
 BUILTIN_ENTITY_PARSER = "builtin_entity_parser"
 CUSTOM_ENTITY_PARSER = "custom_entity_parser"
-PARSER_THRESHOLD = "parser_threshold"
+MATCHING_STRICTNESS = "matching_strictness"
 
 # resources
 STOP_WORDS = "stop_words"

--- a/snips_nlu/dataset.py
+++ b/snips_nlu/dataset.py
@@ -8,13 +8,12 @@ from copy import deepcopy
 from future.utils import iteritems, itervalues
 from snips_nlu_ontology import get_all_languages
 
-from snips_nlu.constants import (AUTOMATICALLY_EXTENSIBLE, CAPITALIZE, DATA,
-                                 ENTITIES, ENTITY, INTENTS, LANGUAGE,
-                                 PARSER_THRESHOLD, SLOT_NAME, SYNONYMS, TEXT,
-                                 USE_SYNONYMS, UTTERANCES, VALIDATED, VALUE)
-from snips_nlu.entity_parser.builtin_entity_parser import (BuiltinEntityParser,
-                                                           is_builtin_entity,
-                                                           is_gazetteer_entity)
+from snips_nlu.constants import (
+    AUTOMATICALLY_EXTENSIBLE, CAPITALIZE, DATA, ENTITIES, ENTITY, INTENTS,
+    LANGUAGE, MATCHING_STRICTNESS, SLOT_NAME, SYNONYMS, TEXT, USE_SYNONYMS,
+    UTTERANCES, VALIDATED, VALUE)
+from snips_nlu.entity_parser.builtin_entity_parser import (
+    BuiltinEntityParser, is_builtin_entity, is_gazetteer_entity)
 from snips_nlu.preprocessing import tokenize_light
 from snips_nlu.string_variations import get_string_variations
 from snips_nlu.utils import validate_key, validate_keys, validate_type
@@ -135,21 +134,23 @@ def validate_and_format_custom_entity(entity, queries_entities, language,
     validate_type(entity, dict)
 
     # TODO: this is here temporarily, only to allow backward compatibility
-    if PARSER_THRESHOLD not in entity:
-        entity[PARSER_THRESHOLD] = 1.0
+    if MATCHING_STRICTNESS not in entity:
+        strictness = entity.get("parser_threshold", 1.0)
+
+        entity[MATCHING_STRICTNESS] = strictness
 
     mandatory_keys = [USE_SYNONYMS, AUTOMATICALLY_EXTENSIBLE, DATA,
-                      PARSER_THRESHOLD]
+                      MATCHING_STRICTNESS]
     validate_keys(entity, mandatory_keys, object_label="entity")
     validate_type(entity[USE_SYNONYMS], bool)
     validate_type(entity[AUTOMATICALLY_EXTENSIBLE], bool)
     validate_type(entity[DATA], list)
-    validate_type(entity[PARSER_THRESHOLD], float)
+    validate_type(entity[MATCHING_STRICTNESS], float)
 
     formatted_entity = dict()
     formatted_entity[AUTOMATICALLY_EXTENSIBLE] = entity[
         AUTOMATICALLY_EXTENSIBLE]
-    formatted_entity[PARSER_THRESHOLD] = entity[PARSER_THRESHOLD]
+    formatted_entity[MATCHING_STRICTNESS] = entity[MATCHING_STRICTNESS]
     use_synonyms = entity[USE_SYNONYMS]
 
     # Validate format and filter out unused data

--- a/snips_nlu/entity_parser/custom_entity_parser.py
+++ b/snips_nlu/entity_parser/custom_entity_parser.py
@@ -9,7 +9,7 @@ from future.utils import iteritems, viewvalues
 from snips_nlu_ontology import GazetteerEntityParser
 
 from snips_nlu.constants import (
-    END, ENTITIES, LANGUAGE, PARSER_THRESHOLD, RES_MATCH_RANGE, START,
+    END, ENTITIES, LANGUAGE, MATCHING_STRICTNESS, RES_MATCH_RANGE, START,
     UTTERANCES, ENTITY_KIND)
 from snips_nlu.entity_parser.builtin_entity_parser import is_builtin_entity
 from snips_nlu.entity_parser.custom_entity_parser_usage import (
@@ -123,7 +123,7 @@ def _create_custom_entity_parser_configuration(entities):
             {
                 "entity_identifier": entity_name,
                 "entity_parser": {
-                    "threshold": entity[PARSER_THRESHOLD],
+                    "threshold": entity[MATCHING_STRICTNESS],
                     "gazetteer": [
                         {
                             "raw_value": k,

--- a/snips_nlu/tests/resources/beverage_dataset.json
+++ b/snips_nlu/tests/resources/beverage_dataset.json
@@ -204,7 +204,7 @@
     "Temperature": {
       "use_synonyms": true,
       "automatically_extensible": true,
-      "parser_threshold": 1.0,
+      "matching_strictness": 1.0,
       "data": [
         {
           "value": "cold",

--- a/snips_nlu/tests/resources/performance_dataset.json
+++ b/snips_nlu/tests/resources/performance_dataset.json
@@ -6308,7 +6308,7 @@
     "weather_location": {
       "use_synonyms": false,
       "data": [],
-      "parser_threshold": 1.0,
+      "matching_strictness": 1.0,
       "automatically_extensible": true
     },
     "snips/datetime": {},
@@ -6365,7 +6365,7 @@
         }
       ],
       "automatically_extensible": true,
-      "parser_threshold": 1.0
+      "matching_strictness": 1.0
     }
   },
   "language": "en"

--- a/snips_nlu/tests/resources/sample_dataset.json
+++ b/snips_nlu/tests/resources/sample_dataset.json
@@ -3,7 +3,7 @@
     "dummy_entity_1": {
       "automatically_extensible": false,
       "use_synonyms": true,
-      "parser_threshold": 1.0,
+      "matching_strictness": 1.0,
       "data": [
         {
           "synonyms": [
@@ -33,7 +33,7 @@
     "dummy_entity_2": {
       "automatically_extensible": false,
       "use_synonyms": true,
-      "parser_threshold": 1.0,
+      "matching_strictness": 1.0,
       "data": [
         {
           "synonyms": [

--- a/snips_nlu/tests/resources/weather_dataset.json
+++ b/snips_nlu/tests/resources/weather_dataset.json
@@ -290,12 +290,12 @@
       "use_synonyms": false,
       "data": [],
       "automatically_extensible": true,
-      "parser_threshold": 1.0
+      "matching_strictness": 1.0
     },
     "snips/datetime": {},
     "weather_condition": {
       "use_synonyms": true,
-      "parser_threshold": 1.0,
+      "matching_strictness": 1.0,
       "data": [
         {
           "value": "wind",

--- a/snips_nlu/tests/test_cli.py
+++ b/snips_nlu/tests/test_cli.py
@@ -181,7 +181,7 @@ class TestCLI(SnipsTest):
                 }
             ],
             "use_synonyms": True,
-            "parser_threshold": 1.0
+            "matching_strictness": 1.0
         }
         self.assertDictEqual(expected_entity_dict, entity_dict)
 
@@ -216,7 +216,7 @@ class TestCLI(SnipsTest):
                 }
             ],
             "use_synonyms": True,
-            "parser_threshold": 1.0
+            "matching_strictness": 1.0
         }
         self.assertDictEqual(expected_entity_dict, entity_dict)
 
@@ -238,13 +238,13 @@ class TestCLI(SnipsTest):
                     "automatically_extensible": True,
                     "data": [],
                     "use_synonyms": True,
-                    "parser_threshold": 1.0,
+                    "matching_strictness": 1.0,
                 },
                 "country": {
                     "automatically_extensible": True,
                     "data": [],
                     "use_synonyms": True,
-                    "parser_threshold": 1.0,
+                    "matching_strictness": 1.0,
                 },
                 "location": {
                     "automatically_extensible": True,
@@ -267,13 +267,13 @@ class TestCLI(SnipsTest):
                         }
                     ],
                     "use_synonyms": True,
-                    "parser_threshold": 1.0,
+                    "matching_strictness": 1.0,
                 },
                 "role": {
                     "automatically_extensible": True,
                     "data": [],
                     "use_synonyms": True,
-                    "parser_threshold": 1.0,
+                    "matching_strictness": 1.0,
                 },
                 "snips/datetime": {}
             },

--- a/snips_nlu/tests/test_crf_slot_filler.py
+++ b/snips_nlu/tests/test_crf_slot_filler.py
@@ -223,7 +223,7 @@ class TestCRFSlotFiller(FixtureTest):
                     "use_synonyms": False,
                     "automatically_extensible": True,
                     "data": [],
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en",

--- a/snips_nlu/tests/test_custom_entity_parser.py
+++ b/snips_nlu/tests/test_custom_entity_parser.py
@@ -26,7 +26,7 @@ DATASET = validate_and_format_dataset({
             ],
             "use_synonyms": True,
             "automatically_extensible": True,
-            "parser_threshold": 1.0
+            "matching_strictness": 1.0
         },
         "dummy_entity_2": {
             "data": [
@@ -37,7 +37,7 @@ DATASET = validate_and_format_dataset({
             ],
             "use_synonyms": True,
             "automatically_extensible": True,
-            "parser_threshold": 1.0
+            "matching_strictness": 1.0
         }
     },
     "language": "en"

--- a/snips_nlu/tests/test_dataset.py
+++ b/snips_nlu/tests/test_dataset.py
@@ -81,7 +81,7 @@ class TestDataset(SnipsTest):
                 "entity1": {
                     "data": [],
                     "automatically_extensible": False,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en",
@@ -93,10 +93,10 @@ class TestDataset(SnipsTest):
         self.assertEqual("Expected entity to have key: 'use_synonyms'",
                          str(ctx.exception.args[0]))
 
-    def test_missing_parser_threshold_should_be_handled(self):
+    def test_missing_matching_strictness_should_be_handled(self):
         # TODO: This test is temporary, and must be removed once the backward
-        # compatibility with the previous dataset format (without
-        # "parser_threshold"), gets deprecated.
+        # compatibility with the previous dataset format, without
+        # "matching_strictness", gets deprecated.
 
         # Given
         dataset = {
@@ -115,7 +115,32 @@ class TestDataset(SnipsTest):
         dataset = validate_and_format_dataset(dataset)
 
         self.assertEqual(
-            1.0, dataset["entities"]["entity1"].get("parser_threshold"))
+            1.0, dataset["entities"]["entity1"].get("matching_strictness"))
+
+    def test_deprecated_parser_threshold_should_be_handled(self):
+        # TODO: This test is temporary, and must be removed once the backward
+        # compatibility with the previous dataset format, using
+        # "parser_threshold", gets deprecated.
+
+        # Given
+        dataset = {
+            "intents": {},
+            "entities": {
+                "entity1": {
+                    "data": [],
+                    "automatically_extensible": False,
+                    "use_synonyms": True,
+                    "parser_threshold": 0.5
+                }
+            },
+            "language": "en",
+        }
+
+        # When/Then
+        dataset = validate_and_format_dataset(dataset)
+
+        self.assertEqual(
+            0.5, dataset["entities"]["entity1"].get("matching_strictness"))
 
     def test_invalid_language_should_raise_exception(self):
         # Given
@@ -152,7 +177,7 @@ class TestDataset(SnipsTest):
                     ],
                     "use_synonyms": True,
                     "automatically_extensible": False,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en",
@@ -170,7 +195,7 @@ class TestDataset(SnipsTest):
                     },
                     "automatically_extensible": False,
                     "capitalize": False,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en",
@@ -234,7 +259,7 @@ class TestDataset(SnipsTest):
                     ],
                     "use_synonyms": True,
                     "automatically_extensible": False,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en",
@@ -283,7 +308,7 @@ class TestDataset(SnipsTest):
                     },
                     "automatically_extensible": False,
                     "capitalize": False,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en",
@@ -347,7 +372,7 @@ class TestDataset(SnipsTest):
                     ],
                     "use_synonyms": False,
                     "automatically_extensible": False,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en",
@@ -393,7 +418,7 @@ class TestDataset(SnipsTest):
                         },
                     "automatically_extensible": False,
                     "capitalize": False,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en",
@@ -492,7 +517,7 @@ class TestDataset(SnipsTest):
                     ],
                     "use_synonyms": False,
                     "automatically_extensible": False,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en",
@@ -538,7 +563,7 @@ class TestDataset(SnipsTest):
                         },
                     "capitalize": False,
                     "automatically_extensible": False,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en",
@@ -612,13 +637,13 @@ class TestDataset(SnipsTest):
                     "data": [],
                     "use_synonyms": False,
                     "automatically_extensible": True,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 },
                 "entity2": {
                     "data": [],
                     "use_synonyms": False,
                     "automatically_extensible": True,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 },
                 "entity3": {
                     "data": [
@@ -629,7 +654,7 @@ class TestDataset(SnipsTest):
                     ],
                     "use_synonyms": False,
                     "automatically_extensible": True,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en",
@@ -692,7 +717,7 @@ class TestDataset(SnipsTest):
                         },
                     "automatically_extensible": True,
                     "capitalize": True,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 },
                 "entity2": {
                     "utterances": {
@@ -703,7 +728,7 @@ class TestDataset(SnipsTest):
                     },
                     "automatically_extensible": True,
                     "capitalize": True,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 },
                 "entity3": {
                     "utterances":
@@ -714,7 +739,7 @@ class TestDataset(SnipsTest):
                         },
                     "automatically_extensible": True,
                     "capitalize": False,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en",
@@ -758,7 +783,7 @@ class TestDataset(SnipsTest):
                     "data": [],
                     "use_synonyms": True,
                     "automatically_extensible": True,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en",
@@ -789,7 +814,7 @@ class TestDataset(SnipsTest):
                     },
                     "automatically_extensible": True,
                     "capitalize": False,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en",
@@ -824,7 +849,7 @@ class TestDataset(SnipsTest):
                     ],
                     "use_synonyms": True,
                     "automatically_extensible": True,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en",
@@ -843,7 +868,7 @@ class TestDataset(SnipsTest):
                     "Entity 2": "Ëntity 1",
                 },
                 "capitalize": False,
-                "parser_threshold": 1.0
+                "matching_strictness": 1.0
             }
         }
 
@@ -886,7 +911,7 @@ class TestDataset(SnipsTest):
                     ],
                     "use_synonyms": True,
                     "automatically_extensible": False,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en",

--- a/snips_nlu/tests/test_deterministic_intent_parser.py
+++ b/snips_nlu/tests/test_deterministic_intent_parser.py
@@ -58,7 +58,7 @@ class TestDeterministicIntentParser(FixtureTest):
                 "dummy_entity_1": {
                     "automatically_extensible": False,
                     "use_synonyms": True,
-                    "parser_threshold": 1.0,
+                    "matching_strictness": 1.0,
                     "data": [
                         {
                             "synonyms": [
@@ -88,7 +88,7 @@ class TestDeterministicIntentParser(FixtureTest):
                 "dummy_entity_2": {
                     "automatically_extensible": False,
                     "use_synonyms": True,
-                    "parser_threshold": 1.0,
+                    "matching_strictness": 1.0,
                     "data": [
                         {
                             "synonyms": [
@@ -482,7 +482,7 @@ class TestDeterministicIntentParser(FixtureTest):
                 "non_ascìi_entïty": {
                     "use_synonyms": False,
                     "automatically_extensible": True,
-                    "parser_threshold": 1.0,
+                    "matching_strictness": 1.0,
                     "data": []
                 }
             },

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -47,7 +47,7 @@ class TestIntentClassifierFeaturizer(SnipsTest):
                     ],
                     "use_synonyms": True,
                     "automatically_extensible": True,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "intents": {},
@@ -192,7 +192,7 @@ class TestIntentClassifierFeaturizer(SnipsTest):
                     ],
                     "use_synonyms": False,
                     "automatically_extensible": False,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 },
                 "entity_2": {
                     "data": [
@@ -207,7 +207,7 @@ class TestIntentClassifierFeaturizer(SnipsTest):
                     ],
                     "use_synonyms": True,
                     "automatically_extensible": False,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 },
                 "snips/number": {}
             },

--- a/snips_nlu/tests/test_log_reg_intent_classifier.py
+++ b/snips_nlu/tests/test_log_reg_intent_classifier.py
@@ -230,7 +230,7 @@ class TestLogRegIntentClassifier(FixtureTest):
                             "synonyms": [],
                         }
                     ],
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "intents": {

--- a/snips_nlu/tests/test_nlu_engine.py
+++ b/snips_nlu/tests/test_nlu_engine.py
@@ -570,7 +570,7 @@ class TestSnipsNLUEngine(FixtureTest):
                             ]
                         }
                     ],
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 },
                 "dummy_entity_2": {
                     "use_synonyms": False,
@@ -583,7 +583,7 @@ class TestSnipsNLUEngine(FixtureTest):
                             ]
                         }
                     ],
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en"
@@ -652,7 +652,7 @@ class TestSnipsNLUEngine(FixtureTest):
                             ]
                         }
                     ],
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en"
@@ -734,7 +734,7 @@ class TestSnipsNLUEngine(FixtureTest):
                     ],
                     "use_synonyms": True,
                     "automatically_extensible": False,
-                    "parser_threshold": 1.0
+                    "matching_strictness": 1.0
                 }
             },
             "language": "en",

--- a/snips_nlu_samples/sample_dataset.json
+++ b/snips_nlu_samples/sample_dataset.json
@@ -210,7 +210,7 @@
       "data": [],
       "use_synonyms": true,
       "automatically_extensible": true,
-      "parser_threshold": 1.0
+      "matching_strictness": 1.0
     },
     "snips/datetime": {},
     "room": {
@@ -231,7 +231,7 @@
       ],
       "use_synonyms": true,
       "automatically_extensible": false,
-      "parser_threshold": 1.0
+      "matching_strictness": 1.0
     }
   },
   "language": "en"


### PR DESCRIPTION
This preserves backward compatibility with the previous name of the attribute which is "parser_threshold".