### PR TITLE
Fix intent classifier data augmentation configuration serizalization

### DIFF
--- a/snips_nlu/intent_classifier/log_reg_classifier_utils.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier_utils.py
@@ -151,13 +151,14 @@ def build_training_data(dataset, language, data_augmentation_config,
         augmented_utterances += utterances
         utterance_classes += [classes_mapping[intent_name] for _ in
                               range(len(utterances))]
-    augmented_utterances = add_unknown_word_to_utterances(
-        augmented_utterances,
-        data_augmentation_config.unknown_words_replacement_string,
-        data_augmentation_config.unknown_word_prob,
-        data_augmentation_config.max_unknown_words,
-        random_state
-    )
+    if data_augmentation_config.unknown_words_replacement_string is not None:
+        augmented_utterances = add_unknown_word_to_utterances(
+            augmented_utterances,
+            data_augmentation_config.unknown_words_replacement_string,
+            data_augmentation_config.unknown_word_prob,
+            data_augmentation_config.max_unknown_words,
+            random_state
+        )
 
     # Adding noise
     noise = get_dataset_specific_noise(dataset, language)

--- a/snips_nlu/pipeline/configs/intent_classifier.py
+++ b/snips_nlu/pipeline/configs/intent_classifier.py
@@ -118,7 +118,8 @@ class IntentClassifierDataAugmentationConfig(Config):
 
     def __init__(self, min_utterances=20, noise_factor=5,
                  add_builtin_entities_examples=True, unknown_word_prob=0,
-                 unknown_words_replacement_string=None, max_unknown_words=3):
+                 unknown_words_replacement_string=None,
+                 max_unknown_words=None):
         self.min_utterances = min_utterances
         self.noise_factor = noise_factor
         self.add_builtin_entities_examples = add_builtin_entities_examples
@@ -146,6 +147,7 @@ class IntentClassifierDataAugmentationConfig(Config):
             "unknown_word_prob": self.unknown_word_prob,
             "unknown_words_replacement_string":
                 self.unknown_words_replacement_string,
+            "max_unknown_words": self.max_unknown_words
         }
 
     @classmethod

--- a/snips_nlu/tests/test_config.py
+++ b/snips_nlu/tests/test_config.py
@@ -27,6 +27,7 @@ class TestConfig(SnipsTest):
             "add_builtin_entities_examples": False,
             "unknown_word_prob": 0.1,
             "unknown_words_replacement_string": "foobar",
+            "max_unknown_words": None,
         }
 
         # When


### PR DESCRIPTION
**Description**:
- Add the `max_unknown_words` parameter in the `IntentClassifierDataAugmentationConfig` serialization