### PR TITLE
Fix bug when generating dataset from YAML and text files

### DIFF
--- a/snips_nlu/dataset/intent.py
+++ b/snips_nlu/dataset/intent.py
@@ -320,7 +320,7 @@ class SM(object):
 def capture_text(state):
     next_pos = state.find('[')
     sub = state[:] if next_pos < 0 else state[:next_pos]
-    if sub.strip():
+    if sub:
         state.add_text(sub)
     if next_pos >= 0:
         state.move(next_pos)

--- a/snips_nlu/tests/test_dataset_loading.py
+++ b/snips_nlu/tests/test_dataset_loading.py
@@ -76,6 +76,9 @@ EXPECTED_DATASET_DICT = {
                             "text": "new york"
                         },
                         {
+                            "text": " "
+                        },
+                        {
                             "entity": "snips/datetime",
                             "slot_name": "weatherDate",
                             "text": "Today"

--- a/snips_nlu/tests/test_intent_loading.py
+++ b/snips_nlu/tests/test_intent_loading.py
@@ -18,7 +18,8 @@ class TestIntentLoading(TestCase):
 type: intent
 name: getWeather
 utterances:
-  - what is the weather in [weatherLocation:location](paris) ?
+  - "what is the weather in [weatherLocation:location](paris) 
+    [date:snips/datetime](today) ?"
   - "Will it rain [date:snips/datetime](tomorrow) in
     [weatherLocation:location](london)?"
         """))
@@ -38,6 +39,14 @@ utterances:
                             "text": "paris",
                             "entity": "location",
                             "slot_name": "weatherLocation"
+                        },
+                        {
+                            "text": " "
+                        },
+                        {
+                            "text": "today",
+                            "entity": "snips/datetime",
+                            "slot_name": "date"
                         },
                         {
                             "text": " ?"
@@ -250,6 +259,9 @@ is it raining in [weatherLocation] [weatherDate:snips/datetime]
                             "text": None
                         },
                         {
+                            "text": " "
+                        },
+                        {
                             "entity": "snips/datetime",
                             "slot_name": "weatherDate",
                             "text": None
@@ -268,6 +280,9 @@ is it raining in [weatherLocation] [weatherDate:snips/datetime]
                             "entity": "location",
                             "slot_name": "weatherLocation",
                             "text": None
+                        },
+                        {
+                            "text": " "
                         },
                         {
                             "entity": "snips/datetime",


### PR DESCRIPTION
**Description**:
This PR fixes an issue when parsing intent utterances from YAML or text file formats, which was first reported [here](https://github.com/snipsco/snips-nlu-metrics/issues/104).
When an utterance contains two consecutive slots separated by a whitespace, then the whitespace is discarded:
```
Show me [ent1:ent1](foo) [ent2:ent2](bar)
```
Gives:
```json
{
  "data": [
    {
      "text": "Show me "
    },
    {
      "entity": "ent1",
      "text": "foo",
      "slot_name": "ent1"
    },
    {
      "entity": "ent2",
      "text": "bar",
      "slot_name": "ent2"
    }
  ]
}
```

Instead of:
```json
{
  "data": [
    {
      "text": "Show me "
    },
    {
      "entity": "ent1",
      "text": "foo",
      "slot_name": "ent1"
    },
    {
      "text": " "
    },
    {
      "entity": "ent2",
      "text": "bar",
      "slot_name": "ent2"
    }
  ]
}
```

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
