### PR TITLE
Fix CLI logging

### DIFF
--- a/snips_nlu/cli/utils.py
+++ b/snips_nlu/cli/utils.py
@@ -20,6 +20,11 @@ class PrettyPrintLevel(Enum):
     SUCCESS = 3
 
 
+FMT = "[%(levelname)s][%(asctime)s.%(msecs)03d][%(name)s]: " \
+      "%(message)s"
+DATE_FMT = "%H:%M:%S"
+
+
 def pretty_print(*texts, **kwargs):
     """Print formatted message
 
@@ -105,6 +110,11 @@ def check_resources_alias(resource_name, shortcuts):
 def set_nlu_logger(level=logging.INFO):
     logger = logging.getLogger(snips_nlu.__name__)
     logger.setLevel(level)
+
+    formatter = logging.Formatter(FMT, DATE_FMT)
+
     handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
     handler.setLevel(level)
+
     logger.addHandler(handler)

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -242,7 +242,7 @@ class LogRegIntentClassifier(IntentClassifier):
         }
 
     def log_best_features(self, top_n=20):
-        log = "Top {} features weights by intent:\n".format(top_n)
+        log = "Top {} features weights by intent:".format(top_n)
         voca = {
             v: k for k, v in
             iteritems(self.featurizer.tfidf_vectorizer.vocabulary_)

--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -121,8 +121,6 @@ class DeterministicIntentParser(IntentParser):
         Raises:
             NotTrained: When the intent parser is not fitted
         """
-        logger.debug("DeterministicIntentParser parsing '%s'...", text)
-
         if isinstance(intents, str):
             intents = [intents]
 

--- a/snips_nlu/intent_parser/probabilistic_intent_parser.py
+++ b/snips_nlu/intent_parser/probabilistic_intent_parser.py
@@ -13,8 +13,8 @@ from snips_nlu.constants import INTENTS, RES_INTENT_NAME
 from snips_nlu.dataset import validate_and_format_dataset
 from snips_nlu.intent_parser.intent_parser import IntentParser
 from snips_nlu.pipeline.configs import ProbabilisticIntentParserConfig
-from snips_nlu.pipeline.processing_unit import (
-    load_processing_unit, build_processing_unit)
+from snips_nlu.pipeline.processing_unit import (build_processing_unit,
+                                                load_processing_unit)
 from snips_nlu.result import empty_result, parsing_result
 from snips_nlu.utils import (check_persisted_path, elapsed_since,
                              fitted_required, json_string, log_elapsed_time,
@@ -121,8 +121,6 @@ class ProbabilisticIntentParser(IntentParser):
         Raises:
             NotTrained: When the intent parser is not fitted
         """
-        logger.debug("Probabilistic intent parser parsing '%s'...", text)
-
         if isinstance(intents, str):
             intents = [intents]
 

--- a/snips_nlu/nlu_engine/nlu_engine.py
+++ b/snips_nlu/nlu_engine/nlu_engine.py
@@ -136,7 +136,7 @@ class SnipsNLUEngine(ProcessingUnit):
             NotTrained: When the nlu engine is not fitted
             TypeError: When input type is not unicode
         """
-        logging.info("NLU engine parsing: '%s'...", text)
+        logger.info("NLU engine parsing: '%s'...", text)
         if not isinstance(text, str):
             raise TypeError("Expected unicode but received: %s" % type(text))
 

--- a/snips_nlu/nlu_engine/nlu_engine.py
+++ b/snips_nlu/nlu_engine/nlu_engine.py
@@ -81,8 +81,6 @@ class SnipsNLUEngine(ProcessingUnit):
         Returns:
             The same object, trained.
         """
-        logger.info("Fitting NLU engine...")
-
         dataset = validate_and_format_dataset(dataset)
         self._dataset_metadata = _get_dataset_metadata(dataset)
         if self.config is None:
@@ -116,7 +114,6 @@ class SnipsNLUEngine(ProcessingUnit):
         self.intent_parsers = parsers
         return self
 
-    @log_result(logger, logging.DEBUG, "Result -> {result}")
     @log_elapsed_time(logger, logging.DEBUG, "Parsed query in {elapsed_time}")
     @fitted_required
     def parse(self, text, intents=None):
@@ -136,7 +133,6 @@ class SnipsNLUEngine(ProcessingUnit):
             NotTrained: When the nlu engine is not fitted
             TypeError: When input type is not unicode
         """
-        logger.info("NLU engine parsing: '%s'...", text)
         if not isinstance(text, str):
             raise TypeError("Expected unicode but received: %s" % type(text))
 


### PR DESCRIPTION
**Description**:
- Removed `logging.info()` call that set up an handler for the root logger and ended up in a double logging
- Removed logs that could have been added by the client. Some logs where immediately after the `SnipsNLUEngine` call or just before the `SnipsNLUEngine` output. These logs are useless since they can be added by the caller. They don't log information that's not directly available by the caller and pollute the log output