### PR TITLE
Feature top n intent #623

### DIFF
--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -137,11 +137,25 @@ class LogRegIntentClassifier(IntentClassifier):
 
         intents_probas = sorted(zip(self.intent_list, proba_vec[0]),
                                 key=lambda p: -p[1])
-        for intent, proba in intents_probas:
-            if intent is None:
-                return None
-            if intents_filter is None or intent in intents_filter:
-                return intent_classification_result(intent, proba)
+        augmentation_config = self.config.data_augmentation_config
+        if augmentation_config.return_top_n_intents:
+            i_list = []
+            count = 0
+            for intent, proba in intents_probas:
+                if count == augmentation_config.top_n_intents_count:
+                    break
+                if intent is None:
+                    continue
+                if intents_filter is None or intent in intents_filter:
+                    i_list.append(intent_classification_result(intent, proba))
+                    count += 1
+            return i_list
+        else:
+            for intent, proba in intents_probas:
+                if intent is None:
+                    return None
+                if intents_filter is None or intent in intents_filter:
+                    return intent_classification_result(intent, proba)
         return None
 
     def _predict_proba(self, X, intents_filter):  # pylint: disable=C0103

--- a/snips_nlu/nlu_engine/nlu_engine.py
+++ b/snips_nlu/nlu_engine/nlu_engine.py
@@ -141,11 +141,21 @@ class SnipsNLUEngine(ProcessingUnit):
 
         for parser in self.intent_parsers:
             res = parser.parse(text, intents)
-            if is_empty(res):
-                continue
-            resolved_slots = self.resolve_slots(text, res[RES_SLOTS])
-            return parsing_result(text, intent=res[RES_INTENT],
-                                  slots=resolved_slots)
+            if isinstance(res, dict):
+                if is_empty(res):
+                    continue
+                resolved_slots = self.resolve_slots(text, res[RES_SLOTS])
+                return parsing_result(text, intent=res[RES_INTENT],
+                                      slots=resolved_slots)
+
+            if isinstance(res, list):
+                final_result = []
+                for item in res:
+                    resolved_slots = self.resolve_slots(text, item[RES_SLOTS])
+                    final_result.append(parsing_result(text, 
+                                    intent=item[RES_INTENT],
+                                    slots=resolved_slots))
+                return final_result
         return empty_result(text)
 
     def resolve_slots(self, text, slots):

--- a/snips_nlu/pipeline/configs/intent_classifier.py
+++ b/snips_nlu/pipeline/configs/intent_classifier.py
@@ -119,7 +119,8 @@ class IntentClassifierDataAugmentationConfig(Config):
     def __init__(self, min_utterances=20, noise_factor=5,
                  add_builtin_entities_examples=True, unknown_word_prob=0,
                  unknown_words_replacement_string=None,
-                 max_unknown_words=None):
+                 max_unknown_words=None, return_top_n_intents = False,
+                 top_n_intents_count=0):
         self.min_utterances = min_utterances
         self.noise_factor = noise_factor
         self.add_builtin_entities_examples = add_builtin_entities_examples
@@ -127,6 +128,8 @@ class IntentClassifierDataAugmentationConfig(Config):
         self.unknown_words_replacement_string = \
             unknown_words_replacement_string
         self.max_unknown_words = max_unknown_words
+        self.return_top_n_intents = return_top_n_intents
+        self.top_n_intents_count = top_n_intents_count
         if unknown_word_prob > 0 and unknown_words_replacement_string is None:
             raise ValueError("unknown_word_prob is positive (%s) but the "
                              "replacement string is None" % unknown_word_prob)

--- a/snips_nlu/tests/test_log_reg_intent_classifier.py
+++ b/snips_nlu/tests/test_log_reg_intent_classifier.py
@@ -264,7 +264,7 @@ class TestLogRegIntentClassifier(FixtureTest):
 
     def test_return_top_n_intent_if_specified(self):
         aug_config = IntentClassifierDataAugmentationConfig(
-            return_top_n_intents = True, top_n_intents_count = 2)
+            return_top_n_intents=True, top_n_intents_count=2)
         log_reg_conf = LogRegIntentClassifierConfig(
             data_augmentation_config=aug_config)
         dataset = validate_and_format_dataset(SAMPLE_DATASET)

--- a/snips_nlu/tests/test_log_reg_intent_classifier.py
+++ b/snips_nlu/tests/test_log_reg_intent_classifier.py
@@ -16,7 +16,7 @@ from snips_nlu.intent_classifier.featurizer import Featurizer
 from snips_nlu.intent_classifier.log_reg_classifier_utils import (
     text_to_utterance)
 from snips_nlu.pipeline.configs import (
-    LogRegIntentClassifierConfig)
+    LogRegIntentClassifierConfig, IntentClassifierDataAugmentationConfig)
 from snips_nlu.tests.utils import (
     BEVERAGE_DATASET, FixtureTest, SAMPLE_DATASET, get_empty_dataset)
 from snips_nlu.utils import NotTrained
@@ -260,6 +260,18 @@ class TestLogRegIntentClassifier(FixtureTest):
         intent_classifier = LogRegIntentClassifier().fit(dataset)
         intent = intent_classifier.get_intent("no intent there")
         self.assertEqual(None, intent)
+
+
+    def test_return_top_n_intent_if_specified(self):
+        aug_config = IntentClassifierDataAugmentationConfig(
+            return_top_n_intents = True, top_n_intents_count = 2)
+        log_reg_conf = LogRegIntentClassifierConfig(
+            data_augmentation_config=aug_config)
+        dataset = validate_and_format_dataset(SAMPLE_DATASET)
+        intent_classifier = LogRegIntentClassifier(
+            config=log_reg_conf).fit(dataset)
+        self.assertEqual(len(intent_classifier.get_intent('dummy test')), 2)
+
 
     def test_log_activation_weights(self):
         # Given

--- a/snips_nlu/tests/test_nlu_engine.py
+++ b/snips_nlu/tests/test_nlu_engine.py
@@ -879,10 +879,9 @@ class TestSnipsNLUEngine(FixtureTest):
         engine.parse("ya", intents=["dummy_intent"])
 
     def test_should_be_able_to_parse_multiple_intent(self):
-        
         aug_config = IntentClassifierDataAugmentationConfig(
             return_top_n_intents=True, top_n_intents_count=2)
-        log_reg_conf=LogRegIntentClassifierConfig(
+        log_reg_conf = LogRegIntentClassifierConfig(
             data_augmentation_config=aug_config)
         parser_conf = ProbabilisticIntentParserConfig(
             intent_classifier_config=log_reg_conf)

--- a/snips_nlu/tests/test_nlu_engine.py
+++ b/snips_nlu/tests/test_nlu_engine.py
@@ -20,7 +20,9 @@ from snips_nlu.entity_parser.custom_entity_parser_usage import \
 from snips_nlu.intent_parser import IntentParser
 from snips_nlu.nlu_engine import SnipsNLUEngine
 from snips_nlu.pipeline.configs import (
-    ProcessingUnitConfig, NLUEngineConfig, ProbabilisticIntentParserConfig)
+    ProcessingUnitConfig, NLUEngineConfig, ProbabilisticIntentParserConfig,
+    IntentClassifierDataAugmentationConfig,
+    LogRegIntentClassifierConfig)
 from snips_nlu.pipeline.units_registry import (
     register_processing_unit, reset_processing_units)
 from snips_nlu.result import (
@@ -875,6 +877,19 @@ class TestSnipsNLUEngine(FixtureTest):
         # When / Then
         engine.fit(dataset)
         engine.parse("ya", intents=["dummy_intent"])
+
+    def test_should_be_able_to_parse_multiple_intent(self):
+        
+        aug_config = IntentClassifierDataAugmentationConfig(
+            return_top_n_intents=True, top_n_intents_count=2)
+        log_reg_conf=LogRegIntentClassifierConfig(
+            data_augmentation_config=aug_config)
+        parser_conf = ProbabilisticIntentParserConfig(
+            intent_classifier_config=log_reg_conf)
+        config = NLUEngineConfig([parser_conf])
+        engine = SnipsNLUEngine(config=config).fit(BEVERAGE_DATASET)
+        result = engine.parse("get me some coffee")
+        self.assertEqual(len(result), 2)
 
 
 class TestIntentParser1Config(ProcessingUnitConfig):

--- a/snips_nlu/tests/test_probabilistic_intent_parser.py
+++ b/snips_nlu/tests/test_probabilistic_intent_parser.py
@@ -283,7 +283,7 @@ class TestProbabilisticIntentParser(FixtureTest):
     def test_should_be_able_to_parse_multiple_intent(self):
         aug_config = IntentClassifierDataAugmentationConfig(
             return_top_n_intents=True, top_n_intents_count=2)
-        log_reg_conf=LogRegIntentClassifierConfig(
+        log_reg_conf = LogRegIntentClassifierConfig(
             data_augmentation_config=aug_config)
         conf = ProbabilisticIntentParserConfig(
             intent_classifier_config=log_reg_conf)

--- a/snips_nlu/tests/test_probabilistic_intent_parser.py
+++ b/snips_nlu/tests/test_probabilistic_intent_parser.py
@@ -12,7 +12,8 @@ from snips_nlu.intent_parser import ProbabilisticIntentParser
 from snips_nlu.pipeline.configs import (CRFSlotFillerConfig,
                                         LogRegIntentClassifierConfig,
                                         ProcessingUnitConfig,
-                                        ProbabilisticIntentParserConfig)
+                                        ProbabilisticIntentParserConfig,
+                                        IntentClassifierDataAugmentationConfig)
 from snips_nlu.pipeline.units_registry import (
     register_processing_unit, reset_processing_units)
 from snips_nlu.slot_filler import CRFSlotFiller, SlotFiller
@@ -277,6 +278,19 @@ class TestProbabilisticIntentParser(FixtureTest):
         feature_weights_2 = fitted_parser_2.slot_fillers[
             "MakeTea"].crf_model.state_features_
         self.assertEqual(feature_weights_1, feature_weights_2)
+
+
+    def test_should_be_able_to_parse_multiple_intent(self):
+        aug_config = IntentClassifierDataAugmentationConfig(
+            return_top_n_intents=True, top_n_intents_count=2)
+        log_reg_conf=LogRegIntentClassifierConfig(
+            data_augmentation_config=aug_config)
+        conf = ProbabilisticIntentParserConfig(
+            intent_classifier_config=log_reg_conf)
+        top_n_parser = ProbabilisticIntentParser(conf)
+        top_n_parser.fit(BEVERAGE_DATASET)
+        result = top_n_parser.parse("get me some coffee")
+        self.assertEqual(len(result), 2)
 
 
 class TestIntentClassifierConfig(ProcessingUnitConfig):


### PR DESCRIPTION
**Description**:
- Added support for returning top n intent, addresses feature request #623 . To use the feature modify
```
"intent_classifier_config": {
  "unit_name": "log_reg_intent_classifier",
    "data_augmentation_config": {
      "min_utterances": 20,
      "noise_factor": 5,
      "add_builtin_entities_examples": True,
      "max_unknown_words": 0,
      "unknown_word_prob": 0,
      "unknown_words_replacement_string": None
      "return_top_n_intents" : True,
      "top_n_intents_count": 3
}
```

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
