### PR TITLE
Prevent max_unknown_words < 1

### DIFF
--- a/snips_nlu/default_configs/config_de.py
+++ b/snips_nlu/default_configs/config_de.py
@@ -175,7 +175,7 @@ CONFIG = {
                     "min_utterances": 20,
                     "noise_factor": 5,
                     "add_builtin_entities_examples": True,
-                    "max_unknown_words": 0,
+                    "max_unknown_words": None,
                     "unknown_word_prob": 0.0,
                     "unknown_words_replacement_string": None
                 },

--- a/snips_nlu/default_configs/config_en.py
+++ b/snips_nlu/default_configs/config_en.py
@@ -152,7 +152,7 @@ CONFIG = {
                     "min_utterances": 20,
                     "noise_factor": 5,
                     "add_builtin_entities_examples": True,
-                    "max_unknown_words": 0,
+                    "max_unknown_words": None,
                     "unknown_word_prob": 0,
                     "unknown_words_replacement_string": None
                 },

--- a/snips_nlu/default_configs/config_es.py
+++ b/snips_nlu/default_configs/config_es.py
@@ -139,7 +139,7 @@ CONFIG = {
                     "min_utterances": 20,
                     "noise_factor": 5,
                     "add_builtin_entities_examples": True,
-                    "max_unknown_words": 0,
+                    "max_unknown_words": None,
                     "unknown_word_prob": 0.0,
                     "unknown_words_replacement_string": None
                 },

--- a/snips_nlu/default_configs/config_fr.py
+++ b/snips_nlu/default_configs/config_fr.py
@@ -139,7 +139,7 @@ CONFIG = {
                     "min_utterances": 20,
                     "noise_factor": 5,
                     "add_builtin_entities_examples": True,
-                    "max_unknown_words": 0,
+                    "max_unknown_words": None,
                     "unknown_word_prob": 0.0,
                     "unknown_words_replacement_string": None
                 },

--- a/snips_nlu/default_configs/config_it.py
+++ b/snips_nlu/default_configs/config_it.py
@@ -139,7 +139,7 @@ CONFIG = {
                     "min_utterances": 20,
                     "noise_factor": 5,
                     "add_builtin_entities_examples": True,
-                    "max_unknown_words": 0,
+                    "max_unknown_words": None,
                     "unknown_word_prob": 0.0,
                     "unknown_words_replacement_string": None
                 },

--- a/snips_nlu/default_configs/config_ja.py
+++ b/snips_nlu/default_configs/config_ja.py
@@ -195,7 +195,7 @@ CONFIG = {
                     "min_utterances": 20,
                     "noise_factor": 5,
                     "add_builtin_entities_examples": True,
-                    "max_unknown_words": 0,
+                    "max_unknown_words": None,
                     "unknown_word_prob": 0.0,
                     "unknown_words_replacement_string": None
                 },

--- a/snips_nlu/default_configs/config_ko.py
+++ b/snips_nlu/default_configs/config_ko.py
@@ -173,7 +173,7 @@ CONFIG = {
                     "min_utterances": 20,
                     "noise_factor": 5,
                     "add_builtin_entities_examples": True,
-                    "max_unknown_words": 0,
+                    "max_unknown_words": None,
                     "unknown_word_prob": 0.0,
                     "unknown_words_replacement_string": None
                 },

--- a/snips_nlu/pipeline/configs/intent_classifier.py
+++ b/snips_nlu/pipeline/configs/intent_classifier.py
@@ -4,7 +4,8 @@ from copy import deepcopy
 
 from snips_nlu.constants import (
     CUSTOM_ENTITY_PARSER_USAGE, NOISE, STEMS, STOP_WORDS, WORD_CLUSTERS)
-from snips_nlu.entity_parser.custom_entity_parser import CustomEntityParserUsage
+from snips_nlu.entity_parser.custom_entity_parser import (
+    CustomEntityParserUsage)
 from snips_nlu.pipeline.configs import Config, ProcessingUnitConfig
 from snips_nlu.resources import merge_required_resources
 from snips_nlu.utils import classproperty
@@ -126,6 +127,8 @@ class IntentClassifierDataAugmentationConfig(Config):
         self.unknown_word_prob = unknown_word_prob
         self.unknown_words_replacement_string = \
             unknown_words_replacement_string
+        if max_unknown_words is not None and max_unknown_words < 1:
+            raise ValueError("max_unknown_words must be None or >= 1")
         self.max_unknown_words = max_unknown_words
         if unknown_word_prob > 0 and unknown_words_replacement_string is None:
             raise ValueError("unknown_word_prob is positive (%s) but the "

--- a/snips_nlu/tests/test_config.py
+++ b/snips_nlu/tests/test_config.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import unittest
+from builtins import str
 from copy import deepcopy
 
 from snips_nlu_ontology import get_all_languages
@@ -36,6 +37,23 @@ class TestConfig(SnipsTest):
 
         # Then
         self.assertDictEqual(config_dict, serialized_config)
+
+    def test_intent_classifier_data_augmentation_config_should_raise(self):
+        # Given
+        config_dict = {
+            "min_utterances": 3,
+            "noise_factor": 2,
+            "add_builtin_entities_examples": False,
+            "unknown_word_prob": 0.1,
+            "unknown_words_replacement_string": "foobar",
+            "max_unknown_words": 0,
+        }
+
+        # When / Then
+        with self.assertRaises(ValueError) as ctx:
+            IntentClassifierDataAugmentationConfig.from_dict(config_dict)
+        self.assertEqual(
+            "max_unknown_words must be None or >= 1", str(ctx.exception))
 
     def test_slot_filler_data_augmentation_config(self):
         # Given


### PR DESCRIPTION
**Description**:
- `max_unknown_words < 1` in the `IntentClassifierDataAugmentationConfig` makes the data augmentation crash, this should not be allowed