### PR TITLE
Fix snips-nlu-metrics import

### DIFF
--- a/snips_nlu/cli/metrics.py
+++ b/snips_nlu/cli/metrics.py
@@ -4,13 +4,14 @@ import json
 from pathlib import Path
 
 import plac
-from snips_nlu_metrics import Engine
 
 from snips_nlu import SnipsNLUEngine, load_resources
 from snips_nlu.utils import json_string
 
 
 def make_engine_cls(config):
+    from snips_nlu_metrics import Engine
+
     class ConfigEngine(Engine):
         def __init__(self):
             self.engine = None


### PR DESCRIPTION
### Added
- Add a `--config` argument in the metrics CLI

### Changed
- Replace "parser_threshold" by "matching_strictness" in dataset format
- Optimize loading and inference runtime
- Disable stemming for intent classification in default configs