### PR TITLE
Allow max_unknownwords to be 0 or None

### DIFF
--- a/snips_nlu/intent_classifier/log_reg_classifier_utils.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier_utils.py
@@ -90,6 +90,9 @@ def generate_noise_utterances(augmented_utterances, noise, num_intents,
 def add_unknown_word_to_utterances(utterances, replacement_string,
                                    unknown_word_prob, max_unknown_words,
                                    random_state):
+    if not max_unknown_words:
+        return utterances
+
     new_utterances = deepcopy(utterances)
     for u in new_utterances:
         if random_state.rand() < unknown_word_prob:

--- a/snips_nlu/pipeline/configs/intent_classifier.py
+++ b/snips_nlu/pipeline/configs/intent_classifier.py
@@ -127,8 +127,8 @@ class IntentClassifierDataAugmentationConfig(Config):
         self.unknown_word_prob = unknown_word_prob
         self.unknown_words_replacement_string = \
             unknown_words_replacement_string
-        if max_unknown_words is not None and max_unknown_words < 1:
-            raise ValueError("max_unknown_words must be None or >= 1")
+        if max_unknown_words is not None and max_unknown_words < 0:
+            raise ValueError("max_unknown_words must be None or >= 0")
         self.max_unknown_words = max_unknown_words
         if unknown_word_prob > 0 and unknown_words_replacement_string is None:
             raise ValueError("unknown_word_prob is positive (%s) but the "

--- a/snips_nlu/tests/test_config.py
+++ b/snips_nlu/tests/test_config.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 import unittest
-from builtins import str
 from copy import deepcopy
 
 from snips_nlu_ontology import get_all_languages
@@ -37,23 +36,6 @@ class TestConfig(SnipsTest):
 
         # Then
         self.assertDictEqual(config_dict, serialized_config)
-
-    def test_intent_classifier_data_augmentation_config_should_raise(self):
-        # Given
-        config_dict = {
-            "min_utterances": 3,
-            "noise_factor": 2,
-            "add_builtin_entities_examples": False,
-            "unknown_word_prob": 0.1,
-            "unknown_words_replacement_string": "foobar",
-            "max_unknown_words": 0,
-        }
-
-        # When / Then
-        with self.assertRaises(ValueError) as ctx:
-            IntentClassifierDataAugmentationConfig.from_dict(config_dict)
-        self.assertEqual(
-            "max_unknown_words must be None or >= 1", str(ctx.exception))
 
     def test_slot_filler_data_augmentation_config(self):
         # Given

--- a/snips_nlu/tests/test_log_reg_classifier_utils.py
+++ b/snips_nlu/tests/test_log_reg_classifier_utils.py
@@ -5,6 +5,8 @@ from copy import deepcopy
 from itertools import cycle
 
 import numpy as np
+from numpy.random.mtrand import RandomState
+
 from future.utils import itervalues
 from mock import MagicMock, patch
 
@@ -511,7 +513,6 @@ class TestLogRegClassifierUtils(SnipsTest):
 
         self.assertDictEqual(expected_dataset, filtered_dataset)
 
-
     @patch("snips_nlu.intent_classifier.log_reg_classifier_utils.get_noise")
     def test_get_dataset_specific_noise(self, mocked_noise):
         # Given
@@ -519,9 +520,40 @@ class TestLogRegClassifierUtils(SnipsTest):
         language = "en"
         mocked_noise.return_value = ["dummy_a", "yo"]
 
-
         # When
         noise = get_dataset_specific_noise(dataset, language)
 
         # Then
         self.assertEqual(["yo"], noise)
+
+    def test_add_unknown_word_to_utterances_with_none_max_unknownword(self):
+        # Given
+        utterances = [text_to_utterance("yo")]
+        replacement_string = "yo"
+        unknown_word_prob = 1
+        max_unknown_words = None
+        random_state = RandomState()
+
+        # When / Then
+        with self.fail_if_exception(
+            "Failed to augment utterances with max_unknownword=None"):
+            add_unknown_word_to_utterances(
+                utterances, replacement_string, unknown_word_prob,
+                max_unknown_words, random_state
+            )
+
+    def test_add_unknown_word_to_utterances_with_zero_max_unknownword(self):
+        # Given
+        utterances = [text_to_utterance("yo")]
+        replacement_string = "yo"
+        unknown_word_prob = 1
+        max_unknown_words = 0
+        random_state = RandomState()
+
+        # When / Then
+        with self.fail_if_exception(
+            "Failed to augment utterances with unknown_word_prob=0"):
+            add_unknown_word_to_utterances(
+                utterances, replacement_string, unknown_word_prob,
+                max_unknown_words, random_state
+            )


### PR DESCRIPTION
**Description**:
- If `max_unknownwords=None` and `replacement_string` is not `None` the `random_state.randint(1, max_unknown_words + 1)` fails with a `TypeError`
- I fixed the bug and also allowed `max_unknownwords` since it's an intuitive value for the user. If it's 0 then we don't add any unknownword

**Checklist**:
- [ ] My PR is ready for code review
- [ ] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
