### PR TITLE
Improve logging

### DIFF
--- a/snips_nlu/cli/utils.py
+++ b/snips_nlu/cli/utils.py
@@ -20,6 +20,11 @@ class PrettyPrintLevel(Enum):
     SUCCESS = 3
 
 
+FMT = "[%(levelname)s][%(asctime)s.%(msecs)03d][%(name)s]: " \
+      "%(message)s"
+DATE_FMT = "%H:%M:%S"
+
+
 def pretty_print(*texts, **kwargs):
     """Print formatted message
 
@@ -105,6 +110,11 @@ def check_resources_alias(resource_name, shortcuts):
 def set_nlu_logger(level=logging.INFO):
     logger = logging.getLogger(snips_nlu.__name__)
     logger.setLevel(level)
+
+    formatter = logging.Formatter(FMT, DATE_FMT)
+
     handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
     handler.setLevel(level)
+
     logger.addHandler(handler)

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -132,6 +132,9 @@ class LogRegIntentClassifier(IntentClassifier):
         X = self.featurizer.transform([text_to_utterance(text)])
         # pylint: enable=C0103
         proba_vec = self._predict_proba(X, intents_filter=intents_filter)
+        logger.debug(
+            "%s", DifferedLoggingMessage(self.log_activation_weights, text, X))
+
         intents_probas = sorted(zip(self.intent_list, proba_vec[0]),
                                 key=lambda p: -p[1])
         for intent, proba in intents_probas:
@@ -257,4 +260,39 @@ class LogRegIntentClassifier(IntentClassifier):
                 feature_name = features[feature_ix]
                 feature_weight = self.classifier.coef_[intent_ix, feature_ix]
                 log += "\n{} -> {}".format(feature_name, feature_weight)
+        return log
+
+    def log_activation_weights(self, text, x, top_n=50):
+        log = "\n\nTop {} feature activations for: \"{}\":\n".format(
+            top_n, text)
+        activations = np.multiply(
+            self.classifier.coef_, np.asarray(x.todense()))
+        abs_activation = np.absolute(activations).flatten().squeeze()
+
+        if top_n > activations.size:
+            top_n = activations.size
+
+        top_n_activations_ix = np.argpartition(abs_activation, -top_n,
+                                               axis=None)[-top_n:]
+        top_n_activations_ix = np.unravel_index(
+            top_n_activations_ix, activations.shape)
+
+        voca = {
+            v: k for k, v in
+            iteritems(self.featurizer.tfidf_vectorizer.vocabulary_)
+        }
+        features = [voca[i] for i in self.featurizer.best_features]
+
+        features_intent_and_activation = [
+            (self.intent_list[i], features[f], activations[i, f])
+            for i, f in zip(*top_n_activations_ix)]
+
+        features_intent_and_activation = sorted(
+            features_intent_and_activation, key=lambda x: abs(x[2]),
+            reverse=True)
+
+        for intent, feature, activation in features_intent_and_activation:
+            log += "\n\n\"{}\" -> ({}, {:.2f})".format(
+                feature, intent, float(activation))
+        log += "\n\n"
         return log

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -242,7 +242,7 @@ class LogRegIntentClassifier(IntentClassifier):
         }
 
     def log_best_features(self, top_n=20):
-        log = "Top {} features weights by intent:\n".format(top_n)
+        log = "Top {} features weights by intent:".format(top_n)
         voca = {
             v: k for k, v in
             iteritems(self.featurizer.tfidf_vectorizer.vocabulary_)

--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -121,8 +121,6 @@ class DeterministicIntentParser(IntentParser):
         Raises:
             NotTrained: When the intent parser is not fitted
         """
-        logger.debug("DeterministicIntentParser parsing '%s'...", text)
-
         if isinstance(intents, str):
             intents = [intents]
 

--- a/snips_nlu/intent_parser/probabilistic_intent_parser.py
+++ b/snips_nlu/intent_parser/probabilistic_intent_parser.py
@@ -13,8 +13,8 @@ from snips_nlu.constants import INTENTS, RES_INTENT_NAME
 from snips_nlu.dataset import validate_and_format_dataset
 from snips_nlu.intent_parser.intent_parser import IntentParser
 from snips_nlu.pipeline.configs import ProbabilisticIntentParserConfig
-from snips_nlu.pipeline.processing_unit import (
-    load_processing_unit, build_processing_unit)
+from snips_nlu.pipeline.processing_unit import (build_processing_unit,
+                                                load_processing_unit)
 from snips_nlu.result import empty_result, parsing_result
 from snips_nlu.utils import (check_persisted_path, elapsed_since,
                              fitted_required, json_string, log_elapsed_time,
@@ -121,8 +121,6 @@ class ProbabilisticIntentParser(IntentParser):
         Raises:
             NotTrained: When the intent parser is not fitted
         """
-        logger.debug("Probabilistic intent parser parsing '%s'...", text)
-
         if isinstance(intents, str):
             intents = [intents]
 

--- a/snips_nlu/nlu_engine/nlu_engine.py
+++ b/snips_nlu/nlu_engine/nlu_engine.py
@@ -136,7 +136,7 @@ class SnipsNLUEngine(ProcessingUnit):
             NotTrained: When the nlu engine is not fitted
             TypeError: When input type is not unicode
         """
-        logging.info("NLU engine parsing: '%s'...", text)
+        logger.info("NLU engine parsing: '%s'...", text)
         if not isinstance(text, str):
             raise TypeError("Expected unicode but received: %s" % type(text))
 

--- a/snips_nlu/nlu_engine/nlu_engine.py
+++ b/snips_nlu/nlu_engine/nlu_engine.py
@@ -81,8 +81,6 @@ class SnipsNLUEngine(ProcessingUnit):
         Returns:
             The same object, trained.
         """
-        logger.info("Fitting NLU engine...")
-
         dataset = validate_and_format_dataset(dataset)
         self._dataset_metadata = _get_dataset_metadata(dataset)
         if self.config is None:
@@ -116,7 +114,6 @@ class SnipsNLUEngine(ProcessingUnit):
         self.intent_parsers = parsers
         return self
 
-    @log_result(logger, logging.DEBUG, "Result -> {result}")
     @log_elapsed_time(logger, logging.DEBUG, "Parsed query in {elapsed_time}")
     @fitted_required
     def parse(self, text, intents=None):
@@ -136,7 +133,6 @@ class SnipsNLUEngine(ProcessingUnit):
             NotTrained: When the nlu engine is not fitted
             TypeError: When input type is not unicode
         """
-        logger.info("NLU engine parsing: '%s'...", text)
         if not isinstance(text, str):
             raise TypeError("Expected unicode but received: %s" % type(text))
 

--- a/snips_nlu/nlu_engine/nlu_engine.py
+++ b/snips_nlu/nlu_engine/nlu_engine.py
@@ -27,7 +27,7 @@ from snips_nlu.result import (
     builtin_slot, custom_slot, empty_result, is_empty, parsing_result)
 from snips_nlu.utils import (
     check_persisted_path, fitted_required, get_slot_name_mappings, json_string,
-    log_elapsed_time, log_result)
+    log_elapsed_time)
 
 logger = logging.getLogger(__name__)
 

--- a/snips_nlu/tests/test_log_reg_intent_classifier.py
+++ b/snips_nlu/tests/test_log_reg_intent_classifier.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 from __future__ import unicode_literals
 
+from builtins import str
+
 from mock import patch
 
 from snips_nlu.constants import (
@@ -258,3 +260,19 @@ class TestLogRegIntentClassifier(FixtureTest):
         intent_classifier = LogRegIntentClassifier().fit(dataset)
         intent = intent_classifier.get_intent("no intent there")
         self.assertEqual(None, intent)
+
+    def test_log_activation_weights(self):
+        # Given
+        dataset = validate_and_format_dataset(SAMPLE_DATASET)
+        intent_classifier = LogRegIntentClassifier().fit(dataset)
+
+        text = "yo"
+        utterances = [text_to_utterance(text)]
+        x = intent_classifier.featurizer.transform(utterances)[0]
+
+        # When
+        log = intent_classifier.log_activation_weights(text, x)
+
+        # Then
+        self.assertIsInstance(log, str)
+        self.assertIn("Top 50", log)


### PR DESCRIPTION
**Description**:
- Removed `logging.info()` call that set up an handler for the root logger and ended up in a double logging
- Removed logs that could have been added by the client. Some logs where immediately after the `SnipsNLUEngine` call or just before the `SnipsNLUEngine` output. These logs are useless since they can be added by the caller. They don't log information that's not directly available by the caller and pollute the log output
- Added a debug log to print top activations in the `LogRegIntentClassifier`