### PR TITLE
Add word cooccurrence as intent classification features

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -47,6 +47,14 @@ Intent Classifier
 .. autoclass:: LogRegIntentClassifier
    :members:
 
+.. autoclass:: Featurizer
+   :members:
+
+.. autoclass:: TfidfVectorizer
+   :members:
+
+.. autoclass:: CooccurrenceVectorizer
+   :members:
 
 Slot Filler
 -----------
@@ -95,6 +103,11 @@ Configurations
 .. autoclass:: CRFSlotFillerConfig
    :members:
 
+.. autoclass:: FeaturizerConfig
+   :members:
+
+.. autoclass:: CooccurrenceVectorizerConfig
+   :members:
 
 Dataset
 -------

--- a/snips_nlu/default_configs/config_de.py
+++ b/snips_nlu/default_configs/config_de.py
@@ -181,10 +181,16 @@ CONFIG = {
                     "unknown_words_replacement_string": None
                 },
                 "featurizer_config": {
-                    "sublinear_tf": False,
                     "pvalue_threshold": 0.4,
                     "word_clusters_name": None,
-                    "use_stemming": False
+                    "use_stemming": True,
+                    "added_cooccurrence_feature_ratio": 0,
+                    "tfidf_vectorizer_config": {},
+                    "cooccurrence_vectorizer_config": {
+                        "unknown_words_replacement_string": None,
+                        "window_size": None,
+                        "filter_stop_words": True
+                    }
                 },
                 "random_seed": None
             }

--- a/snips_nlu/default_configs/config_de.py
+++ b/snips_nlu/default_configs/config_de.py
@@ -182,10 +182,11 @@ CONFIG = {
                 },
                 "featurizer_config": {
                     "pvalue_threshold": 0.4,
-                    "word_clusters_name": None,
-                    "use_stemming": True,
-                    "added_cooccurrence_feature_ratio": 0,
-                    "tfidf_vectorizer_config": {},
+                    "added_cooccurrence_feature_ratio": 0.0,
+                    "tfidf_vectorizer_config": {
+                        "use_stemming": True,
+                        "word_clusters_name": None
+                    },
                     "cooccurrence_vectorizer_config": {
                         "unknown_words_replacement_string": None,
                         "window_size": None,

--- a/snips_nlu/default_configs/config_en.py
+++ b/snips_nlu/default_configs/config_en.py
@@ -158,10 +158,16 @@ CONFIG = {
                     "unknown_words_replacement_string": None
                 },
                 "featurizer_config": {
-                    "sublinear_tf": False,
                     "pvalue_threshold": 0.4,
                     "word_clusters_name": None,
-                    "use_stemming": False
+                    "use_stemming": False,
+                    "added_cooccurrence_feature_ratio": 0,
+                    "tfidf_vectorizer_config": {},
+                    "cooccurrence_vectorizer_config": {
+                        "unknown_words_replacement_string": None,
+                        "window_size": None,
+                        "filter_stop_words": True
+                    }
                 },
                 "random_seed": None
             }

--- a/snips_nlu/default_configs/config_en.py
+++ b/snips_nlu/default_configs/config_en.py
@@ -159,10 +159,11 @@ CONFIG = {
                 },
                 "featurizer_config": {
                     "pvalue_threshold": 0.4,
-                    "word_clusters_name": None,
-                    "use_stemming": False,
-                    "added_cooccurrence_feature_ratio": 0,
-                    "tfidf_vectorizer_config": {},
+                    "added_cooccurrence_feature_ratio": 0.0,
+                    "tfidf_vectorizer_config": {
+                        "use_stemming": False,
+                        "word_clusters_name": None
+                    },
                     "cooccurrence_vectorizer_config": {
                         "unknown_words_replacement_string": None,
                         "window_size": None,

--- a/snips_nlu/default_configs/config_es.py
+++ b/snips_nlu/default_configs/config_es.py
@@ -146,10 +146,11 @@ CONFIG = {
                 },
                 "featurizer_config": {
                     "pvalue_threshold": 0.4,
-                    "word_clusters_name": None,
-                    "use_stemming": True,
-                    "added_cooccurrence_feature_ratio": 0,
-                    "tfidf_vectorizer_config": {},
+                    "added_cooccurrence_feature_ratio": 0.0,
+                    "tfidf_vectorizer_config": {
+                        "use_stemming": True,
+                        "word_clusters_name": None
+                    },
                     "cooccurrence_vectorizer_config": {
                         "unknown_words_replacement_string": None,
                         "window_size": None,

--- a/snips_nlu/default_configs/config_es.py
+++ b/snips_nlu/default_configs/config_es.py
@@ -145,10 +145,16 @@ CONFIG = {
                     "unknown_words_replacement_string": None
                 },
                 "featurizer_config": {
-                    "sublinear_tf": False,
                     "pvalue_threshold": 0.4,
                     "word_clusters_name": None,
-                    "use_stemming": True
+                    "use_stemming": True,
+                    "added_cooccurrence_feature_ratio": 0,
+                    "tfidf_vectorizer_config": {},
+                    "cooccurrence_vectorizer_config": {
+                        "unknown_words_replacement_string": None,
+                        "window_size": None,
+                        "filter_stop_words": True
+                    }
                 },
                 "random_seed": None
             }

--- a/snips_nlu/default_configs/config_fr.py
+++ b/snips_nlu/default_configs/config_fr.py
@@ -146,10 +146,11 @@ CONFIG = {
                 },
                 "featurizer_config": {
                     "pvalue_threshold": 0.4,
-                    "word_clusters_name": None,
-                    "use_stemming": True,
-                    "added_cooccurrence_feature_ratio": 0,
-                    "tfidf_vectorizer_config": {},
+                    "added_cooccurrence_feature_ratio": 0.0,
+                    "tfidf_vectorizer_config": {
+                        "use_stemming": True,
+                        "word_clusters_name": None
+                    },
                     "cooccurrence_vectorizer_config": {
                         "unknown_words_replacement_string": None,
                         "window_size": None,

--- a/snips_nlu/default_configs/config_fr.py
+++ b/snips_nlu/default_configs/config_fr.py
@@ -145,10 +145,16 @@ CONFIG = {
                     "unknown_words_replacement_string": None
                 },
                 "featurizer_config": {
-                    "sublinear_tf": False,
                     "pvalue_threshold": 0.4,
                     "word_clusters_name": None,
-                    "use_stemming": True
+                    "use_stemming": True,
+                    "added_cooccurrence_feature_ratio": 0,
+                    "tfidf_vectorizer_config": {},
+                    "cooccurrence_vectorizer_config": {
+                        "unknown_words_replacement_string": None,
+                        "window_size": None,
+                        "filter_stop_words": True
+                    }
                 },
                 "random_seed": None
             }

--- a/snips_nlu/default_configs/config_it.py
+++ b/snips_nlu/default_configs/config_it.py
@@ -146,10 +146,11 @@ CONFIG = {
                 },
                 "featurizer_config": {
                     "pvalue_threshold": 0.4,
-                    "word_clusters_name": None,
-                    "use_stemming": True,
-                    "added_cooccurrence_feature_ratio": 0,
-                    "tfidf_vectorizer_config": {},
+                    "added_cooccurrence_feature_ratio": 0.0,
+                    "tfidf_vectorizer_config": {
+                        "use_stemming": True,
+                        "word_clusters_name": None
+                    },
                     "cooccurrence_vectorizer_config": {
                         "unknown_words_replacement_string": None,
                         "window_size": None,

--- a/snips_nlu/default_configs/config_it.py
+++ b/snips_nlu/default_configs/config_it.py
@@ -145,10 +145,16 @@ CONFIG = {
                     "unknown_words_replacement_string": None
                 },
                 "featurizer_config": {
-                    "sublinear_tf": False,
                     "pvalue_threshold": 0.4,
                     "word_clusters_name": None,
-                    "use_stemming": True
+                    "use_stemming": True,
+                    "added_cooccurrence_feature_ratio": 0,
+                    "tfidf_vectorizer_config": {},
+                    "cooccurrence_vectorizer_config": {
+                        "unknown_words_replacement_string": None,
+                        "window_size": None,
+                        "filter_stop_words": True
+                    }
                 },
                 "random_seed": None
             }

--- a/snips_nlu/default_configs/config_ja.py
+++ b/snips_nlu/default_configs/config_ja.py
@@ -201,10 +201,16 @@ CONFIG = {
                     "unknown_words_replacement_string": None
                 },
                 "featurizer_config": {
-                    "sublinear_tf": False,
                     "pvalue_threshold": 0.4,
                     "word_clusters_name": None,
-                    "use_stemming": False
+                    "use_stemming": False,
+                    "added_cooccurrence_feature_ratio": 0,
+                    "tfidf_vectorizer_config": {},
+                    "cooccurrence_vectorizer_config": {
+                        "unknown_words_replacement_string": None,
+                        "window_size": None,
+                        "filter_stop_words": True
+                    }
                 },
                 "random_seed": None
             }

--- a/snips_nlu/default_configs/config_ja.py
+++ b/snips_nlu/default_configs/config_ja.py
@@ -202,10 +202,11 @@ CONFIG = {
                 },
                 "featurizer_config": {
                     "pvalue_threshold": 0.4,
-                    "word_clusters_name": None,
-                    "use_stemming": False,
-                    "added_cooccurrence_feature_ratio": 0,
-                    "tfidf_vectorizer_config": {},
+                    "added_cooccurrence_feature_ratio": 0.0,
+                    "tfidf_vectorizer_config": {
+                        "use_stemming": False,
+                        "word_clusters_name": None
+                    },
                     "cooccurrence_vectorizer_config": {
                         "unknown_words_replacement_string": None,
                         "window_size": None,

--- a/snips_nlu/default_configs/config_ko.py
+++ b/snips_nlu/default_configs/config_ko.py
@@ -180,10 +180,11 @@ CONFIG = {
                 },
                 "featurizer_config": {
                     "pvalue_threshold": 0.4,
-                    "word_clusters_name": None,
-                    "use_stemming": False,
-                    "added_cooccurrence_feature_ratio": 0,
-                    "tfidf_vectorizer_config": {},
+                    "added_cooccurrence_feature_ratio": 0.0,
+                    "tfidf_vectorizer_config": {
+                        "use_stemming": False,
+                        "word_clusters_name": None
+                    },
                     "cooccurrence_vectorizer_config": {
                         "unknown_words_replacement_string": None,
                         "window_size": None,

--- a/snips_nlu/default_configs/config_ko.py
+++ b/snips_nlu/default_configs/config_ko.py
@@ -179,10 +179,16 @@ CONFIG = {
                     "unknown_words_replacement_string": None
                 },
                 "featurizer_config": {
-                    "sublinear_tf": False,
                     "pvalue_threshold": 0.4,
                     "word_clusters_name": None,
-                    "use_stemming": False
+                    "use_stemming": False,
+                    "added_cooccurrence_feature_ratio": 0,
+                    "tfidf_vectorizer_config": {},
+                    "cooccurrence_vectorizer_config": {
+                        "unknown_words_replacement_string": None,
+                        "window_size": None,
+                        "filter_stop_words": True
+                    }
                 },
                 "random_seed": None
             }

--- a/snips_nlu/entity_parser/builtin_entity_parser.py
+++ b/snips_nlu/entity_parser/builtin_entity_parser.py
@@ -30,7 +30,7 @@ class BuiltinEntityParser(EntityParser):
         self._parser = parser
 
     def _parse(self, text, scope=None):
-        entities = self._parser.parse(text, scope=scope)
+        entities = self._parser.parse(text.lower(), scope=scope)
         result = []
         for entity in entities:
             ent = parsed_entity(

--- a/snips_nlu/entity_parser/builtin_entity_parser.py
+++ b/snips_nlu/entity_parser/builtin_entity_parser.py
@@ -14,6 +14,7 @@ from snips_nlu.constants import DATA_PATH, ENTITIES, LANGUAGE
 from snips_nlu.entity_parser.entity_parser import EntityParser
 from snips_nlu.common.utils import json_string
 from snips_nlu.common.io_utils import temp_dir
+from snips_nlu.result import parsed_entity
 
 _BUILTIN_ENTITY_PARSERS = dict()
 
@@ -24,6 +25,23 @@ except NameError:
 
 
 class BuiltinEntityParser(EntityParser):
+    def __init__(self, parser):
+        super(BuiltinEntityParser, self).__init__()
+        self._parser = parser
+
+    def _parse(self, text, scope=None):
+        entities = self._parser.parse(text, scope=scope)
+        result = []
+        for entity in entities:
+            ent = parsed_entity(
+                entity_kind=entity["entity_kind"],
+                entity_value=entity["value"],
+                entity_resolved_value=entity["entity"],
+                entity_range=entity["range"]
+            )
+            result.append(ent)
+        return result
+
     def persist(self, path):
         self._parser.persist(path)
 

--- a/snips_nlu/entity_parser/custom_entity_parser.py
+++ b/snips_nlu/entity_parser/custom_entity_parser.py
@@ -134,10 +134,10 @@ def _create_custom_entity_parser_configuration(entities):
                         {
                             "raw_value": k,
                             "resolved_value": v
-                        } for k, v in iteritems(entity[UTTERANCES])
+                        } for k, v in sorted(iteritems(entity[UTTERANCES]))
                     ]
                 }
-            } for entity_name, entity in iteritems(entities)
+            } for entity_name, entity in sorted(iteritems(entities))
         ]
     }
 

--- a/snips_nlu/entity_parser/custom_entity_parser.py
+++ b/snips_nlu/entity_parser/custom_entity_parser.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import json
+import operator
 from copy import deepcopy
 from pathlib import Path
 
@@ -104,14 +105,20 @@ class CustomEntityParser(EntityParser):
 
 
 def _stem_entity_utterances(entity_utterances, language):
-    return {
-        stem(raw_value, language): resolved_value
-        for raw_value, resolved_value in iteritems(entity_utterances)
-    }
+    values = dict()
+    # Sort by resolved value, so that values conflict in a deterministic way
+    for raw_value, resolved_value in sorted(
+            iteritems(entity_utterances), key=operator.itemgetter(1)):
+        stemmed_value = stem(raw_value, language)
+        if stemmed_value not in values:
+            values[stemmed_value] = resolved_value
+    return values
 
 
 def _merge_entity_utterances(raw_utterances, stemmed_utterances):
-    for raw_stemmed_value, resolved_value in iteritems(stemmed_utterances):
+    # Sort by resolved value, so that values conflict in a deterministic way
+    for raw_stemmed_value, resolved_value in sorted(
+            iteritems(stemmed_utterances), key=operator.itemgetter(1)):
         if raw_stemmed_value not in raw_utterances:
             raw_utterances[raw_stemmed_value] = resolved_value
     return raw_utterances

--- a/snips_nlu/entity_parser/custom_entity_parser.py
+++ b/snips_nlu/entity_parser/custom_entity_parser.py
@@ -10,21 +10,44 @@ from future.utils import iteritems, viewvalues
 from snips_nlu_ontology import GazetteerEntityParser
 
 from snips_nlu.constants import (
-    END, ENTITIES, LANGUAGE, MATCHING_STRICTNESS, RES_MATCH_RANGE, START,
-    UTTERANCES, ENTITY_KIND)
+    END, ENTITIES, LANGUAGE, MATCHING_STRICTNESS, START, UTTERANCES)
 from snips_nlu.entity_parser.builtin_entity_parser import is_builtin_entity
 from snips_nlu.entity_parser.custom_entity_parser_usage import (
     CustomEntityParserUsage)
 from snips_nlu.entity_parser.entity_parser import EntityParser
 from snips_nlu.preprocessing import stem, tokenize
+from snips_nlu.result import parsed_entity
 from snips_nlu.common.utils import json_string
 
 
 class CustomEntityParser(EntityParser):
     def __init__(self, parser, language, parser_usage):
-        super(CustomEntityParser, self).__init__(parser)
+        super(CustomEntityParser, self).__init__()
+        self._parser = parser
         self.language = language
         self.parser_usage = parser_usage
+
+    def _parse(self, text, scope=None):
+        tokens = tokenize(text, self.language)
+        shifts = _compute_char_shifts(tokens)
+        cleaned_text = " ".join(token.value for token in tokens)
+
+        entities = self._parser.parse(cleaned_text, scope)
+        result = []
+        for entity in entities:
+            start = entity["range"]["start"]
+            start -= shifts[start]
+            end = entity["range"]["end"]
+            end -= shifts[end -1]
+            entity_range = {START: start, END: end}
+            ent = parsed_entity(
+                entity_kind=entity["entity_identifier"],
+                entity_value=entity["value"],
+                entity_resolved_value=entity["resolved_value"],
+                entity_range=entity_range
+            )
+            result.append(ent)
+        return result
 
     def persist(self, path):
         path = Path(path)
@@ -78,30 +101,6 @@ class CustomEntityParser(EntityParser):
             custom_entities)
         parser = GazetteerEntityParser.build(configuration)
         return cls(parser, language, parser_usage)
-
-    def parse(self, text, scope=None, use_cache=True):
-        text = text.lower()
-        if not use_cache:
-            return self._parse(text, scope)
-        scope_key = tuple(sorted(scope)) if scope is not None else scope
-        cache_key = (text, scope_key)
-        if cache_key not in self._cache:
-            parser_result = self._parse(text, scope)
-            self._cache[cache_key] = parser_result
-        return self._cache[cache_key]
-
-    def _parse(self, text, scope):
-        tokens = tokenize(text, self.language)
-        shifts = _compute_char_shifts(tokens)
-        cleaned_text = " ".join(token.value for token in tokens)
-        entities = self._parser.parse(cleaned_text, scope)
-        for entity in entities:
-            start = entity[RES_MATCH_RANGE][START]
-            end = entity[RES_MATCH_RANGE][END]
-            entity[ENTITY_KIND] = entity.pop("entity_identifier")
-            entity[RES_MATCH_RANGE][START] -= shifts[start]
-            entity[RES_MATCH_RANGE][END] -= shifts[end - 1]
-        return entities
 
 
 def _stem_entity_utterances(entity_utterances, language):

--- a/snips_nlu/entity_parser/entity_parser.py
+++ b/snips_nlu/entity_parser/entity_parser.py
@@ -58,7 +58,7 @@ class EntityParser(with_metaclass(ABCMeta, object)):
     @abstractmethod
     def _parse(self, text, scope=None):
         """Internal parse method to implement in each subclass of
-            .EntityParser.
+         :class:`.EntityParser`
 
             Args:
                 text (str): input text
@@ -73,7 +73,7 @@ class EntityParser(with_metaclass(ABCMeta, object)):
             Returns:
                 list of dict: list of the parsed entities. These entity must
                     have the same output format as the
-                    .snips_nlu.result.parsed_entity function
+                    :func:`snips_nlu.utils.result.parsed_entity` function
         """
         pass
 

--- a/snips_nlu/entity_parser/entity_parser.py
+++ b/snips_nlu/entity_parser/entity_parser.py
@@ -45,7 +45,6 @@ class EntityParser(with_metaclass(ABCMeta, object)):
                     containing the string value, the resolved value, the
                     entity kind and the entity range
         """
-        text = text.lower()
         if not use_cache:
             return self._parse(text, scope)
         scope_key = tuple(sorted(scope)) if scope is not None else scope

--- a/snips_nlu/entity_parser/entity_parser.py
+++ b/snips_nlu/entity_parser/entity_parser.py
@@ -20,20 +20,62 @@ except ImportError:
 
 
 class EntityParser(with_metaclass(ABCMeta, object)):
-    def __init__(self, parser):
-        self._parser = parser
+    """Abstraction of a entity parser implementing some basic caching
+    """
+
+    def __init__(self):
         self._cache = LimitedSizeDict(size_limit=1000)
 
     def parse(self, text, scope=None, use_cache=True):
+        """Search the given text for entities defined in the scope. If no
+        scope is provided, search for all kinds of entities.
+
+            Args:
+                text (str): input text
+                scope (list or set of str, optional): if provided the parser
+                    will only look for entities which entity kind is given in
+                    the scope. By default the scope is None and the parser
+                    will search for all kinds of supported entities
+                use_cache (bool): if False the internal cache will not be use,
+                    this can be useful if the output of the parser depends on
+                    the current timestamp. Defaults to True.
+
+            Returns:
+                list of dict: list of the parsed entities formatted as a dict
+                    containing the string value, the resolved value, the
+                    entity kind and the entity range
+        """
         text = text.lower()
         if not use_cache:
-            return self._parser.parse(text, scope)
+            return self._parse(text, scope)
         scope_key = tuple(sorted(scope)) if scope is not None else scope
         cache_key = (text, scope_key)
         if cache_key not in self._cache:
-            parser_result = self._parser.parse(text, scope)
+            parser_result = self._parse(text, scope)
             self._cache[cache_key] = parser_result
         return self._cache[cache_key]
+
+    @abstractmethod
+    def _parse(self, text, scope=None):
+        """Internal parse method to implement in each subclass of
+            .EntityParser.
+
+            Args:
+                text (str): input text
+                scope (list or set of str, optional): if provided the parser
+                    will only look for entities which entity kind is given in
+                    the scope. By default the scope is None and the parser
+                    will search for all kinds of supported entities
+                use_cache (bool): if False the internal cache will not be use,
+                    this can be useful if the output of the parser depends on
+                    the current timestamp. Defaults to True.
+
+            Returns:
+                list of dict: list of the parsed entities. These entity must
+                    have the same output format as the
+                    .snips_nlu.result.parsed_entity function
+        """
+        pass
 
     @abstractmethod
     def persist(self, path):

--- a/snips_nlu/exceptions.py
+++ b/snips_nlu/exceptions.py
@@ -24,6 +24,11 @@ class DatasetFormatError(SnipsNLUError):
     format"""
 
 
+class _EmptyDatasetUtterancesError(SnipsNLUError):
+    """Raised when attempting to train a processing unit on a dataset having
+     only empty utterances"""
+
+
 class EntityFormatError(DatasetFormatError):
     """Raised when attempting to create a Snips NLU entity using a wrong
     format"""

--- a/snips_nlu/exceptions.py
+++ b/snips_nlu/exceptions.py
@@ -10,11 +10,6 @@ class NotTrained(SnipsNLUError):
     """Raised when a processing unit is used while not fitted"""
 
 
-class _EmptyDatasetError(SnipsNLUError):
-    """Raised when a processing unit can't fit because the provided data is
-    empty"""
-
-
 class IntentNotFoundError(SnipsNLUError):
     """Raised when an intent is used although it was not part of the
     training data"""

--- a/snips_nlu/exceptions.py
+++ b/snips_nlu/exceptions.py
@@ -10,6 +10,11 @@ class NotTrained(SnipsNLUError):
     """Raised when a processing unit is used while not fitted"""
 
 
+class _EmptyDataError(SnipsNLUError):
+    """Raised when a processing unit can't fit because the provided data is
+    empty"""
+
+
 class IntentNotFoundError(SnipsNLUError):
     """Raised when an intent is used although it was not part of the
     training data"""

--- a/snips_nlu/exceptions.py
+++ b/snips_nlu/exceptions.py
@@ -10,7 +10,7 @@ class NotTrained(SnipsNLUError):
     """Raised when a processing unit is used while not fitted"""
 
 
-class _EmptyDataError(SnipsNLUError):
+class _EmptyDatasetError(SnipsNLUError):
     """Raised when a processing unit can't fit because the provided data is
     empty"""
 

--- a/snips_nlu/intent_classifier/__init__.py
+++ b/snips_nlu/intent_classifier/__init__.py
@@ -1,2 +1,3 @@
 from .intent_classifier import IntentClassifier
 from .log_reg_classifier import LogRegIntentClassifier
+from .featurizer import Featurizer, CooccurrenceVectorizer, TfidfVectorizer

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -691,7 +691,6 @@ class CooccurrenceVectorizer(ProcessingUnit):
         }
         return self
 
-    @fitted_required
     def _placeholder_fn(self, entity_name):
         return "".join(
             tokenize_light(str(entity_name), str(self.language))).upper()

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -215,31 +215,6 @@ class Featurizer(ProcessingUnit):
         return (normalized_utterances, normalized_utterances_texts,
                 builtin_ents, custom_ents, w_clusters)
 
-    def fit_builtin_entity_parser_if_needed(self, dataset):
-        # We only fit a builtin entity parser when the unit has already been
-        # fitted or if the parser is none.
-        # In the other cases the parser is provided fitted by another unit.
-        if self.builtin_entity_parser is None or self.fitted:
-            self.builtin_entity_parser = BuiltinEntityParser.build(
-                dataset=dataset)
-        return self
-
-    def fit_custom_entity_parser_if_needed(self, dataset):
-        # We only fit a custom entity parser when the unit has already been
-        # fitted or if the parser is none.
-        # In the other cases the parser is provided fitted by another unit.
-        required_resources = self.config.get_required_resources()
-        if not required_resources:
-            return self
-        parser_usage = required_resources.get(CUSTOM_ENTITY_PARSER_USAGE)
-        if not parser_usage:
-            return self
-
-        if self.custom_entity_parser is None or self.fitted:
-            self.custom_entity_parser = CustomEntityParser.build(
-                dataset, parser_usage)
-        return self
-
     def persist(self, path):
         path = Path(path)
         path.mkdir()

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -175,7 +175,7 @@ class Featurizer(ProcessingUnit):
         top_k = int(self.config.added_cooccurrence_feature_ratio * len(
             self.tfidf_vectorizer.idf_diag))
         # Don't select more word pairs than we have
-        top_k = min(len(self.cooccurrence_vectorizer.word_pairs), top_k)
+        top_k = min(len(self.cooccurrence_vectorizer.word_pairs) - 1, top_k)
         top_k_cooccurrence_ix = np.argpartition(pval, top_k, axis=None)[:top_k]
         top_k_cooccurrence_ix = set(top_k_cooccurrence_ix)
 

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -143,12 +143,15 @@ class Featurizer(ProcessingUnit):
             return self
         _, pval = chi2(x_cooccurrence, classes)
 
-        # TODO: fix top k
         top_k = int(self.config.added_cooccurrence_feature_ratio * len(
             self.tfidf_vectorizer.idf_diag))
-        # Don't select more word pairs than we have
-        top_k = min(len(self.cooccurrence_vectorizer.word_pairs) - 1, top_k)
-        top_k_cooccurrence_ix = np.argpartition(pval, top_k, axis=None)[:top_k]
+
+        # No selection if k is greater or equal than the number of word pairs
+        if top_k >= len(self.cooccurrence_vectorizer.word_pairs):
+            return self
+
+        top_k_cooccurrence_ix = np.argpartition(
+            pval, top_k - 1, axis=None)[:top_k]
         top_k_cooccurrence_ix = set(top_k_cooccurrence_ix)
         top_word_pairs = [
             pair for pair, i in iteritems(

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -26,20 +26,21 @@ from snips_nlu.exceptions import (NotTrained, DatasetFormatError)
 from snips_nlu.languages import get_default_sep
 from snips_nlu.pipeline.configs import FeaturizerConfig
 from snips_nlu.pipeline.configs.intent_classifier import (
-    CooccurrenceVectorizerConfig, TfidfVectorizerConfig)
+    CooccurrenceVectorizerConfig)
 from snips_nlu.pipeline.processing_unit import ProcessingUnit
 from snips_nlu.preprocessing import stem, tokenize_light
 from snips_nlu.resources import (
     get_stop_words, get_word_cluster)
 from snips_nlu.slot_filler.features_utils import get_all_ngrams
-from snips_nlu.utils import json_string, replace_entities_with_placeholders
+from snips_nlu.common.utils import (
+    json_string, replace_entities_with_placeholders)
 
 
+@ProcessingUnit.register("featurizer")
 class Featurizer(ProcessingUnit):
     """Feature extractor for text classification relying on ngrams tfidf and
     word cooccurrences features"""
     config_type = FeaturizerConfig
-    unit_name = "featurizer"
 
     def __init__(self, config=None, **shared):
         # TODO: missing docstring
@@ -339,15 +340,12 @@ def _get_word_cluster_features(query_tokens, clusters_name, language):
     return cluster_features
 
 
+
+@ProcessingUnit.register("tfidf_vectorizer")
 class TfidfVectorizer(ProcessingUnit):
-    # TODO: missing doctring
-    unit_name = "tfidf_vectorizer"
-    config_type = TfidfVectorizerConfig
 
     def __init__(self, config=None, **shared):
         # TODO: missing doctring
-        if config is None:
-            config = TfidfVectorizerConfig()
         super(TfidfVectorizer, self).__init__(config, **shared)
         self._tfidf_vectorizer = None
         self._language = None
@@ -541,8 +539,8 @@ class TfidfVectorizer(ProcessingUnit):
         return vectorizer
 
 
+@ProcessingUnit.register("cooccurrence_vectorizer")
 class CooccurrenceVectorizer(ProcessingUnit):
-    unit_name = "cooccurrence_vectorizer"
     config_type = CooccurrenceVectorizerConfig
 
     def __init__(self, config=None, **shared):

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -239,9 +239,7 @@ class TfidfVectorizer(ProcessingUnit):
         and the potential word matches
 
         Args:
-            x (list of 4-tuple): list of 4-tuple in the form: utterance in the
-                dictionary format: (utterance, builtin entities,
-                custom entities, potential word clusters)
+            x (list of dict): list dict utterances
             dataset (dict): dataset from which x was extracted (needed to
                 extract the language and the builtin entity scope)
 
@@ -268,9 +266,7 @@ class TfidfVectorizer(ProcessingUnit):
         and the potential word matches. Returns the featurized utterances
 
         Args:
-            x (list of 4-tuple): list of 4-tuple in the form: utterance in the
-                dictionary format: (utterance, builtin entities,
-                custom entities, potential word clusters)
+            x (list of dict): list dict utterances
             dataset (dict): dataset from which x was extracted (needed to
                 extract the language and the builtin entity scope)
 
@@ -303,9 +299,7 @@ class TfidfVectorizer(ProcessingUnit):
         matches
 
         Args:
-            x (list of 4-tuple): list of 4-tuple in the form: utterance in the
-                dictionary format: (utterance, builtin entities,
-                custom entities, potential word clusters)
+            x (list of dict): list dict utterances
 
         Returns:
             :class:`.scipy.sparse.csr_matrix`: A sparse matrix X of shape
@@ -552,8 +546,7 @@ class CooccurrenceVectorizer(ProcessingUnit):
         self.config.window_size after each word.
 
         Args:
-            x (iterable): iterable of 3-tuples of the form
-                (tokenized_utterances, builtin_entities, custom_entities)
+            x (list of dict): list dict utterances
             dataset (dict): dataset from which x was extracted (needed to
                 extract the language and the builtin entity scope)
 
@@ -617,8 +610,7 @@ class CooccurrenceVectorizer(ProcessingUnit):
     def transform(self, x):
         """Computes the cooccurrence feature matrix.
         Args:
-            x (iterable): iterable of 3-tuples of the form
-            (tokenized_utterances, builtin_entities, custom_entities)
+            x (list of dict): list dict utterances
 
         Returns:
             :class:`.scipy.sparse.csr_matrix`: A sparse matrix X of shape

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -796,7 +796,7 @@ def _entities_from_utterance(utterance):
     builtin_ents = []
     custom_ents = []
     current_ix = 0
-    for i, chunk in enumerate(utterance[DATA]):
+    for chunk in utterance[DATA]:
         text = chunk[TEXT]
         text_length = len(text)
         if ENTITY in chunk:

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -16,15 +16,14 @@ from sklearn.feature_selection import chi2
 from sklearn.utils.validation import check_is_fitted
 from snips_nlu_utils import normalize
 
-from snips_nlu.constants import (CUSTOM_ENTITY_PARSER_USAGE, DATA, END,
-                                 ENTITIES, ENTITY, ENTITY_KIND, LANGUAGE,
-                                 NGRAM, RES_MATCH_RANGE, RES_VALUE, START,
-                                 TEXT)
+from snips_nlu.constants import (
+    CUSTOM_ENTITY_PARSER_USAGE, DATA, END, ENTITIES, ENTITY, ENTITY_KIND,
+    LANGUAGE, NGRAM, RES_MATCH_RANGE, RES_VALUE, START, TEXT)
 from snips_nlu.dataset import get_text_from_chunks
-from snips_nlu.entity_parser.builtin_entity_parser import (BuiltinEntityParser,
-                                                           is_builtin_entity)
+from snips_nlu.entity_parser.builtin_entity_parser import (
+    BuiltinEntityParser, is_builtin_entity)
 from snips_nlu.entity_parser.custom_entity_parser import CustomEntityParser
-from snips_nlu.exceptions import NotTrained, _EmptyDataError
+from snips_nlu.exceptions import NotTrained, _EmptyDatasetError
 from snips_nlu.languages import get_default_sep
 from snips_nlu.pipeline.configs import FeaturizerConfig
 from snips_nlu.pipeline.configs.intent_classifier import (
@@ -72,7 +71,7 @@ class Featurizer(ProcessingUnit):
 
         utterances_texts = (get_text_from_chunks(u[DATA]) for u in utterances)
         if not any(tokenize_light(q, self.language) for q in utterances_texts):
-            raise _EmptyDataError(
+            raise _EmptyDatasetError(
                 "Couldn't fit because no utterance was found an")
 
         self.fit_builtin_entity_parser_if_needed(dataset)

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -167,7 +167,8 @@ class Featurizer(ProcessingUnit):
         return self.tfidf_vectorizer.transform(x)
 
     def _fit_cooccurrence_vectorizer(self, x, y):
-        self.cooccurrence_vectorizer = CooccurrenceVectorizer()
+        self.cooccurrence_vectorizer = CooccurrenceVectorizer(
+            self.config.cooccurrence_vectorizer_config)
         x_cooccurrence = self.cooccurrence_vectorizer.fit_transform(
             x, self.language)
         _, pval = chi2(x_cooccurrence, y)
@@ -175,8 +176,7 @@ class Featurizer(ProcessingUnit):
             self.tfidf_vectorizer.idf_diag))
         # Don't select more word pairs than we have
         top_k = min(len(self.cooccurrence_vectorizer.word_pairs), top_k)
-        top_k_cooccurrence_ix = np.argpartition(
-            pval, top_k, axis=None)[-top_k:]
+        top_k_cooccurrence_ix = np.argpartition(pval, top_k, axis=None)[:top_k]
         top_k_cooccurrence_ix = set(top_k_cooccurrence_ix)
 
         top_word_pairs = [

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -1,11 +1,14 @@
 from __future__ import division, unicode_literals
 
-from builtins import object, range
+import json
+from pathlib import Path
 
 import numpy as np
 import scipy.sparse as sp
-from future.utils import iteritems
-from sklearn.exceptions import NotFittedError
+from scipy.sparse import hstack, dok_matrix
+
+from future.utils import iteritems, itervalues
+from sklearn.exceptions import NotFittedError as SklearnNotFittedError
 from sklearn.feature_extraction.text import TfidfTransformer, TfidfVectorizer
 from sklearn.feature_selection import chi2
 from sklearn.utils.validation import check_is_fitted
@@ -13,105 +16,238 @@ from snips_nlu_utils import normalize
 
 from snips_nlu.constants import (
     BUILTIN_ENTITY_PARSER, CUSTOM_ENTITY_PARSER, CUSTOM_ENTITY_PARSER_USAGE,
-    DATA, ENTITY, ENTITY_KIND, NGRAM, TEXT)
+    DATA, ENTITY, ENTITY_KIND, NGRAM, TEXT, LANGUAGE, ENTITIES, RES_VALUE,
+    RES_MATCH_RANGE, START, END)
 from snips_nlu.dataset import get_text_from_chunks
 from snips_nlu.entity_parser.builtin_entity_parser import (BuiltinEntityParser,
                                                            is_builtin_entity)
 from snips_nlu.entity_parser.custom_entity_parser import CustomEntityParser
+from snips_nlu.exceptions import _EmptyDataError, NotTrained
 from snips_nlu.languages import get_default_sep
 from snips_nlu.pipeline.configs import FeaturizerConfig
+from snips_nlu.pipeline.configs.intent_classifier import \
+    CooccurrenceVectorizerConfig
+from snips_nlu.pipeline.processing_unit import ProcessingUnit
 from snips_nlu.preprocessing import stem, tokenize_light
 from snips_nlu.resources import (
     get_stop_words, get_word_cluster)
 from snips_nlu.slot_filler.features_utils import get_all_ngrams
+from snips_nlu.utils import replace_entities_with_placeholders, json_string
 
 
 class Featurizer(object):
-    def __init__(self, language, unknown_words_replacement_string,
-                 config=FeaturizerConfig(), tfidf_vectorizer=None,
-                 best_features=None, builtin_entity_parser=None,
-                 custom_entity_parser=None):
+    def __init__(self, language=None, config=FeaturizerConfig(),
+                 tfidf_vectorizer=None,
+                 unknown_words_replacement_string=None,
+                 cooccurrence_vectorizer=None,
+                 builtin_entity_parser=None, custom_entity_parser=None,
+                 builtin_entity_scope=None):
         self.config = config
         self.language = language
-        if tfidf_vectorizer is None:
-            tfidf_vectorizer = _get_tfidf_vectorizer(
-                self.language, sublinear_tf=self.config.sublinear_tf)
         self.tfidf_vectorizer = tfidf_vectorizer
-        self.best_features = best_features
+        self.language = language
+        self.cooccurrence_vectorizer = cooccurrence_vectorizer
         self.unknown_words_replacement_string = \
             unknown_words_replacement_string
 
         self.builtin_entity_parser = builtin_entity_parser
         self.custom_entity_parser = custom_entity_parser
 
+        self.builtin_entity_scope = builtin_entity_scope
+
     @property
     def fitted(self):
+        if not self.tfidf_vectorizer:
+            return False
         try:
             check_is_fitted(self.tfidf_vectorizer, 'vocabulary_')
             return True
-        except NotFittedError:
+        except SklearnNotFittedError:
             return False
 
     def fit(self, dataset, utterances, classes):
-        self.fit_builtin_entity_parser_if_needed(dataset)
-        self.fit_custom_entity_parser_if_needed(dataset)
+        self.fit_transform(dataset, utterances, classes)
+        return self
+
+    def fit_transform(self, dataset, utterances, classes):
+        self.language = dataset[LANGUAGE]
+        self.tfidf_vectorizer = _get_tfidf_vectorizer(
+            self.language, sublinear_tf=self.config.sublinear_tf)
 
         utterances_texts = (get_text_from_chunks(u[DATA]) for u in utterances)
         if not any(tokenize_light(q, self.language) for q in utterances_texts):
-            return None
+            raise _EmptyDataError(
+                "Couldn't fit because no utterance was found an")
 
-        preprocessed_utterances = self.preprocess_utterances(utterances)
-        # pylint: disable=C0103
-        X_train_tfidf = self.tfidf_vectorizer.fit_transform(
-            preprocessed_utterances)
-        # pylint: enable=C0103
-        features_idx = {self.tfidf_vectorizer.vocabulary_[word]: word for word
-                        in self.tfidf_vectorizer.vocabulary_}
+        self.fit_builtin_entity_parser_if_needed(dataset)
+        self.fit_custom_entity_parser_if_needed(dataset)
 
-        stop_words = get_stop_words(self.language)
+        dataset_entities = set(dataset[ENTITIES])
 
-        _, pval = chi2(X_train_tfidf, classes)
-        self.best_features = [i for i, v in enumerate(pval) if
-                              v < self.config.pvalue_threshold]
-        if not self.best_features:
-            self.best_features = [idx for idx, val in enumerate(pval) if
-                                  val == pval.min()]
+        self.builtin_entity_scope = set(
+            e for e in dataset_entities if is_builtin_entity(e))
 
-        feature_names = {}
-        for utterance_index in self.best_features:
-            feature_names[utterance_index] = {
-                "word": features_idx[utterance_index],
-                "pval": pval[utterance_index]}
+        self.none_class_ix = max(classes)
 
-        for feat in feature_names:
-            if feature_names[feat]["word"] in stop_words:
-                if feature_names[feat]["pval"] > \
-                        self.config.pvalue_threshold / 2.0:
-                    self.best_features.remove(feat)
+        normalized, builtin_ents, custom_ents, w_clusters = self. \
+            _preprocess(utterances, training=True)
+        tfidf_data = zip(utterances, builtin_ents, custom_ents, w_clusters)
+        x_tfidf = self._fit_transform_tfidf_vectorizer(tfidf_data, classes)
 
-        return self
+        x = x_tfidf
+        if self.config.added_cooccurrence_feature_ratio:
+            cooccurrence_data = list(
+                zip(normalized, builtin_ents, custom_ents))
+            # We fit the coocurrence matrix without noise
+            non_null_cooccurrence_data, non_null_cooccurrence_classes = zip(*(
+                (d, c) for d, c in zip(cooccurrence_data, classes)
+                if c != self.none_class_ix))
+            self._fit_cooccurrence_vectorizer(
+                non_null_cooccurrence_data, non_null_cooccurrence_classes)
+            # We fit transform all the data
+            x_cooccurrence = self.cooccurrence_vectorizer.transform(
+                cooccurrence_data)
+
+            x = hstack((x_tfidf, x_cooccurrence))
+
+        return x
 
     def transform(self, utterances):
-        preprocessed_utterances = self.preprocess_utterances(utterances)
-        # pylint: disable=C0103
-        X_train_tfidf = self.tfidf_vectorizer.transform(
-            preprocessed_utterances)
-        X = X_train_tfidf[:, self.best_features]
-        # pylint: enable=C0103
-        return X
+        normalized_utterances, builtin_ents, custom_ents, w_clusters = self. \
+            _preprocess(utterances)
 
-    def fit_transform(self, dataset, queries, y):
-        return self.fit(dataset, queries, y).transform(queries)
+        tfidf_data = zip(utterances, builtin_ents, custom_ents, w_clusters)
 
-    def preprocess_utterances(self, utterances):
-        return [
-            _preprocess_utterance(
-                u, self.language, self.builtin_entity_parser,
-                self.custom_entity_parser, self.config.word_clusters_name,
-                self.config.use_stemming,
-                self.unknown_words_replacement_string)
-            for u in utterances
+        enriched_utterances = (self._enrich_utterance_for_tfidf(*d)
+                               for d in tfidf_data)
+
+        x = self.tfidf_vectorizer.transform(enriched_utterances)
+        if self.cooccurrence_vectorizer:
+            cooccurrence_data = zip(normalized_utterances, builtin_ents,
+                                    custom_ents)
+            x_cooccurrence = self.cooccurrence_vectorizer.transform(
+                cooccurrence_data)
+            x = hstack((x, x_cooccurrence))
+        return x
+
+    def _preprocess(self, utterances, training=False):
+        text_utterances = [get_text_from_chunks(u[DATA]) for u in utterances]
+
+        normalized_utterances = [
+            _normalize_stem(u, self.language, self.config.use_stemming)
+            for u in text_utterances
         ]
+
+        if training:
+            builtin_ents, custom_ents = zip(*(
+                _entities_from_utterance(u, self.config.use_stemming,
+                                         self.language) for u in utterances))
+        else:
+            # Extract builtin entities
+            builtin_ents = [
+                self.builtin_entity_parser.parse(
+                    u, self.builtin_entity_scope, use_cache=True)
+                for u in normalized_utterances
+            ]
+
+            custom_ents = [
+                self.custom_entity_parser.parse(u, use_cache=True)
+                for u in normalized_utterances
+            ]
+
+        if self.config.word_clusters_name:
+            w_clusters = [
+                _get_word_cluster_features(
+                    tokenize_light(u.lower(), self.language),
+                    self.config.word_clusters_name,
+                    self.language)
+                for u in text_utterances
+            ]
+        else:
+            w_clusters = [None for _ in text_utterances]
+
+        return (normalized_utterances, builtin_ents, custom_ents, w_clusters)
+
+    def _fit_transform_tfidf_vectorizer(self, x, y):
+        featurized_utterances = [
+            self._enrich_utterance_for_tfidf(
+                utterance, builtin_ents, customs_ents, w_clusters)
+            for utterance, builtin_ents, customs_ents, w_clusters in x
+        ]
+
+        x_tfidf = self.tfidf_vectorizer.fit_transform(featurized_utterances, y)
+        _, tfidf_pval = chi2(x_tfidf, y)
+        best_tfidf_features = [i for i, v in enumerate(tfidf_pval)
+                               if v < self.config.pvalue_threshold]
+        if not best_tfidf_features:
+            best_tfidf_features = [
+                idx for idx, val in enumerate(tfidf_pval) if
+                val == tfidf_pval.min()]
+        self._limit_tfidf_vectorizer_vocabulary(best_tfidf_features)
+        # We can't return x_tfidf[:best_tfidf_features] because of the
+        # normalization in the tranform of the tfidf_vectorizer
+        # this would lead to inconsistent result between: fit_transform(x, y)
+        # and fit(x, y).transform(x)
+        return self.tfidf_vectorizer.transform(featurized_utterances)
+
+    # pylint: disable=protected-access
+    def _limit_tfidf_vectorizer_vocabulary(self, ngram_indexes):
+        """Set the vectorizer vocabulary by limiting it to the n-grams
+        which index is contained in ngram_indexes
+            Args:
+             ngram_indexes (iterable of int): indexes of the ngrams to keep
+            Returns:
+                self: the vectorizer with a limited vocabulary
+        :return:
+        """
+        try:
+            check_is_fitted(self.tfidf_vectorizer, "vocabulary_")
+        except SklearnNotFittedError:
+            raise NotTrained(
+                "vectorizer must be fitted before limiting its vocabulary")
+
+        ngram_indexes = set(ngram_indexes)
+        existing_ix = set(itervalues(self.tfidf_vectorizer.vocabulary_))
+
+        extra_values = ngram_indexes - existing_ix
+
+        # Restrict the vectorizer vocabulary and remove corresponding indexes
+        # from the transformer's idf diag
+
+        if extra_values:
+            raise ValueError("Invalid ngrams indexes %s, expected values in"
+                             " %s" % (extra_values, existing_ix))
+
+        new_ngrams, new_index = zip(*sorted(
+            (ng, i) for ng, i in iteritems(self.tfidf_vectorizer.vocabulary_)
+            if i in ngram_indexes))
+
+        if not new_ngrams:
+            raise ValueError(
+                "No feature remain after limiting the vocabulary, please use "
+                "different ngram_indexes"
+            )
+
+        self.tfidf_vectorizer.vocabulary_ = {
+            ng: new_i for new_i, ng in enumerate(new_ngrams)
+        }
+        new_idf_data = self.tfidf_vectorizer._tfidf._idf_diag.data[
+            list(new_index)]
+        self.tfidf_vectorizer._tfidf._idf_diag = sp.spdiags(
+            new_idf_data, diags=0, m=len(new_index), n=len(new_index),
+            format="csr")
+        return self
+
+    def _fit_cooccurrence_vectorizer(self, x, y):
+        self.cooccurrence_vectorizer = CooccurrenceVectorizer()
+        x_cooccurrence = self.cooccurrence_vectorizer.fit_transform(
+            x, self.language)
+        _, pval = chi2(x_cooccurrence, y)
+        top_k = int(self.config.added_cooccurrence_feature_ratio * len(
+            self.tfidf_vectorizer.idf_))
+        top_k_cooccurrence_ix = np.argpartition(pval, top_k, axis=None)
+        self.cooccurrence_vectorizer.limit_vocabulary(top_k_cooccurrence_ix)
+        return self
 
     def fit_builtin_entity_parser_if_needed(self, dataset):
         # We only fit a builtin entity parser when the unit has already been
@@ -138,13 +274,45 @@ class Featurizer(object):
                 dataset, parser_usage)
         return self
 
+    def _enrich_utterance_for_tfidf(self, utterance, builtin_entities,
+                                    custom_entities, word_clusters):
+        custom_entities_features = [
+            _entity_name_to_feature(e[ENTITY_KIND], self.language)
+            for e in custom_entities]
+
+        builtin_entities_features = [
+            _builtin_entity_to_feature(ent[ENTITY_KIND], self.language)
+            for ent in builtin_entities
+        ]
+
+        # We remove values of builtin slots from the utterance to avoid
+        # learning specific samples such as '42' or 'tomorrow'
+        filtered_normalized_stemmed_tokens = [
+            _normalize_stem(
+                chunk[TEXT], self.language, self.config.use_stemming)
+            for chunk in utterance[DATA]
+            if ENTITY not in chunk or not is_builtin_entity(chunk[ENTITY])
+        ]
+
+        features = get_default_sep(self.language).join(
+            filtered_normalized_stemmed_tokens)
+
+        if builtin_entities_features:
+            features += " " + " ".join(sorted(builtin_entities_features))
+        if custom_entities_features:
+            features += " " + " ".join(sorted(custom_entities_features))
+        if word_clusters:
+            features += " " + " ".join(sorted(word_clusters))
+
+        return features
+
     def to_dict(self):
         """Returns a json-serializable dict"""
         if hasattr(self.tfidf_vectorizer, "vocabulary_"):
             # pylint: # pylint: disable=W0212
             vocab = {k: int(v) for k, v in
                      iteritems(self.tfidf_vectorizer.vocabulary_)}
-            idf_diag = self.tfidf_vectorizer._tfidf._idf_diag.data.tolist()
+            idf_diag = self.tfidf_vectorizer.idf_.tolist()
         else:
             vocab = None
             idf_diag = None
@@ -154,13 +322,17 @@ class Featurizer(object):
             "idf_diag": idf_diag
         }
 
+        builtin_scope = self.builtin_entity_scope
+        if builtin_scope is not None:
+            builtin_scope = list(builtin_scope)
+
         return {
             "language_code": self.language,
             "tfidf_vectorizer": tfidf_vectorizer,
-            "best_features": self.best_features,
             "config": self.config.to_dict(),
             "unknown_words_replacement_string":
-                self.unknown_words_replacement_string
+                self.unknown_words_replacement_string,
+            "builtin_entity_scope": builtin_scope
         }
 
     @classmethod
@@ -169,66 +341,25 @@ class Featurizer(object):
 
         The dict must have been generated with :func:`~Featurizer.to_dict`
         """
-        language = obj_dict["language_code"]
-        config = FeaturizerConfig.from_dict(obj_dict["config"])
+        language = obj_dict.pop("language_code")
+        config = FeaturizerConfig.from_dict(obj_dict.pop("config"))
         tfidf_vectorizer = _deserialize_tfidf_vectorizer(
-            obj_dict["tfidf_vectorizer"], language, config.sublinear_tf)
+            obj_dict.pop("tfidf_vectorizer"), language, config.sublinear_tf)
+
+        builtin_scope = obj_dict.pop("builtin_entity_scope")
+        if builtin_scope is not None:
+            builtin_scope = set(builtin_scope)
+
         self = cls(
             language=language,
             tfidf_vectorizer=tfidf_vectorizer,
-            best_features=obj_dict["best_features"],
             config=config,
-            unknown_words_replacement_string=obj_dict[
-                "unknown_words_replacement_string"],
             builtin_entity_parser=shared.get(BUILTIN_ENTITY_PARSER),
-            custom_entity_parser=shared.get(CUSTOM_ENTITY_PARSER)
+            custom_entity_parser=shared.get(CUSTOM_ENTITY_PARSER),
+            builtin_entity_scope=builtin_scope,
+            **obj_dict
         )
         return self
-
-
-def _preprocess_utterance(utterance, language, builtin_entity_parser,
-                          custom_entity_parser, word_clusters_name,
-                          use_stemming, unknownword_replacement_string):
-    utterance_text = get_text_from_chunks(utterance[DATA])
-    utterance_tokens = tokenize_light(utterance_text, language)
-    word_clusters_features = _get_word_cluster_features(
-        utterance_tokens, word_clusters_name, language)
-    normalized_stemmed_tokens = [_normalize_stem(t, language, use_stemming)
-                                 for t in utterance_tokens]
-
-    custom_entities = custom_entity_parser.parse(
-        " ".join(normalized_stemmed_tokens))
-    custom_entities = [e for e in custom_entities
-                       if e["value"] != unknownword_replacement_string]
-    custom_entities_features = [
-        _entity_name_to_feature(e[ENTITY_KIND], language)
-        for e in custom_entities]
-
-    builtin_entities = builtin_entity_parser.parse(
-        utterance_text, use_cache=True)
-    builtin_entities_features = [
-        _builtin_entity_to_feature(ent[ENTITY_KIND], language)
-        for ent in builtin_entities
-    ]
-
-    # We remove values of builtin slots from the utterance to avoid learning
-    # specific samples such as '42' or 'tomorrow'
-    filtered_normalized_stemmed_tokens = [
-        _normalize_stem(chunk[TEXT], language, use_stemming)
-        for chunk in utterance[DATA]
-        if ENTITY not in chunk or not is_builtin_entity(chunk[ENTITY])
-    ]
-
-    features = get_default_sep(language).join(
-        filtered_normalized_stemmed_tokens)
-    if builtin_entities_features:
-        features += " " + " ".join(sorted(builtin_entities_features))
-    if custom_entities_features:
-        features += " " + " ".join(sorted(custom_entities_features))
-    if word_clusters_features:
-        features += " " + " ".join(sorted(word_clusters_features))
-
-    return features
 
 
 def _get_tfidf_vectorizer(language, sublinear_tf=False):
@@ -285,3 +416,206 @@ def _deserialize_tfidf_vectorizer(vectorizer_dict, language, sublinear_tf):
         tfidf_transformer._idf_diag = idf_diag  # pylint: disable=W0212
     tfidf_vectorizer._tfidf = tfidf_transformer  # pylint: disable=W0212
     return tfidf_vectorizer
+
+
+class CooccurrenceVectorizer(ProcessingUnit):
+    unit_name = "cooccurrence_vectorizer"
+    config_type = CooccurrenceVectorizerConfig
+
+    def __init__(self, config=None, **shared):
+        if config is None:
+            config = CooccurrenceVectorizerConfig()
+        super(CooccurrenceVectorizer, self).__init__(config, **shared)
+        self.word_pairs = None
+        self.language = None
+
+    def fit(self, x, language):
+        """Fits the CooccurrenceVectorizer
+
+        Given list of utterances the CooccurrenceVectorizer will extract word
+        pairs appearing in the same utterance. The order in which the words
+        appear is kept. Additionally, if self.config.window_size is not None
+        then the vectorizer will only look in a context window of
+        self.config.window_size after each word.
+
+            Args:
+             x (iterable): iterable of 3-tuples of the form
+              (tokenized_utterances, builtin_entities, custom_entities)
+             language (str): language used in the utterances
+            Returns:
+             self: the fitted CooccurrenceVectorizer
+        """
+        self.language = language
+        utterances = self._preprocess(list(x))
+
+        self.word_pairs = dict()
+        word_pairs = set()
+        for u in utterances:
+            for i, w1 in enumerate(u):
+                max_index = None
+                if self.config.window_size is not None:
+                    max_index = i + self.config.window_size + 1
+                for w2 in u[i + 1:max_index]:
+                    word_pairs.add((w1, w2))
+        self.word_pairs = {
+            pair: i for i, pair in enumerate(sorted(word_pairs))
+        }
+        return self
+
+    def fitted(self):
+        return self.word_pairs is not None
+
+    def fit_transform(self, x, language):
+        """Fits the vectorizer and returns the feature matrix"""
+        return self.fit(x, language).transform(x)
+
+    def _preprocess(self, x):
+        if not x:
+            return []
+        utterances, builtin_ents, custom_ents = zip(*x)
+
+        placeholder_fn = lambda entity_name: "".join(
+            tokenize_light(str(entity_name), str(self.language))).upper()
+
+        all_entities = (b + c for b, c in zip(builtin_ents, custom_ents))
+        tokenized_utterances = [
+            replace_entities_with_placeholders(u, ents, placeholder_fn)[1]
+            for u, ents in zip(utterances, all_entities)
+        ]
+
+        tokenized_utterances = [tokenize_light(u, self.language)
+                                for u in tokenized_utterances]
+
+        if self.config.unknown_words_replacement_string:
+            tokenized_utterances = [
+                [t for t in u if
+                 t != self.config.unknown_words_replacement_string]
+                for u in tokenized_utterances
+            ]
+
+        return tokenized_utterances
+
+    def transform(self, x):
+        """Computes the cooccurrence feature matrix.
+            Args:
+             x (iterable): iterable of 3-tuples of the form
+              (tokenized_utterances, builtin_entities, custom_entities)
+            Returns:
+             A sparse matrix X of shape (len(x), len(self.word_pairs)) where
+             X[i, j] = 1.0 if x[i][0] contains the contains the words
+             cooccurrence (w1, w2) and if self.word_paris[(w1, w2)] = j
+        """
+        if self.word_pairs is None:
+            raise NotTrained("CooccurrenceVectorizer must be fitted")
+        x = list(x)
+        utterances = self._preprocess(x)
+        x_coo = dok_matrix((len(x), len(self.word_pairs)), dtype=np.int32)
+        if self.config.use_stop_words:
+            stop_words = get_stop_words(self.language)
+            utterances = ([t for t in u if t not in stop_words]
+                          for u in utterances)
+        for i, u in enumerate(utterances):
+            for j, w1 in enumerate(u):
+                max_index = None
+                if self.config.window_size is not None:
+                    max_index = j + self.config.window_size + 1
+                for w2 in u[j + 1:max_index]:
+                    if (w1, w2) in self.word_pairs:
+                        x_coo[i, self.word_pairs[(w1, w2)]] = 1
+
+        return x_coo.tocsr()
+
+    def limit_vocabulary(self, word_pair_indexes):
+        """Set the vectorizer vocabulary by limiting it to the words pairs
+        which index is contained in word_pair_indexes
+            Args:
+             word_pair_indexes (iterable of int): indexes of the word_pairs to
+              keep
+            Returns:
+                self: the vectorizer with a limited vocabulary
+        :return:
+        """
+
+        word_pair_indexes = set(word_pair_indexes)
+        existing_ix = set(itervalues(self.word_pairs))
+
+        extra_values = word_pair_indexes - existing_ix
+
+        if extra_values:
+            raise ValueError("Invalid word pairs indexes %s, expected values "
+                             "in %s" % (extra_values, existing_ix))
+
+        new_pairs = (p for p, i in iteritems(self.word_pairs)
+                     if i in word_pair_indexes)
+        self.word_pairs = {
+            pair: i for i, pair in enumerate(sorted(new_pairs))
+        }
+        if not self.word_pairs:
+            raise ValueError(
+                "No feature remain after limiting the vocabulary, please use "
+                "different word_pair_indexes"
+            )
+        return self
+
+    def persist(self, path):
+        path = Path(path)
+        path.mkdir()
+
+        self_as_dict = {
+            "language": self.language,
+            "word_pairs": {
+                i: list(p) for p, i in iteritems(self.word_pairs)
+            },
+            "config": self.config.to_dict()
+        }
+        vectorizer_json = json_string(self_as_dict)
+        with (path / ("%s.json" % self.unit_name)).open(mode="w") as f:
+            f.write(vectorizer_json)
+        self.persist_metadata(path)
+
+    @classmethod
+    def from_path(cls, path, **shared):
+        path = Path(path)
+        vectorizer_path = path / ("%s.json" % cls.unit_name)
+        if not vectorizer_path.exists():
+            raise OSError("Missing vectorizer file: %s" % vectorizer_path.name)
+
+        with vectorizer_path.open(encoding="utf8") as f:
+            vectorizer_dict = json.load(f)
+        config = vectorizer_dict.pop("config")
+
+        self = cls(config, **shared)
+        self.language = vectorizer_dict["language"]
+        self.word_pairs = None
+        if vectorizer_dict["word_pairs"]:
+            self.word_pairs = {
+                tuple(p): int(i)
+                for i, p in iteritems(vectorizer_dict["word_pairs"])
+            }
+        return self
+
+
+def _entities_from_utterance(utterance, use_stemming, language):
+    builtin_ents = []
+    custom_ents = []
+    current_ix = 0
+    for i, chunk in enumerate(utterance[DATA]):
+        text = _normalize_stem(chunk[TEXT], language, use_stemming)
+        if i != 0:
+            current_ix += 1  # normalized stemmed tokens are joined with a " "
+        text_length = len(text)
+        if ENTITY in chunk:
+            ent = {
+                ENTITY_KIND: chunk[ENTITY],
+                RES_VALUE: text,
+                RES_MATCH_RANGE: {
+                    START: current_ix,
+                    END: current_ix + text_length
+                }
+            }
+            if is_builtin_entity(ent[ENTITY_KIND]):
+                builtin_ents.append(ent)
+            else:
+                custom_ents.append(ent)
+        current_ix += text_length
+    return builtin_ents, custom_ents

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -483,8 +483,8 @@ class TfidfVectorizer(ProcessingUnit):
         extra_values = ngrams - existing_ngrams
 
         if extra_values:
-            raise ValueError("Invalid ngrams %s, expected values in %s"
-                             % (sorted(extra_values), sorted(existing_ngrams)))
+            raise ValueError("Invalid ngrams %s, expected values in word_pairs"
+                             % sorted(extra_values))
 
         new_ngrams, new_index = zip(*sorted(
             (ng, self.vocabulary[ng]) for ng in ngrams))
@@ -732,9 +732,8 @@ class CooccurrenceVectorizer(ProcessingUnit):
 
         if extra_values:
             raise ValueError(
-                "Invalid word pairs %s, expected values in %s"
-                % (sorted(extra_values), sorted(existing_pairs))
-            )
+                "Invalid word pairs %s, expected values in word_pairs"
+                % sorted(extra_values))
 
         self._word_pairs = {
             ng: new_i for new_i, ng in enumerate(sorted(word_pairs))

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -22,7 +22,7 @@ from snips_nlu.constants import (
 from snips_nlu.dataset import get_text_from_chunks
 from snips_nlu.entity_parser.builtin_entity_parser import (
     is_builtin_entity)
-from snips_nlu.exceptions import NotTrained, _EmptyDatasetError
+from snips_nlu.exceptions import (NotTrained, DatasetFormatError)
 from snips_nlu.languages import get_default_sep
 from snips_nlu.pipeline.configs import FeaturizerConfig
 from snips_nlu.pipeline.configs.intent_classifier import (
@@ -89,8 +89,7 @@ class Featurizer(ProcessingUnit):
 
         utterances_texts = (get_text_from_chunks(u[DATA]) for u in utterances)
         if not any(tokenize_light(q, self.language) for q in utterances_texts):
-            raise _EmptyDatasetError(
-                "Couldn't fit because no utterance was found an")
+            raise DatasetFormatError("Tokenized utterances are empty")
 
         self.fit_builtin_entity_parser_if_needed(dataset)
         self.fit_custom_entity_parser_if_needed(dataset)

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -592,7 +592,7 @@ class CooccurrenceVectorizer(ProcessingUnit):
     def _enrich_utterance(self, x, builtin_ents, custom_ents):
         utterance = get_text_from_chunks(x[DATA])
         all_entities = builtin_ents + custom_ents
-        placeholder_fn = self._get_placeholder_fn()
+        placeholder_fn = self._placeholder_fn
         # Replace entities with placeholders
         enriched_utterance = replace_entities_with_placeholders(
             utterance, all_entities, placeholder_fn)[1]
@@ -692,12 +692,9 @@ class CooccurrenceVectorizer(ProcessingUnit):
         return self
 
     @fitted_required
-    def _get_placeholder_fn(self):
-        def fn(entity_name):
-            return "".join(
-                tokenize_light(str(entity_name), str(self.language))).upper()
-
-        return fn
+    def _placeholder_fn(self, entity_name):
+        return "".join(
+            tokenize_light(str(entity_name), str(self.language))).upper()
 
     def persist(self, path):
         path = Path(path)

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -264,7 +264,7 @@ class Featurizer(ProcessingUnit):
             "builtin_entity_scope": builtin_scope
         }
 
-        featurizer_path = type(self).build_unit_path(path)
+        featurizer_path = path / "featurizer.json"
         with featurizer_path.open("w", encoding="utf-8") as f:
             f.write(json_string(self_as_dict))
 
@@ -275,7 +275,7 @@ class Featurizer(ProcessingUnit):
     def from_path(cls, path, **shared):
         path = Path(path)
 
-        featurizer_path = cls.build_unit_path(path)
+        featurizer_path = path / "featurizer.json"
         with featurizer_path.open("r", encoding="utf-8") as f:
             featurizer_dict = json.load(f)
 
@@ -497,7 +497,7 @@ class TfidfVectorizer(ProcessingUnit):
         }
 
         path.mkdir()
-        vectorizer_path = type(self).build_unit_path(path)
+        vectorizer_path = path / "vectorizer.json"
         with vectorizer_path.open("w", encoding="utf-8") as f:
             f.write(json_string(self_as_dict))
         self.persist_metadata(path)
@@ -506,8 +506,8 @@ class TfidfVectorizer(ProcessingUnit):
     # pylint: disable=W0212
     def from_path(cls, path, **shared):
         path = Path(path)
-        vectorizer_path = cls.build_unit_path(path)
 
+        vectorizer_path = path / "vectorizer.json"
         with vectorizer_path.open("r", encoding="utf-8") as f:
             vectorizer_dict = json.load(f)
 
@@ -712,7 +712,7 @@ class CooccurrenceVectorizer(ProcessingUnit):
             "config": self.config.to_dict()
         }
         vectorizer_json = json_string(self_as_dict)
-        vectorizer_path = type(self).build_unit_path(path)
+        vectorizer_path = path / "vectorizer.json"
         with vectorizer_path.open(mode="w") as f:
             f.write(vectorizer_json)
         self.persist_metadata(path)
@@ -720,7 +720,7 @@ class CooccurrenceVectorizer(ProcessingUnit):
     @classmethod
     def from_path(cls, path, **shared):
         path = Path(path)
-        vectorizer_path = cls.build_unit_path(path)
+        vectorizer_path = path / "vectorizer.json"
         if not vectorizer_path.exists():
             raise OSError("Missing vectorizer file: %s" % vectorizer_path.name)
 

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -11,7 +11,7 @@ from sklearn.linear_model import SGDClassifier
 
 from snips_nlu.constants import LANGUAGE, RES_INTENT_NAME, RES_PROBA
 from snips_nlu.dataset import validate_and_format_dataset
-from snips_nlu.exceptions import _EmptyDataError
+from snips_nlu.exceptions import _EmptyDatasetError
 from snips_nlu.intent_classifier.featurizer import Featurizer
 from snips_nlu.intent_classifier.intent_classifier import IntentClassifier
 from snips_nlu.intent_classifier.log_reg_classifier_utils import (
@@ -92,7 +92,7 @@ class LogRegIntentClassifier(IntentClassifier):
         try:
             self.featurizer = self.featurizer.fit(
                 dataset, utterances, classes, none_class)
-        except _EmptyDataError:
+        except _EmptyDatasetError:
             self.featurizer = None
             return self
 

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -88,17 +88,19 @@ class LogRegIntentClassifier(IntentClassifier):
         )
         self.featurizer.language = language
 
+        none_class = max(classes)
         try:
-            self.featurizer = self.featurizer.fit(dataset, utterances, classes)
+            self.featurizer = self.featurizer.fit(
+                dataset, utterances, classes, none_class)
         except _EmptyDataError:
             self.featurizer = None
             return self
 
-        X = self.featurizer.transform(utterances)  # pylint: disable=C0103
+        x = self.featurizer.transform(utterances)
         alpha = get_regularization_factor(dataset)
         self.classifier = SGDClassifier(random_state=random_state,
                                         alpha=alpha, **LOG_REG_ARGS)
-        self.classifier.fit(X, classes)
+        self.classifier.fit(x, classes)
         logger.debug("%s", DifferedLoggingMessage(self.log_best_features))
         return self
 

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -10,7 +10,7 @@ from sklearn.linear_model import SGDClassifier
 
 from snips_nlu.constants import LANGUAGE, RES_INTENT_NAME, RES_PROBA
 from snips_nlu.dataset import validate_and_format_dataset
-from snips_nlu.exceptions import DatasetFormatError
+from snips_nlu.exceptions import _EmptyDatasetUtterancesError
 from snips_nlu.intent_classifier.featurizer import Featurizer
 from snips_nlu.intent_classifier.intent_classifier import IntentClassifier
 from snips_nlu.intent_classifier.log_reg_classifier_utils import (
@@ -88,7 +88,7 @@ class LogRegIntentClassifier(IntentClassifier):
         try:
             self.featurizer = self.featurizer.fit(
                 dataset, utterances, classes, none_class)
-        except DatasetFormatError:
+        except _EmptyDatasetUtterancesError:
             self.featurizer = None
             return self
 

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -11,7 +11,7 @@ from sklearn.linear_model import SGDClassifier
 
 from snips_nlu.constants import LANGUAGE, RES_INTENT_NAME, RES_PROBA
 from snips_nlu.dataset import validate_and_format_dataset
-from snips_nlu.exceptions import _EmptyDatasetError
+from snips_nlu.exceptions import DatasetFormatError
 from snips_nlu.intent_classifier.featurizer import Featurizer
 from snips_nlu.intent_classifier.intent_classifier import IntentClassifier
 from snips_nlu.intent_classifier.log_reg_classifier_utils import (
@@ -89,7 +89,7 @@ class LogRegIntentClassifier(IntentClassifier):
         try:
             self.featurizer = self.featurizer.fit(
                 dataset, utterances, classes, none_class)
-        except _EmptyDatasetError:
+        except DatasetFormatError:
             self.featurizer = None
             return self
 

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -77,8 +77,6 @@ class LogRegIntentClassifier(IntentClassifier):
 
         self.featurizer = Featurizer(
             config=self.config.featurizer_config,
-            unknown_words_replacement_string=\
-                data_augmentation_config.unknown_words_replacement_string,
             builtin_entity_parser=self.builtin_entity_parser,
             custom_entity_parser=self.custom_entity_parser
         )
@@ -127,7 +125,7 @@ class LogRegIntentClassifier(IntentClassifier):
     @fitted_required
     def get_intents(self, text):
         """Performs intent classification on the provided *text* and returns
-            the list of intents ordered by decreasing probability
+        the list of intents ordered by decreasing probability
 
         The length of the returned list is exactly the number of intents in the
         dataset + 1 for the None intent

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -77,7 +77,7 @@ class LogRegIntentClassifier(IntentClassifier):
 
         self.featurizer = Featurizer(
             config=self.config.featurizer_config,
-            unknown_words_replacement_string= \
+            unknown_words_replacement_string=\
                 data_augmentation_config.unknown_words_replacement_string,
             builtin_entity_parser=self.builtin_entity_parser,
             custom_entity_parser=self.custom_entity_parser
@@ -115,7 +115,8 @@ class LogRegIntentClassifier(IntentClassifier):
             *None* if no intent was found
 
         Raises:
-            NotTrained: When the intent classifier is not fitted
+            :class:`snips_nlu.exceptions.NotTrained`: When the intent
+                classifier is not fitted
 
         """
         intents_results = self._get_intents(text, intents_filter)
@@ -132,7 +133,8 @@ class LogRegIntentClassifier(IntentClassifier):
         dataset + 1 for the None intent
 
         Raises:
-            NotTrained: when the intent classifier is not fitted
+            :class:`snips_nlu.exceptions.NotTrained`: when the intent
+                classifier is not fitted
         """
         return self._get_intents(text, intents_filter=None)
 

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -6,7 +6,6 @@ from builtins import range, str, zip
 from pathlib import Path
 
 import numpy as np
-from future.utils import iteritems
 from sklearn.linear_model import SGDClassifier
 
 from snips_nlu.constants import LANGUAGE, RES_INTENT_NAME, RES_PROBA

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -267,7 +267,7 @@ class LogRegIntentClassifier(IntentClassifier):
 
         return intent_classifier
 
-    def log_best_features(self, top_n=20):
+    def log_best_features(self, top_n=50):
         if not hasattr(self.featurizer, "feature_index_to_feature_name"):
             return None
 

--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -475,4 +475,3 @@ def _deduplicate_overlapping_slots(slots, language):
 def _get_entity_name_placeholder(entity_label, language):
     return "%%%s%%" % "".join(
         tokenize_light(entity_label, language)).upper()
-

--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -475,3 +475,4 @@ def _deduplicate_overlapping_slots(slots, language):
 def _get_entity_name_placeholder(entity_label, language):
     return "%%%s%%" % "".join(
         tokenize_light(entity_label, language)).upper()
+

--- a/snips_nlu/nlu_engine/nlu_engine.py
+++ b/snips_nlu/nlu_engine/nlu_engine.py
@@ -386,7 +386,6 @@ class SnipsNLUEngine(ProcessingUnit):
                 slot_builder = builtin_slot
                 use_cache = False
                 extensible = False
-                resolved_value_key = ENTITY
             else:
                 entities = custom_entities
                 parser = self.custom_entity_parser
@@ -394,13 +393,12 @@ class SnipsNLUEngine(ProcessingUnit):
                 use_cache = True
                 extensible = self._dataset_metadata[ENTITIES][entity_name][
                     AUTOMATICALLY_EXTENSIBLE]
-                resolved_value_key = RESOLVED_VALUE
 
             resolved_slot = None
             for ent in entities:
                 if ent[ENTITY_KIND] == entity_name and \
                         ent[RES_MATCH_RANGE] == slot[RES_MATCH_RANGE]:
-                    resolved_slot = slot_builder(slot, ent[resolved_value_key])
+                    resolved_slot = slot_builder(slot, ent[RESOLVED_VALUE])
                     break
             if resolved_slot is None:
                 matches = parser.parse(
@@ -409,7 +407,7 @@ class SnipsNLUEngine(ProcessingUnit):
                     match = matches[0]
                     if is_builtin or len(match[RES_VALUE]) == len(raw_value):
                         resolved_slot = slot_builder(
-                            slot, match[resolved_value_key])
+                            slot, match[RESOLVED_VALUE])
 
             if resolved_slot is None and extensible:
                 resolved_slot = slot_builder(slot)

--- a/snips_nlu/nlu_engine/nlu_engine.py
+++ b/snips_nlu/nlu_engine/nlu_engine.py
@@ -15,7 +15,7 @@ from snips_nlu.common.utils import (
     check_persisted_path, fitted_required, json_string)
 from snips_nlu.constants import (
     AUTOMATICALLY_EXTENSIBLE, BUILTIN_ENTITY_PARSER, CUSTOM_ENTITY_PARSER,
-    ENTITIES, ENTITY, ENTITY_KIND, LANGUAGE, RESOLVED_VALUE, RES_ENTITY,
+    ENTITIES, ENTITY_KIND, LANGUAGE, RESOLVED_VALUE, RES_ENTITY,
     RES_INTENT, RES_INTENT_NAME, RES_MATCH_RANGE, RES_PROBA, RES_SLOTS,
     RES_VALUE)
 from snips_nlu.dataset import validate_and_format_dataset

--- a/snips_nlu/pipeline/configs/__init__.py
+++ b/snips_nlu/pipeline/configs/__init__.py
@@ -2,7 +2,7 @@ from .config import Config, ProcessingUnitConfig
 from .features import default_features_factories
 from .intent_classifier import (
     LogRegIntentClassifierConfig, IntentClassifierDataAugmentationConfig,
-    FeaturizerConfig)
+    FeaturizerConfig, CooccurrenceVectorizerConfig)
 from .intent_parser import (DeterministicIntentParserConfig,
                             ProbabilisticIntentParserConfig)
 from .nlu_engine import NLUEngineConfig

--- a/snips_nlu/pipeline/configs/config.py
+++ b/snips_nlu/pipeline/configs/config.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from abc import ABCMeta, abstractmethod, abstractproperty
 from builtins import object
 

--- a/snips_nlu/pipeline/configs/intent_classifier.py
+++ b/snips_nlu/pipeline/configs/intent_classifier.py
@@ -7,6 +7,7 @@ from snips_nlu.entity_parser.custom_entity_parser import (
     CustomEntityParserUsage)
 from snips_nlu.pipeline.configs import Config, ProcessingUnitConfig
 from snips_nlu.resources import merge_required_resources
+from snips_nlu.common.abc_utils import classproperty
 
 
 class LogRegIntentClassifierConfig(FromDict, ProcessingUnitConfig):
@@ -226,3 +227,31 @@ class CooccurrenceVectorizerConfig(ProcessingUnitConfig):
             "window_size": self.window_size,
             "use_stop_words": self.use_stop_words
         }
+
+    @classmethod
+    def from_dict(cls, obj_dict):
+        return cls(**obj_dict)
+
+
+class TfidfVectorizerConfig(ProcessingUnitConfig):
+    """Configuration of a :class:`.TfidfVectorizer` object"""
+
+    def __init__(self, use_stemming=False):
+        self.use_stemming = use_stemming
+
+    @classproperty
+    def unit_name(cls):  # pylint:disable=no-self-argument
+        from snips_nlu.intent_classifier.featurizer import TfidfVectorizer
+        return TfidfVectorizer.unit_name
+
+    def get_required_resources(self):
+        return None
+
+    def to_dict(self):
+        return {
+            "use_stemming": self.use_stemming
+        }
+
+    @classmethod
+    def from_dict(cls, obj_dict):
+        return cls(**obj_dict)

--- a/snips_nlu/pipeline/configs/intent_classifier.py
+++ b/snips_nlu/pipeline/configs/intent_classifier.py
@@ -11,22 +11,20 @@ from snips_nlu.resources import merge_required_resources
 
 
 class LogRegIntentClassifierConfig(FromDict, ProcessingUnitConfig):
+    """Configuration of a :class:`.LogRegIntentClassifier`"""
+
     # pylint: disable=line-too-long
-    """Configuration of a :class:`.LogRegIntentClassifier`
-
-    Args:
-        data_augmentation_config (:class:`IntentClassifierDataAugmentationConfig`):
-            Defines the strategy of the underlying data augmentation
-        featurizer_config (:class:`FeaturizerConfig`): Configuration of the
-            :class:`.Featurizer` used underneath
-        random_seed (int, optional): Allows to fix the seed ot have
-            reproducible trainings
-    """
-
-    # pylint: enable=line-too-long
-
     def __init__(self, data_augmentation_config=None, featurizer_config=None,
                  random_seed=None):
+        """
+        Args:
+            data_augmentation_config (:class:`IntentClassifierDataAugmentationConfig`):
+                    Defines the strategy of the underlying data augmentation
+            featurizer_config (:class:`FeaturizerConfig`): Configuration of the
+                :class:`.Featurizer` used underneath
+            random_seed (int, optional): Allows to fix the seed ot have
+                reproducible trainings
+        """
         if data_augmentation_config is None:
             data_augmentation_config = IntentClassifierDataAugmentationConfig()
         if featurizer_config is None:
@@ -91,24 +89,24 @@ class LogRegIntentClassifierConfig(FromDict, ProcessingUnitConfig):
 
 class IntentClassifierDataAugmentationConfig(FromDict, Config):
     """Configuration used by a :class:`.LogRegIntentClassifier` which defines
-        how to augment data to improve the training of the classifier
-
-    Args:
-        min_utterances (int, optional): The minimum number of utterances to
-            automatically generate for each intent, based on the existing
-            utterances. Default is 20.
-        noise_factor (int, optional): Defines the size of the noise to
-            generate to train the implicit *None* intent, as a multiplier of
-            the average size of the other intents. Default is 5.
-        add_builtin_entities_examples (bool, optional): If True, some builtin
-            entity examples will be automatically added to the training data.
-            Default is True.
-    """
+        how to augment data to improve the training of the classifier"""
 
     def __init__(self, min_utterances=20, noise_factor=5,
                  add_builtin_entities_examples=True, unknown_word_prob=0,
                  unknown_words_replacement_string=None,
                  max_unknown_words=None):
+        """
+        Args:
+            min_utterances (int, optional): The minimum number of utterances to
+                automatically generate for each intent, based on the existing
+                utterances. Default is 20.
+            noise_factor (int, optional): Defines the size of the noise to
+                generate to train the implicit *None* intent, as a multiplier
+                of the average size of the other intents. Default is 5.
+            add_builtin_entities_examples (bool, optional): If True, some
+                builtin entity examples will be automatically added to the
+                training data. Default is True.
+        """
         self.min_utterances = min_utterances
         self.noise_factor = noise_factor
         self.add_builtin_entities_examples = add_builtin_entities_examples
@@ -143,28 +141,41 @@ class IntentClassifierDataAugmentationConfig(FromDict, Config):
 
 
 class FeaturizerConfig(FromDict, ProcessingUnitConfig):
-    """Configuration of a :class:`.Featurizer` object
+    """Configuration of a :class:`.Featurizer` object"""
 
-    Args:
-        sublinear_tf (bool, optional): Whether or not to use sublinear
-            (vs linear) term frequencies, default is *False*.
-        pvalue_threshold (float, optional): max pvalue for a feature to be
-        kept in the feature selection
-    """
-
-    @property
-    def unit_name(self):
-        from snips_nlu.intent_classifier import Featurizer
-        return Featurizer.unit_name
-
-    # TODO: update docstring
-
+    # pylint: disable=line-too-long
     def __init__(self, tfidf_vectorizer_config=None,
                  cooccurrence_vectorizer_config=None,
                  pvalue_threshold=0.4,
                  word_clusters_name=None,
                  use_stemming=False,
                  added_cooccurrence_feature_ratio=0):
+        """
+        Args:
+            tfidf_vectorizer_config (:class:`.DefaultProcessingUnitConfig`):
+                empty configuration of the featurizer's
+                :attr:`tfidf_vectorizer`
+            cooccurrence_vectorizer_config: (:class:`.CooccurrenceVectorizerConfig`, optional):
+                configuration of the featurizer's
+                :attr:`cooccurrence_vectorizer`
+            pvalue_threshold (float): after fitting the training set to
+                extract tfidf features, a univariate feature selection is
+                applied. Features are tested for independence using a Chi-2
+                test, under the null hypothesis that the each feature should be
+                equally present in each class. Only features having a p-value
+                lower that the threshold are kept
+            word_clusters_name (str, optional): if a word cluster name is
+                provided then the featurizer will use the word clusters IDs
+                detected in the utterances and add them to the utterance text
+                before computing the tfidf. Default to None
+            use_stemming (bool, optional): use stemming before computing the
+                tfdif. Defaults to False (no stemming used)
+            added_cooccurrence_feature_ratio (float, optional): proportion of
+                cooccurrence features to add with respect of the number of
+                tfidf features. For instance with a ratio of 0.5, if 100 tfidf
+                features are remaining after feature selection, a maximum of 50
+                cooccurrence features will be added
+        """
         self.pvalue_threshold = pvalue_threshold
         self.word_clusters_name = word_clusters_name
         self.use_stemming = use_stemming
@@ -187,6 +198,11 @@ class FeaturizerConfig(FromDict, ProcessingUnitConfig):
                 .from_dict(cooccurrence_vectorizer_config)
         self.cooccurrence_vectorizer_config = cooccurrence_vectorizer_config
         self.use_stemming = use_stemming
+
+    @property
+    def unit_name(self):
+        from snips_nlu.intent_classifier import Featurizer
+        return Featurizer.unit_name
 
     def get_required_resources(self):
         if self.use_stemming:
@@ -218,21 +234,22 @@ class FeaturizerConfig(FromDict, ProcessingUnitConfig):
 
 
 class CooccurrenceVectorizerConfig(FromDict, ProcessingUnitConfig):
-    """Configuration of a :class:`.CooccurrenceVectorizer` object
-
-        Args:
-            window_size (int, optional): if provided word cooccurrence will be
-             taken into account only in a context window of size window_size.
-             If the window size is 3 then given a word w[i], the vectorizer
-             will only extract the following pairs: (w[i], w[i + 1]),
-             (w[i], w[i + 2]) and (w[i], w[i + 3])
-             Defaults to None, which means that we consider all words
-        """
-
-    # TODO: finish docstring
+    """Configuration of a :class:`.CooccurrenceVectorizer` object"""
 
     def __init__(self, window_size=None, unknown_words_replacement_string=None,
                  filter_stop_words=True):
+        """
+        Args:
+            window_size (int, optional): if provided word cooccurrences will be
+                taken into account only in a context window of size
+                :attr:`window_size`. If the window size is 3 then given a word
+                w[i], the vectorizer will only extract the following pairs:
+                (w[i], w[i + 1]), (w[i], w[i + 2]) and (w[i], w[i + 3]).
+                Defaults to None, which means that we consider all words
+            unknown_words_replacement_string (str, optional)
+            filter_stop_words (bool, optional): if True, stop words are ignore
+                when computing cooccurrences
+        """
         self.window_size = window_size
         self.unknown_words_replacement_string = \
             unknown_words_replacement_string

--- a/snips_nlu/pipeline/configs/intent_classifier.py
+++ b/snips_nlu/pipeline/configs/intent_classifier.py
@@ -152,15 +152,34 @@ class FeaturizerConfig(FromDict, Config):
         kept in the feature selection
     """
 
-    def __init__(self, sublinear_tf=False, pvalue_threshold=0.4,
-                 word_clusters_name=None, use_stemming=False,
+    # TODO: update docstring
+
+    def __init__(self, tfidf_vectorizer_config=None,
+                 cooccurrence_vectorizer_config=None,
+                 pvalue_threshold=0.4,
+                 word_clusters_name=None,
+                 use_stemming=False,
                  added_cooccurrence_feature_ratio=0):
-        self.sublinear_tf = sublinear_tf
         self.pvalue_threshold = pvalue_threshold
         self.word_clusters_name = word_clusters_name
         self.use_stemming = use_stemming
         self.added_cooccurrence_feature_ratio = \
             added_cooccurrence_feature_ratio
+
+        if tfidf_vectorizer_config is None:
+            tfidf_vectorizer_config = TfidfVectorizerConfig()
+        elif isinstance(tfidf_vectorizer_config, dict):
+            tfidf_vectorizer_config = TfidfVectorizerConfig.from_dict(
+                tfidf_vectorizer_config)
+        self.tfidf_vectorizer_config = tfidf_vectorizer_config
+
+        if cooccurrence_vectorizer_config is None:
+            cooccurrence_vectorizer_config = CooccurrenceVectorizerConfig()
+        elif isinstance(cooccurrence_vectorizer_config, dict):
+            cooccurrence_vectorizer_config = CooccurrenceVectorizerConfig \
+                .from_dict(cooccurrence_vectorizer_config)
+        self.cooccurrence_vectorizer_config = cooccurrence_vectorizer_config
+        self.use_stemming = use_stemming
 
     def get_required_resources(self):
         if self.use_stemming:
@@ -179,12 +198,14 @@ class FeaturizerConfig(FromDict, Config):
 
     def to_dict(self):
         return {
-            "sublinear_tf": self.sublinear_tf,
             "pvalue_threshold": self.pvalue_threshold,
             "word_clusters_name": self.word_clusters_name,
             "use_stemming": self.use_stemming,
             "added_cooccurrence_feature_ratio":
-                self.added_cooccurrence_feature_ratio
+                self.added_cooccurrence_feature_ratio,
+            "tfidf_vectorizer_config": self.tfidf_vectorizer_config.to_dict(),
+            "cooccurrence_vectorizer_config":
+                self.cooccurrence_vectorizer_config.to_dict(),
         }
 
     @classmethod
@@ -204,12 +225,14 @@ class CooccurrenceVectorizerConfig(ProcessingUnitConfig):
              Defaults to None, which means that we consider all words
         """
 
+    # TODO: finish docstring
+
     def __init__(self, window_size=None, unknown_words_replacement_string=None,
-                 use_stop_words=True):
+                 filter_stop_words=True):
         self.window_size = window_size
         self.unknown_words_replacement_string = \
             unknown_words_replacement_string
-        self.use_stop_words = use_stop_words
+        self.filter_stop_words = filter_stop_words
 
     @classproperty
     def unit_name(cls):  # pylint:disable=no-self-argument
@@ -225,7 +248,7 @@ class CooccurrenceVectorizerConfig(ProcessingUnitConfig):
             "unknown_words_replacement_string":
                 self.unknown_words_replacement_string,
             "window_size": self.window_size,
-            "use_stop_words": self.use_stop_words
+            "filter_stop_words": self.filter_stop_words
         }
 
     @classmethod
@@ -236,9 +259,6 @@ class CooccurrenceVectorizerConfig(ProcessingUnitConfig):
 class TfidfVectorizerConfig(ProcessingUnitConfig):
     """Configuration of a :class:`.TfidfVectorizer` object"""
 
-    def __init__(self, use_stemming=False):
-        self.use_stemming = use_stemming
-
     @classproperty
     def unit_name(cls):  # pylint:disable=no-self-argument
         from snips_nlu.intent_classifier.featurizer import TfidfVectorizer
@@ -248,9 +268,7 @@ class TfidfVectorizerConfig(ProcessingUnitConfig):
         return None
 
     def to_dict(self):
-        return {
-            "use_stemming": self.use_stemming
-        }
+        return dict()
 
     @classmethod
     def from_dict(cls, obj_dict):

--- a/snips_nlu/pipeline/configs/intent_classifier.py
+++ b/snips_nlu/pipeline/configs/intent_classifier.py
@@ -6,7 +6,6 @@ from snips_nlu.constants import (
 from snips_nlu.entity_parser.custom_entity_parser import (
     CustomEntityParserUsage)
 from snips_nlu.pipeline.configs import Config, ProcessingUnitConfig
-from snips_nlu.pipeline.configs.config import DefaultProcessingUnitConfig
 from snips_nlu.resources import merge_required_resources
 
 
@@ -210,6 +209,7 @@ class FeaturizerConfig(FromDict, ProcessingUnitConfig):
             "cooccurrence_vectorizer_config":
                 self.cooccurrence_vectorizer_config.to_dict(),
         }
+
 
 class TfidfVectorizerConfig(FromDict, ProcessingUnitConfig):
     """Configuration of a :class:`.TfidfVectorizerConfig` object"""

--- a/snips_nlu/pipeline/configs/intent_classifier.py
+++ b/snips_nlu/pipeline/configs/intent_classifier.py
@@ -152,11 +152,14 @@ class FeaturizerConfig(FromDict, Config):
     """
 
     def __init__(self, sublinear_tf=False, pvalue_threshold=0.4,
-                 word_clusters_name=None, use_stemming=False):
+                 word_clusters_name=None, use_stemming=False,
+                 added_cooccurrence_feature_ratio=0):
         self.sublinear_tf = sublinear_tf
         self.pvalue_threshold = pvalue_threshold
         self.word_clusters_name = word_clusters_name
         self.use_stemming = use_stemming
+        self.added_cooccurrence_feature_ratio = \
+            added_cooccurrence_feature_ratio
 
     def get_required_resources(self):
         if self.use_stemming:
@@ -178,5 +181,48 @@ class FeaturizerConfig(FromDict, Config):
             "sublinear_tf": self.sublinear_tf,
             "pvalue_threshold": self.pvalue_threshold,
             "word_clusters_name": self.word_clusters_name,
-            "use_stemming": self.use_stemming
+            "use_stemming": self.use_stemming,
+            "added_cooccurrence_feature_ratio":
+                self.added_cooccurrence_feature_ratio
+        }
+
+    @classmethod
+    def from_dict(cls, obj_dict):
+        return cls(**obj_dict)
+
+
+class CooccurrenceVectorizerConfig(ProcessingUnitConfig):
+    """Configuration of a :class:`.CooccurrenceVectorizer` object
+
+        Args:
+            window_size (int, optional): if provided word cooccurrence will be
+             taken into account only in a context window of size window_size.
+             If the window size is 3 then given a word w[i], the vectorizer
+             will only extract the following pairs: (w[i], w[i + 1]),
+             (w[i], w[i + 2]) and (w[i], w[i + 3])
+             Defaults to None, which means that we consider all words
+        """
+
+    def __init__(self, window_size=None, unknown_words_replacement_string=None,
+                 use_stop_words=True):
+        self.window_size = window_size
+        self.unknown_words_replacement_string = \
+            unknown_words_replacement_string
+        self.use_stop_words = use_stop_words
+
+    @classproperty
+    def unit_name(cls):  # pylint:disable=no-self-argument
+        from snips_nlu.intent_classifier.featurizer import \
+            CooccurrenceVectorizer
+        return CooccurrenceVectorizer.unit_name
+
+    def get_required_resources(self):
+        return None
+
+    def to_dict(self):
+        return {
+            "unknown_words_replacement_string":
+                self.unknown_words_replacement_string,
+            "window_size": self.window_size,
+            "use_stop_words": self.use_stop_words
         }

--- a/snips_nlu/pipeline/processing_unit.py
+++ b/snips_nlu/pipeline/processing_unit.py
@@ -192,16 +192,6 @@ class ProcessingUnit(with_metaclass(ABCMeta, Registrable)):
                                             **shared)
         return processing_unit
 
-    @classmethod
-    def build_unit_path(cls, unit_dir):
-        """Load a :class:`ProcessingUnit` instance from a bytearray
-            Args:
-                unit_dir (pathlib.Path): directory where the unit will be save
-            Returns:
-                pathlib.Path: the path where the
-        """
-        return unit_dir / ("%s.json" % cls.unit_name)
-
 
 def _sanitize_unit_name(unit_name):
     return unit_name \

--- a/snips_nlu/pipeline/processing_unit.py
+++ b/snips_nlu/pipeline/processing_unit.py
@@ -192,6 +192,16 @@ class ProcessingUnit(with_metaclass(ABCMeta, Registrable)):
                                             **shared)
         return processing_unit
 
+    @classmethod
+    def build_unit_path(cls, unit_dir):
+        """Load a :class:`ProcessingUnit` instance from a bytearray
+            Args:
+                unit_dir (pathlib.Path): directory where the unit will be save
+            Returns:
+                pathlib.Path: the path where the
+        """
+        return unit_dir / ("%s.json" % cls.unit_name)
+
 
 def _sanitize_unit_name(unit_name):
     return unit_name \

--- a/snips_nlu/result.py
+++ b/snips_nlu/result.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 
 from snips_nlu.constants import (
     RES_ENTITY, RES_INPUT, RES_INTENT, RES_INTENT_NAME, RES_MATCH_RANGE,
-    RES_PROBA, RES_RAW_VALUE, RES_SLOTS, RES_SLOT_NAME, RES_VALUE)
+    RES_PROBA, RES_RAW_VALUE, RES_SLOTS, RES_SLOT_NAME, RES_VALUE, ENTITY_KIND,
+    RESOLVED_VALUE, VALUE)
 
 
 def intent_classification_result(intent_name, probability):
@@ -288,6 +289,37 @@ def empty_result(input):  # pylint:disable=redefined-builtin
         {'input': 'foo bar', 'intent': None, 'slots': None}
     """
     return parsing_result(input=input, intent=None, slots=None)
+
+
+def parsed_entity(entity_kind, entity_value, entity_resolved_value,
+                  entity_range):
+    """Create the items in the output of :meth:`.EntityParser.parse`
+
+    Example:
+        >>> resolved_value = dict(age=28, role="datascientist")
+        >>> range = dict(start=0, end=6)
+        >>> ent = parsed_entity("snipster", "adrien", resolved_value, range)
+        >>> import json
+        >>> print(json.dumps(ent, indent=4, sort_keys=True))
+        {
+            "entity_kind": "snipster",
+            "range": {
+                "end": 6,
+                "start": 0
+            },
+            "resolved_value: {
+                "age": 28,
+                "role": "datascientist"
+            },
+            "value": "adrien"
+        }
+    """
+    return {
+        VALUE: entity_value,
+        RESOLVED_VALUE: entity_resolved_value,
+        ENTITY_KIND: entity_kind,
+        RES_MATCH_RANGE: entity_range
+    }
 
 
 def _convert_range(rng):

--- a/snips_nlu/result.py
+++ b/snips_nlu/result.py
@@ -286,6 +286,7 @@ def empty_result(input):  # pylint:disable=redefined-builtin
     Example:
 
         >>> res = empty_result("foo bar")
+        >>> print(res)
         {'input': 'foo bar', 'intent': None, 'slots': None}
     """
     return parsing_result(input=input, intent=None, slots=None)
@@ -293,7 +294,8 @@ def empty_result(input):  # pylint:disable=redefined-builtin
 
 def parsed_entity(entity_kind, entity_value, entity_resolved_value,
                   entity_range):
-    """Create the items in the output of :meth:`.EntityParser.parse`
+    """Create the items in the output of
+        :meth:`snips_nlu.entity_parser.EntityParser.parse`
 
     Example:
         >>> resolved_value = dict(age=28, role="datascientist")
@@ -307,7 +309,7 @@ def parsed_entity(entity_kind, entity_value, entity_resolved_value,
                 "end": 6,
                 "start": 0
             },
-            "resolved_value: {
+            "resolved_value": {
                 "age": 28,
                 "role": "datascientist"
             },

--- a/snips_nlu/slot_filler/keyword_slot_filler.py
+++ b/snips_nlu/slot_filler/keyword_slot_filler.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 
 from snips_nlu.common.utils import json_string

--- a/snips_nlu/string_variations.py
+++ b/snips_nlu/string_variations.py
@@ -10,8 +10,8 @@ from num2words import num2words
 from snips_nlu_utils import normalize
 
 from snips_nlu.constants import (
-    END, ENTITY, LANGUAGE_DE, LANGUAGE_EN, LANGUAGE_ES, LANGUAGE_FR,
-    RES_MATCH_RANGE, SNIPS_NUMBER, START, VALUE)
+    END, LANGUAGE_DE, LANGUAGE_EN, LANGUAGE_ES, LANGUAGE_FR, RES_MATCH_RANGE,
+    SNIPS_NUMBER, START, VALUE, RESOLVED_VALUE)
 from snips_nlu.languages import (
     get_default_sep, get_punctuation_regex, supports_num2words)
 from snips_nlu.preprocessing import tokenize_light
@@ -97,7 +97,7 @@ def punctuation_variations(string, language):
 
 
 def digit_value(number_entity):
-    value = number_entity[ENTITY][VALUE]
+    value = number_entity[RESOLVED_VALUE][VALUE]
     if value == int(value):
         # Convert 24.0 into "24" instead of "24.0"
         value = int(value)
@@ -105,7 +105,7 @@ def digit_value(number_entity):
 
 
 def alphabetic_value(number_entity, language):
-    value = number_entity[ENTITY][VALUE]
+    value = number_entity[RESOLVED_VALUE][VALUE]
     if value != int(value):  # num2words does not handle floats correctly
         return None
     return num2words(int(value), lang=language)

--- a/snips_nlu/tests/doctests.py
+++ b/snips_nlu/tests/doctests.py
@@ -20,4 +20,3 @@ runner = unittest.TextTestRunner()
 
 if not runner.run(suite).wasSuccessful():
     sys.exit(1)
-

--- a/snips_nlu/tests/doctests.py
+++ b/snips_nlu/tests/doctests.py
@@ -1,6 +1,8 @@
 import doctest
 import unittest
 
+from future.moves import sys
+
 import snips_nlu.dataset
 import snips_nlu.result
 
@@ -15,4 +17,7 @@ suite = unittest.TestSuite()
 for mod in doctest_modules:
     suite.addTest(doctest.DocTestSuite(mod))
 runner = unittest.TextTestRunner()
-runner.run(suite)
+
+if not runner.run(suite).wasSuccessful():
+    sys.exit(1)
+

--- a/snips_nlu/tests/test_builtin_entity_parser.py
+++ b/snips_nlu/tests/test_builtin_entity_parser.py
@@ -25,7 +25,7 @@ class TestBuiltinEntityParser(SnipsTest):
 
         expected_parse = [
             {
-                "entity": {
+                "resolved_value": {
                     "kind": "Number",
                     "value": 2.0
                 },
@@ -50,7 +50,7 @@ class TestBuiltinEntityParser(SnipsTest):
 
         expected_parse = [
             {
-                "entity": {
+                "resolved_value": {
                     "kind": "MusicArtist",
                     "value": "Daft Punk"
                 },
@@ -104,7 +104,7 @@ class TestBuiltinEntityParser(SnipsTest):
         # Then
         expected_parse1 = [
             {
-                "entity": {
+                "resolved_value": {
                     "kind": "MusicArtist",
                     "value": "Metallica"
                 },
@@ -118,7 +118,7 @@ class TestBuiltinEntityParser(SnipsTest):
         ]
         expected_parse2 = [
             {
-                "entity": {
+                "resolved_value": {
                     "kind": "MusicAlbum",
                     "value": "Metallica"
                 },
@@ -151,7 +151,7 @@ class TestBuiltinEntityParser(SnipsTest):
                     "start": 0,
                     "end": 5
                 },
-                "entity": {
+                "resolved_value": {
                     "kind": "Number",
                     "value": 3.0
                 },
@@ -163,7 +163,7 @@ class TestBuiltinEntityParser(SnipsTest):
                     "start": 0,
                     "end": 23
                 },
-                "entity": {
+                "resolved_value": {
                     "kind": "MusicTrack",
                     "value": "3 nuits par semaine"
                 },

--- a/snips_nlu/tests/test_config.py
+++ b/snips_nlu/tests/test_config.py
@@ -17,7 +17,7 @@ from snips_nlu.pipeline.configs import (
     SlotFillerDataAugmentationConfig)
 from snips_nlu.pipeline.configs.config import DefaultProcessingUnitConfig
 from snips_nlu.pipeline.configs.intent_classifier import (
-    CooccurrenceVectorizerConfig)
+    CooccurrenceVectorizerConfig, TfidfVectorizerConfig)
 from snips_nlu.tests.utils import SnipsTest
 
 
@@ -57,14 +57,11 @@ class TestConfig(SnipsTest):
 
     def test_featurizer_config(self):
         # Given
-        tfid_vectorizer_config = DefaultProcessingUnitConfig()
-        tfid_vectorizer_config.set_unit_name(TfidfVectorizer.unit_name)
+        tfid_vectorizer_config = TfidfVectorizerConfig()
         cooccurrence_vectorizer_config = CooccurrenceVectorizerConfig()
         config_dict = {
             "unit_name": "featurizer",
             "pvalue_threshold": 0.2,
-            "word_clusters_name": "my_clusters",
-            "use_stemming": True,
             "added_cooccurrence_feature_ratio": 0.2,
             "tfidf_vectorizer_config": tfid_vectorizer_config.to_dict(),
             "cooccurrence_vectorizer_config":
@@ -73,6 +70,21 @@ class TestConfig(SnipsTest):
 
         # When
         config = FeaturizerConfig.from_dict(config_dict)
+        serialized_config = config.to_dict()
+
+        # Then
+        self.assertDictEqual(config_dict, serialized_config)
+
+    def test_tfidf_vectorizer_config(self):
+        # Given
+        config_dict = {
+            "unit_name": "tfidf_vectorizer",
+            "use_stemming": False,
+            "word_clusters_name": None
+        }
+
+        # When
+        config = TfidfVectorizerConfig.from_dict(config_dict)
         serialized_config = config.to_dict()
 
         # Then

--- a/snips_nlu/tests/test_config.py
+++ b/snips_nlu/tests/test_config.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 import io
-import unittest
 
 from snips_nlu_ontology import get_all_languages
 
@@ -16,6 +15,8 @@ from snips_nlu.pipeline.configs import (
     IntentClassifierDataAugmentationConfig, LogRegIntentClassifierConfig,
     NLUEngineConfig, ProbabilisticIntentParserConfig,
     SlotFillerDataAugmentationConfig)
+from snips_nlu.pipeline.configs.intent_classifier import (
+    TfidfVectorizerConfig, CooccurrenceVectorizerConfig)
 from snips_nlu.tests.utils import SnipsTest
 
 
@@ -55,16 +56,46 @@ class TestConfig(SnipsTest):
 
     def test_featurizer_config(self):
         # Given
+        tfid_vectorizer_config = TfidfVectorizerConfig()
+        cooccurrence_vectorizer_config = CooccurrenceVectorizerConfig()
         config_dict = {
-            "sublinear_tf": True,
-            "pvalue_threshold": 0.4,
-            "added_cooccurrence_feature_ratio": 0,
-            "word_clusters_name": None,
-            "use_stemming": False
+            "pvalue_threshold": 0.2,
+            "word_clusters_name": "my_clusters",
+            "use_stemming": True,
+            "added_cooccurrence_feature_ratio": 0.2,
+            "tfidf_vectorizer_config": tfid_vectorizer_config.to_dict(),
+            "cooccurrence_vectorizer_config":
+                cooccurrence_vectorizer_config.to_dict()
         }
 
         # When
         config = FeaturizerConfig.from_dict(config_dict)
+        serialized_config = config.to_dict()
+
+        # Then
+        self.assertDictEqual(config_dict, serialized_config)
+
+    def test_cooccurrence_vectorizer_config(self):
+        # Given
+        config_dict = {
+            "unknown_words_replacement_string": None,
+            "window_size": 5,
+            "filter_stop_words": True
+        }
+
+        # When
+        config = CooccurrenceVectorizerConfig.from_dict(config_dict)
+        serialized_config = config.to_dict()
+
+        # Then
+        self.assertDictEqual(config_dict, serialized_config)
+
+    def test_tfidf_vectorizer_config(self):
+        # Given
+        config_dict = dict()
+
+        # When
+        config = TfidfVectorizerConfig.from_dict(config_dict)
         serialized_config = config.to_dict()
 
         # Then
@@ -210,7 +241,3 @@ utterances:
             self.assertIsNotNone(result[RES_INTENT])
             intent_name = result[RES_INTENT][RES_INTENT_NAME]
             self.assertEqual("GetWeather", intent_name)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/snips_nlu/tests/test_config.py
+++ b/snips_nlu/tests/test_config.py
@@ -58,6 +58,7 @@ class TestConfig(SnipsTest):
         config_dict = {
             "sublinear_tf": True,
             "pvalue_threshold": 0.4,
+            "added_cooccurrence_feature_ratio": 0,
             "word_clusters_name": None,
             "use_stemming": False
         }

--- a/snips_nlu/tests/test_config.py
+++ b/snips_nlu/tests/test_config.py
@@ -9,14 +9,15 @@ from snips_nlu import SnipsNLUEngine
 from snips_nlu.constants import LANGUAGE, RES_INTENT, RES_INTENT_NAME
 from snips_nlu.dataset import Dataset
 from snips_nlu.default_configs import DEFAULT_CONFIGS
-from snips_nlu.intent_classifier import LogRegIntentClassifier
+from snips_nlu.intent_classifier import LogRegIntentClassifier, TfidfVectorizer
 from snips_nlu.pipeline.configs import (
     CRFSlotFillerConfig, DeterministicIntentParserConfig, FeaturizerConfig,
     IntentClassifierDataAugmentationConfig, LogRegIntentClassifierConfig,
     NLUEngineConfig, ProbabilisticIntentParserConfig,
     SlotFillerDataAugmentationConfig)
+from snips_nlu.pipeline.configs.config import DefaultProcessingUnitConfig
 from snips_nlu.pipeline.configs.intent_classifier import (
-    TfidfVectorizerConfig, CooccurrenceVectorizerConfig)
+    CooccurrenceVectorizerConfig)
 from snips_nlu.tests.utils import SnipsTest
 
 
@@ -56,9 +57,11 @@ class TestConfig(SnipsTest):
 
     def test_featurizer_config(self):
         # Given
-        tfid_vectorizer_config = TfidfVectorizerConfig()
+        tfid_vectorizer_config = DefaultProcessingUnitConfig()
+        tfid_vectorizer_config.set_unit_name(TfidfVectorizer.unit_name)
         cooccurrence_vectorizer_config = CooccurrenceVectorizerConfig()
         config_dict = {
+            "unit_name": "featurizer",
             "pvalue_threshold": 0.2,
             "word_clusters_name": "my_clusters",
             "use_stemming": True,
@@ -78,6 +81,7 @@ class TestConfig(SnipsTest):
     def test_cooccurrence_vectorizer_config(self):
         # Given
         config_dict = {
+            "unit_name": "cooccurrence_vectorizer",
             "unknown_words_replacement_string": None,
             "window_size": 5,
             "filter_stop_words": True
@@ -85,17 +89,6 @@ class TestConfig(SnipsTest):
 
         # When
         config = CooccurrenceVectorizerConfig.from_dict(config_dict)
-        serialized_config = config.to_dict()
-
-        # Then
-        self.assertDictEqual(config_dict, serialized_config)
-
-    def test_tfidf_vectorizer_config(self):
-        # Given
-        config_dict = dict()
-
-        # When
-        config = TfidfVectorizerConfig.from_dict(config_dict)
         serialized_config = config.to_dict()
 
         # Then

--- a/snips_nlu/tests/test_config.py
+++ b/snips_nlu/tests/test_config.py
@@ -9,13 +9,12 @@ from snips_nlu import SnipsNLUEngine
 from snips_nlu.constants import LANGUAGE, RES_INTENT, RES_INTENT_NAME
 from snips_nlu.dataset import Dataset
 from snips_nlu.default_configs import DEFAULT_CONFIGS
-from snips_nlu.intent_classifier import LogRegIntentClassifier, TfidfVectorizer
+from snips_nlu.intent_classifier import LogRegIntentClassifier
 from snips_nlu.pipeline.configs import (
     CRFSlotFillerConfig, DeterministicIntentParserConfig, FeaturizerConfig,
     IntentClassifierDataAugmentationConfig, LogRegIntentClassifierConfig,
     NLUEngineConfig, ProbabilisticIntentParserConfig,
     SlotFillerDataAugmentationConfig)
-from snips_nlu.pipeline.configs.config import DefaultProcessingUnitConfig
 from snips_nlu.pipeline.configs.intent_classifier import (
     CooccurrenceVectorizerConfig, TfidfVectorizerConfig)
 from snips_nlu.tests.utils import SnipsTest

--- a/snips_nlu/tests/test_deterministic_intent_parser.py
+++ b/snips_nlu/tests/test_deterministic_intent_parser.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import io
+
 from builtins import range
 
 from mock import patch
@@ -14,7 +15,7 @@ from snips_nlu.entity_parser import BuiltinEntityParser
 from snips_nlu.exceptions import IntentNotFoundError, NotTrained
 from snips_nlu.intent_parser.deterministic_intent_parser import (
     DeterministicIntentParser, _deduplicate_overlapping_slots,
-    _get_range_shift, _replace_entities_with_placeholders)
+    _get_range_shift)
 from snips_nlu.pipeline.configs import DeterministicIntentParserConfig
 from snips_nlu.result import (
     extraction_result, intent_classification_result, unresolved_slot)
@@ -910,51 +911,6 @@ utterances:
         # Then
         self.assertEqual(2, len(parser.regexes_per_intent["my_first_intent"]))
         self.assertEqual(1, len(parser.regexes_per_intent["my_second_intent"]))
-
-    def test_should_replace_entities(self):
-        # Given
-        text = "Be the first to be there at 9pm"
-
-        # When
-        entities = [
-            {
-                "entity_kind": "snips/ordinal",
-                "value": "the first",
-                "range": {
-                    "start": 3,
-                    "end": 12
-                }
-            },
-            {
-                "entity_kind": "my_custom_entity",
-                "value": "first",
-                "range": {
-                    "start": 7,
-                    "end": 12
-                }
-            },
-            {
-                "entity_kind": "snips/datetime",
-                "value": "at 9pm",
-                "range": {
-                    "start": 25,
-                    "end": 31
-                }
-            }
-        ]
-        range_mapping, processed_text = _replace_entities_with_placeholders(
-            text=text, language=LANGUAGE_EN, entities=entities)
-
-        # Then
-        expected_mapping = {
-            (3, 17): {START: 3, END: 12},
-            (30, 45): {START: 25, END: 31}
-        }
-        expected_processed_text = \
-            "Be %SNIPSORDINAL% to be there %SNIPSDATETIME%"
-
-        self.assertDictEqual(expected_mapping, range_mapping)
-        self.assertEqual(expected_processed_text, processed_text)
 
     def test_should_get_range_shift(self):
         # Given

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -11,7 +11,7 @@ from snips_nlu.dataset import validate_and_format_dataset
 from snips_nlu.entity_parser import BuiltinEntityParser, CustomEntityParser
 from snips_nlu.entity_parser.custom_entity_parser_usage import (
     CustomEntityParserUsage)
-from snips_nlu.exceptions import _EmptyDatasetError
+from snips_nlu.exceptions import DatasetFormatError
 from snips_nlu.intent_classifier.featurizer import (
     CooccurrenceVectorizer, Featurizer, TfidfVectorizer)
 from snips_nlu.intent_classifier.log_reg_classifier_utils import (
@@ -706,7 +706,7 @@ class TestIntentClassifierFeaturizer(FixtureTest):
         dataset = SAMPLE_DATASET
 
         # When/Then
-        with self.assertRaises(_EmptyDatasetError) as ctx:
+        with self.assertRaises(DatasetFormatError) as ctx:
             Featurizer().fit_transform(dataset, utterances, classes, None)
 
         self.assertEqual(

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -2,9 +2,9 @@
 from __future__ import unicode_literals
 
 import io
+from builtins import str, zip
 
 import numpy as np
-from builtins import str, zip
 from mock import patch
 from snips_nlu_utils import normalize
 
@@ -93,7 +93,7 @@ utterances:
         self.assertTrue(tfidf_vectorizer_path.exists())
 
         cooccurrence_vectorizer_path = (
-                self.tmp_file_path / "cooccurrence_vectorizer")
+            self.tmp_file_path / "cooccurrence_vectorizer")
         self.assertTrue(cooccurrence_vectorizer_path.exists())
 
     def test_should_be_serializable_before_fit(self):
@@ -128,7 +128,7 @@ utterances:
         self.assertFalse(tfidf_vectorizer_path.exists())
 
         cooccurrence_vectorizer_path = (
-                self.tmp_file_path / "cooccurrence_vectorizer")
+            self.tmp_file_path / "cooccurrence_vectorizer")
         self.assertFalse(cooccurrence_vectorizer_path.exists())
 
     @patch("snips_nlu.intent_classifier.featurizer.TfidfVectorizer.from_path")
@@ -144,7 +144,6 @@ utterances:
         config = FeaturizerConfig()
 
         builtin_scope = ["snips/datetime"]
-        none_class_ix = 2
         featurizer_dict = {
             "language_code": language,
             "tfidf_vectorizer": "tfidf_vectorizer",
@@ -311,12 +310,13 @@ values:
         }
 
         expected_data = [
-            (u_0,
-             "hello world entity_2",
-             [num_0],
-             [ent_0],
-             []
-             ),
+            (
+                u_0,
+                "hello world entity_2",
+                [num_0],
+                [ent_0],
+                []
+            ),
             (
                 u_1,
                 "beauty world ent 1",

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -8,6 +8,7 @@ import numpy as np
 from mock import patch, MagicMock
 from snips_nlu_utils import normalize
 
+from snips_nlu.common.utils import json_string
 from snips_nlu.constants import LANGUAGE_EN
 from snips_nlu.dataset import validate_and_format_dataset, Dataset
 from snips_nlu.entity_parser import BuiltinEntityParser, CustomEntityParser

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -85,7 +85,7 @@ class TestIntentClassifierFeaturizer(FixtureTest):
         ]
         utterances = [text_to_utterance(u) for u in utterances]
         classes = np.array([0, 0, 0, 1, 1])
-        featurizer.fit(dataset, utterances, classes)
+        featurizer.fit(dataset, utterances, classes, max(classes))
 
         # When
         featurizer.persist(self.tmp_file_path)
@@ -96,8 +96,7 @@ class TestIntentClassifierFeaturizer(FixtureTest):
             "tfidf_vectorizer": "tfidf_vectorizer",
             "cooccurrence_vectorizer": "cooccurrence_vectorizer",
             "config": config.to_dict(),
-            "builtin_entity_scope": ["snips/datetime"],
-            "none_class_index": 1
+            "builtin_entity_scope": ["snips/datetime"]
         }
         featurizer_dict_path = self.tmp_file_path / "featurizer.json"
         self.assertJsonContent(featurizer_dict_path, expected_featurizer_dict)
@@ -132,8 +131,7 @@ class TestIntentClassifierFeaturizer(FixtureTest):
             "tfidf_vectorizer": None,
             "cooccurrence_vectorizer": None,
             "config": config.to_dict(),
-            "builtin_entity_scope": None,
-            "none_class_index": None
+            "builtin_entity_scope": None
         }
         featurizer_dict_path = self.tmp_file_path / "featurizer.json"
         self.assertJsonContent(featurizer_dict_path, expected_featurizer_dict)
@@ -168,8 +166,7 @@ class TestIntentClassifierFeaturizer(FixtureTest):
             "tfidf_vectorizer": "tfidf_vectorizer",
             "cooccurrence_vectorizer": "cooccurrence_vectorizer",
             "config": config.to_dict(),
-            "builtin_entity_scope": builtin_scope,
-            "none_class_index": none_class_ix
+            "builtin_entity_scope": builtin_scope
         }
 
         self.tmp_file_path.mkdir()
@@ -183,7 +180,6 @@ class TestIntentClassifierFeaturizer(FixtureTest):
         # Then
         self.assertEqual(language, featurizer.language)
         self.assertEqual(set(builtin_scope), featurizer.builtin_entity_scope)
-        self.assertEqual(none_class_ix, featurizer.none_class_index)
         self.assertEqual("tfidf_vectorizer", featurizer.tfidf_vectorizer)
         self.assertEqual("cooccurrence_vectorizer",
                          featurizer.cooccurrence_vectorizer)
@@ -696,7 +692,8 @@ class TestIntentClassifierFeaturizer(FixtureTest):
         classes = [0, 0, 1, 1]
 
         # When
-        x_0 = featurizer.fit_transform(dataset, utterances, classes)
+        x_0 = featurizer.fit_transform(dataset, utterances, classes,
+                                       max(classes))
         x_1 = featurizer.transform(utterances)
 
         # Then
@@ -710,7 +707,7 @@ class TestIntentClassifierFeaturizer(FixtureTest):
 
         # When/Then
         with self.assertRaises(_EmptyDataError) as ctx:
-            Featurizer().fit_transform(dataset, utterances, classes)
+            Featurizer().fit_transform(dataset, utterances, classes, None)
 
         self.assertEqual(
             "Couldn't fit because no utterance was found an",

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -1008,14 +1008,8 @@ class CooccurrenceVectorizerTest(FixtureTest):
         }
 
         # When / Then
-        with self.assertRaises(ValueError) as ctx:
+        with self.assertRaises(ValueError):
             vectorizer.limit_word_pairs([("a", "f")])
-
-        self.assertEqual(
-            str(ctx.exception),
-            "Invalid word pairs [(u'a', u'f')], expected values in"
-            " [(u'a', u'b'), (u'a', u'c'), (u'a', u'd'), (u'a', u'e')]"
-        )
 
 
 class TestTfidfVectorizer(FixtureTest):
@@ -1214,9 +1208,5 @@ class TestTfidfVectorizer(FixtureTest):
 
         # When / Then
         kept_indexes = ["7", "8"]
-        with self.assertRaises(ValueError) as ctx:
+        with self.assertRaises(ValueError):
             vectorizer.limit_vocabulary(kept_indexes)
-
-        expected_ctx = "Invalid ngrams [u'7', u'8'], expected values" \
-                       " in [u'5', u'55', u'6', u'66', u'666']"
-        self.assertEqual(expected_ctx, str(ctx.exception))

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -92,7 +92,7 @@ utterances:
         self.assertTrue(tfidf_vectorizer_path.exists())
 
         cooccurrence_vectorizer_path = (
-                self.tmp_file_path / "cooccurrence_vectorizer")
+            self.tmp_file_path / "cooccurrence_vectorizer")
         self.assertTrue(cooccurrence_vectorizer_path.exists())
 
     def test_should_be_serializable_before_fit(self):
@@ -125,7 +125,7 @@ utterances:
         self.assertFalse(tfidf_vectorizer_path.exists())
 
         cooccurrence_vectorizer_path = (
-                self.tmp_file_path / "cooccurrence_vectorizer")
+            self.tmp_file_path / "cooccurrence_vectorizer")
         self.assertFalse(cooccurrence_vectorizer_path.exists())
 
     @patch("snips_nlu.intent_classifier.featurizer.TfidfVectorizer.from_path")
@@ -998,8 +998,8 @@ class CooccurrenceVectorizerTest(FixtureTest):
         self.assertDictEqual(config.to_dict(), vectorizer.config.to_dict())
         self.assertEqual("en", vectorizer.language)
         self.assertDictEqual(vectorizer.word_pairs, word_pairs)
-        self.assertEqual(
-            set(["snips/datetime"]  ), vectorizer.builtin_entity_scope)
+        self.assertEqual(set(["snips/datetime"]),
+                         vectorizer.builtin_entity_scope)
 
     def test_enrich_utterance(self):
         # Given

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -14,7 +14,7 @@ from snips_nlu.dataset import validate_and_format_dataset, Dataset
 from snips_nlu.entity_parser import BuiltinEntityParser, CustomEntityParser
 from snips_nlu.entity_parser.custom_entity_parser_usage import (
     CustomEntityParserUsage)
-from snips_nlu.exceptions import DatasetFormatError
+from snips_nlu.exceptions import _EmptyDatasetUtterancesError
 from snips_nlu.intent_classifier.featurizer import (
     CooccurrenceVectorizer, Featurizer, TfidfVectorizer)
 from snips_nlu.intent_classifier.log_reg_classifier_utils import (
@@ -264,7 +264,7 @@ values:
         dataset = get_empty_dataset("en")
 
         # When/Then
-        with self.assertRaises(DatasetFormatError) as ctx:
+        with self.assertRaises(_EmptyDatasetUtterancesError) as ctx:
             Featurizer().fit_transform(dataset, utterances, classes, None)
 
         self.assertEqual("Tokenized utterances are empty", str(ctx.exception))

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -2,40 +2,59 @@
 from __future__ import unicode_literals
 
 import json
+from builtins import str, zip
 
 import numpy as np
 from mock import patch
+from scipy.sparse import spdiags
 from snips_nlu_utils import normalize
 
-from snips_nlu.constants import DATA, ENTITY, LANGUAGE_EN, SLOT_NAME, TEXT
+from snips_nlu.constants import LANGUAGE_EN
 from snips_nlu.dataset import validate_and_format_dataset
-from snips_nlu.entity_parser import CustomEntityParser
-from snips_nlu.entity_parser.custom_entity_parser_usage import \
-    CustomEntityParserUsage
+from snips_nlu.entity_parser import BuiltinEntityParser, CustomEntityParser
+from snips_nlu.entity_parser.custom_entity_parser_usage import (
+    CustomEntityParserUsage)
+from snips_nlu.exceptions import _EmptyDataError
 from snips_nlu.intent_classifier.featurizer import (
-    Featurizer, _get_tfidf_vectorizer)
+    CooccurrenceVectorizer, Featurizer, _get_tfidf_vectorizer)
 from snips_nlu.intent_classifier.log_reg_classifier_utils import (
     text_to_utterance)
 from snips_nlu.languages import get_default_sep
 from snips_nlu.pipeline.configs import FeaturizerConfig
+from snips_nlu.pipeline.configs.intent_classifier import (
+    CooccurrenceVectorizerConfig)
 from snips_nlu.preprocessing import tokenize_light
-from snips_nlu.tests.utils import SnipsTest
+from snips_nlu.tests.utils import FixtureTest, SAMPLE_DATASET
 from snips_nlu.common.utils import json_string
 
 
-class TestIntentClassifierFeaturizer(SnipsTest):
+def _stem(t):
+    t = normalize(t)
+    if t == "beautiful":
+        s = "beauty"
+    elif t == "birdy":
+        s = "bird"
+    elif t == "entity":
+        s = "ent"
+    else:
+        s = t
+    return s
+
+
+def stem_function(text, language):
+    return get_default_sep(language).join(
+        [_stem(t) for t in tokenize_light(text, language)])
+
+
+# pylint: disable=protected-access
+class TestIntentClassifierFeaturizer(FixtureTest):
     def test_should_be_serializable(self):
         # Given
-        language = LANGUAGE_EN
-        tfidf_vectorizer = _get_tfidf_vectorizer(language)
-
         pvalue_threshold = 0.42
         featurizer = Featurizer(
-            language,
             config=FeaturizerConfig(pvalue_threshold=pvalue_threshold,
                                     word_clusters_name="brown_clusters"),
-            unknown_words_replacement_string=None,
-            tfidf_vectorizer=tfidf_vectorizer)
+            unknown_words_replacement_string=None)
         dataset = {
             "entities": {
                 "entity2": {
@@ -80,24 +99,23 @@ class TestIntentClassifierFeaturizer(SnipsTest):
         with self.fail_if_exception(msg):
             _ = Featurizer.from_dict(json.loads(dumped))
 
-        vocabulary = tfidf_vectorizer.vocabulary_
+        vocabulary = featurizer.tfidf_vectorizer.vocabulary_
         # pylint: disable=W0212
-        idf_diag = tfidf_vectorizer._tfidf._idf_diag.data.tolist()
+        idf_diag = featurizer.tfidf_vectorizer._tfidf._idf_diag.data.tolist()
         # pylint: enable=W0212
-
-        best_features = featurizer.best_features
 
         expected_serialized = {
             "config": {
                 "sublinear_tf": False,
                 "pvalue_threshold": pvalue_threshold,
+                "added_cooccurrence_feature_ratio": 0,
                 "word_clusters_name": "brown_clusters",
                 "use_stemming": False
             },
             "language_code": "en",
             "tfidf_vectorizer": {"idf_diag": idf_diag, "vocab": vocabulary},
-            "best_features": best_features,
-            "unknown_words_replacement_string": None
+            "unknown_words_replacement_string": None,
+            "builtin_entity_scope": []
         }
         self.assertDictEqual(expected_serialized, serialized_featurizer)
 
@@ -107,10 +125,10 @@ class TestIntentClassifierFeaturizer(SnipsTest):
         idf_diag = [1.52, 1.21, 1.04]
         vocabulary = {"hello": 0, "beautiful": 1, "world": 2}
 
-        best_features = [0, 1]
         config = {
             "pvalue_threshold": 0.4,
             "sublinear_tf": False,
+            "added_cooccurrence_feature_ratio": 0,
             "word_clusters_name": "brown_clusters",
             "use_stemming": False
         }
@@ -119,8 +137,8 @@ class TestIntentClassifierFeaturizer(SnipsTest):
             "config": config,
             "language_code": language,
             "tfidf_vectorizer": {"idf_diag": idf_diag, "vocab": vocabulary},
-            "best_features": best_features,
-            "unknown_words_replacement_string": None
+            "unknown_words_replacement_string": None,
+            "builtin_entity_scope": None
         }
 
         # When
@@ -135,33 +153,167 @@ class TestIntentClassifierFeaturizer(SnipsTest):
         # pylint: enable=W0212
         self.assertDictEqual(featurizer.tfidf_vectorizer.vocabulary_,
                              vocabulary)
-        self.assertListEqual(featurizer.best_features, best_features)
         self.assertEqual(config, featurizer.config.to_dict())
+
+    @patch("snips_nlu.intent_classifier.featurizer.stem")
+    def test_enrich_utterance_for_tfidf(self, mocked_stem):
+        # Given
+        mocked_stem.side_effect = stem_function
+        utterances = [
+            {
+                "data": [
+                    {
+                        "text": "one",
+                        "entity": "snips/number"
+                    },
+                    {
+                        "text": " beauTiful World ",
+                    },
+                    {
+                        "text": "entity 1",
+                        "entity": "dummy_entity_1"
+                    },
+                ]
+            },
+            text_to_utterance("one beauTiful World entity 1"),
+            text_to_utterance("hÉllo wOrld Éntity_2"),
+            text_to_utterance("Bird bïrdy"),
+        ]
+
+        builtin_ents = [
+            [
+                {
+                    "value": "one",
+                    "resolved_value": 1,
+                    "range": {
+                        "start": 0,
+                        "end": 3
+                    },
+                    "entity_kind": "snips/number"
+
+                }
+            ],
+            [
+                {
+                    "value": "one",
+                    "resolved_value": 1,
+                    "range": {
+                        "start": 0,
+                        "end": 3
+                    },
+                    "entity_kind": "snips/number"
+                },
+                {
+                    "value": "1",
+                    "resolved_value": 1,
+                    "range": {
+                        "start": 27,
+                        "end": 28
+                    },
+                    "entity_kind": "snips/number"
+                }
+            ],
+            [
+                {
+                    "value": "2",
+                    "resolved_value": 2,
+                    "range": {
+                        "start": 19,
+                        "end": 20
+                    },
+                    "entity_kind": "snips/number"
+                }
+            ],
+            []
+        ]
+
+        custom_ents = [
+            [
+                {
+                    "value": "ent 1",
+                    "resolved_value": "entity 1",
+                    "range": {
+                        "start": 20,
+                        "end": 28
+                    },
+                    "entity_kind": "dummy_entity_1"
+                }
+            ],
+            [
+
+                {
+                    "value": "ent 1",
+                    "resolved_value": "entity 1",
+                    "range": {
+                        "start": 20,
+                        "end": 28
+                    },
+                    "entity_kind": "dummy_entity_1"
+                }
+            ],
+            [
+                {
+                    "value": "entity_2",
+                    "resolved_value": "Éntity_2",
+                    "range": {
+                        "start": 12,
+                        "end": 20
+                    },
+                    "entity_kind": "dummy_entity_2"
+                }
+            ],
+            []
+        ]
+
+        w_clusters = [
+            ["111", "112"],
+            ["111", "112"],
+            [],
+            []
+        ]
+
+        featurizer = Featurizer(
+            config=FeaturizerConfig(word_clusters_name="brown_clusters",
+                                    use_stemming=True))
+        featurizer.language = "en"
+
+        # When
+        enriched_utterances = [
+            featurizer._enrich_utterance_for_tfidf(*data)
+            for data in zip(utterances, builtin_ents, custom_ents, w_clusters)
+        ]
+
+        # Then
+        expected_u0 = "beauty world ent 1 " \
+                      "builtinentityfeaturesnipsnumber " \
+                      "entityfeaturedummy_entity_1 111 112"
+
+        expected_u1 = "one beauty world ent 1 " \
+                      "builtinentityfeaturesnipsnumber " \
+                      "builtinentityfeaturesnipsnumber " \
+                      "entityfeaturedummy_entity_1 111 112"
+
+        expected_u2 = "hello world entity_2 builtinentityfeaturesnipsnumber " \
+                      "entityfeaturedummy_entity_2"
+
+        expected_u3 = "bird bird"
+
+        expected_utterances = [
+            expected_u0,
+            expected_u1,
+            expected_u2,
+            expected_u3
+        ]
+
+        self.assertEqual(expected_utterances, enriched_utterances)
 
     @patch("snips_nlu.intent_classifier.featurizer.get_word_cluster")
     @patch("snips_nlu.intent_classifier.featurizer.stem")
     @patch("snips_nlu.entity_parser.custom_entity_parser.stem")
-    def test_preprocess_utterances(
-            self, mocked_parser_stem, mocked_featurizer_stem,
-            mocked_word_cluster):
+    def test_preprocess(self, mocked_parser_stem, mocked_featurizer_stem,
+                        mocked_word_cluster):
         # Given
         language = LANGUAGE_EN
-
-        def _stem(t):
-            t = normalize(t)
-            if t == "beautiful":
-                s = "beauty"
-            elif t == "birdy":
-                s = "bird"
-            elif t == "entity":
-                s = "ent"
-            else:
-                s = t
-            return s
-
-        def stem_function(text, language):
-            return get_default_sep(language).join(
-                [_stem(t) for t in tokenize_light(text, language)])
 
         mocked_word_cluster.return_value = {
             "beautiful": "cluster_1",
@@ -209,6 +361,366 @@ class TestIntentClassifierFeaturizer(SnipsTest):
                     "automatically_extensible": False,
                     "matching_strictness": 1.0
                 },
+                "snips/number": {}  # To test the builtin feature
+            },
+            "language": "en",
+        }
+
+        dataset = validate_and_format_dataset(dataset)
+
+        custom_entity_parser = CustomEntityParser.build(
+            dataset, CustomEntityParserUsage.WITH_STEMS)
+
+        builtin_entity_parser = BuiltinEntityParser.build(dataset, language)
+        utterances = [
+            text_to_utterance("hÉllo wOrld Éntity_2"),
+            text_to_utterance("beauTiful World entity 1"),
+            text_to_utterance("Bird bïrdy"),
+            text_to_utterance("Bird birdy"),
+        ]
+
+        config = FeaturizerConfig(
+            use_stemming=True, word_clusters_name="brown_clusters")
+        featurizer = Featurizer(language=language,
+                                custom_entity_parser=custom_entity_parser,
+                                builtin_entity_parser=builtin_entity_parser,
+                                config=config)
+        featurizer.language = language
+
+        # When
+        processed_data = featurizer._preprocess(
+            utterances, training=False)
+        processed_data = list(zip(*processed_data))
+
+        # Then
+        ent_0 = {
+            "entity_kind": "entity_2",
+            "value": "entity_2",
+            "resolved_value": "Éntity 2",
+            "range": {"start": 12, "end": 20}
+        }
+        num_0 = {
+            "entity_kind": "snips/number",
+            "value": "2",
+            "entity": {
+                "value": 2.0,
+                "kind": "Number"
+            },
+            "range": {"start": 19, "end": 20}
+        }
+        ent_11 = {
+            "entity_kind": "entity_1",
+            "value": "ent 1",
+            "resolved_value": "entity 1",
+            "range": {"start": 13, "end": 18}
+        }
+        ent_12 = {
+            "entity_kind": "entity_2",
+            "value": "ent 1",
+            "resolved_value": "entity 1",
+            "range": {"start": 13, "end": 18}
+        }
+        num_1 = {
+            "entity_kind": "snips/number",
+            "value": "1",
+            "range": {"start": 17, "end": 18},
+            "entity": {
+                "value": 1.0,
+                "kind": "Number"
+            },
+        }
+
+        expected_data = [
+            (
+                "hello world entity_2",
+                [num_0],
+                [ent_0],
+                []
+            ),
+            (
+                "beauty world ent 1",
+                [num_1],
+                [ent_11, ent_12],
+                ["cluster_1", "cluster_3"]
+            ),
+            (
+                "bird bird",
+                [],
+                [],
+                []
+            ),
+            (
+                "bird bird",
+                [],
+                [],
+                ["cluster_2"]
+            )
+        ]
+
+        self.assertSequenceEqual(expected_data, processed_data)
+
+    @patch("snips_nlu.intent_classifier.featurizer.get_word_cluster")
+    @patch("snips_nlu.intent_classifier.featurizer.stem")
+    def test_preprocess_for_training(self, mocked_featurizer_stem,
+                                     mocked_word_cluster):
+        # Given
+        language = LANGUAGE_EN
+
+        mocked_word_cluster.return_value = {
+            "beautiful": "cluster_1",
+            "birdy": "cluster_2",
+            "entity": "cluster_3"
+        }
+
+        mocked_featurizer_stem.side_effect = stem_function
+
+        dataset = {
+            "intents": {
+                "intent1": {
+                    "utterances": []
+                }
+            },
+            "entities": {
+                "entity_1": {
+                    "data": [
+                        {
+                            "value": "entity 1",
+                            "synonyms": ["alternative entity 1"]
+                        },
+                        {
+                            "value": "éntity 1",
+                            "synonyms": ["alternative entity 1"]
+                        }
+                    ],
+                    "use_synonyms": False,
+                    "automatically_extensible": False,
+                    "matching_strictness": 1.0
+                },
+                "entity_2": {
+                    "data": [
+                        {
+                            "value": "entity 1",
+                            "synonyms": []
+                        },
+                        {
+                            "value": "Éntity 2",
+                            "synonyms": ["Éntity_2", "Alternative entity 2"]
+                        }
+                    ],
+                    "use_synonyms": True,
+                    "automatically_extensible": False,
+                    "matching_strictness": 1.0
+                },
+                "snips/number": {}  # To test the builtin feature
+            },
+            "language": "en",
+        }
+
+        dataset = validate_and_format_dataset(dataset)
+
+        custom_entity_parser = CustomEntityParser.build(
+            dataset, CustomEntityParserUsage.WITH_STEMS)
+
+        builtin_entity_parser = BuiltinEntityParser.build(dataset, language)
+        utterances = [
+            {
+                "data": [
+                    {
+                        "text": "hÉllo wOrld "
+                    },
+                    {
+                        "text": " yo "
+                    },
+                    {
+                        "text": " yo "
+                    },
+                    {
+                        "text": "yo "
+                    },
+                    {
+                        "text": "Éntity_2 ",
+                        "entity": "entity_2"
+                    },
+                    {
+                        "text": "Éntity_2",
+                        "entity": "entity_2"
+                    }
+                ]
+            },
+            {
+                "data": [
+                    {
+                        "text": "beauTiful World "
+                    },
+                    {
+                        "text": "entity 1",
+                        "entity": "entity_1"
+                    }
+                ]
+            },
+            {
+                "data": [
+                    {
+                        "text": "Bird bïrdy"
+                    }
+                ]
+            },
+            {
+                "data": [
+                    {
+                        "text": "Bird birdy"
+                    }
+                ]
+            }
+        ]
+
+        config = FeaturizerConfig(
+            use_stemming=True, word_clusters_name="brown_clusters")
+        featurizer = Featurizer(language=language,
+                                custom_entity_parser=custom_entity_parser,
+                                builtin_entity_parser=builtin_entity_parser,
+                                config=config)
+        featurizer.language = language
+
+        # When
+        processed_data = featurizer._preprocess(
+            utterances, training=True)
+        processed_data = list(zip(*processed_data))
+
+        # Then
+        ent_00 = {
+            "entity_kind": "entity_2",
+            "value": "entity_2",
+            "range": {"start": 21, "end": 29}
+        }
+        ent_01 = {
+            "entity_kind": "entity_2",
+            "value": "entity_2",
+            "range": {"start": 30, "end": 38}
+        }
+        ent_1 = {
+            "entity_kind": "entity_1",
+            "value": "ent 1",
+            "range": {"start": 13, "end": 18}
+        }
+
+        expected_data = [
+            (
+                "hello world yo yo yo entity_2 entity_2",
+                [],
+                [ent_00, ent_01],
+                []
+            ),
+            (
+                "beauty world ent 1",
+                [],
+                [ent_1],
+                ["cluster_1", "cluster_3"]
+            ),
+            (
+                "bird bird",
+                [],
+                [],
+                []
+            ),
+            (
+                "bird bird",
+                [],
+                [],
+                ["cluster_2"]
+            )
+        ]
+
+        self.assertSequenceEqual(expected_data, processed_data)
+
+    def test_featurizer_should_be_serialized_when_not_fitted(self):
+        # Given
+        language = LANGUAGE_EN
+        featurizer = Featurizer(language)
+        # When/Then
+        featurizer.to_dict()
+
+    def test_limit_tfidf_vectorizer_vocabulary(self):
+        # Given
+        featurizer = Featurizer()
+        featurizer.tfidf_vectorizer = _get_tfidf_vectorizer("en")
+
+        utterances = [
+            "5 55 6 66 666",
+            "55 66",
+        ]
+
+        voca = {
+            "5": 0,
+            "55": 1,
+            "6": 2,
+            "66": 3,
+            "666": 4
+        }
+
+        # When
+        kept_indexes = [0, 2, 4]
+        featurizer.tfidf_vectorizer.fit_transform(utterances)
+        self.assertDictEqual(voca, featurizer.tfidf_vectorizer.vocabulary_)
+        diag = featurizer.tfidf_vectorizer.idf_.copy()
+        featurizer._limit_tfidf_vectorizer_vocabulary(kept_indexes)
+
+        # Then
+        expected_voca = {
+            "5": 0,
+            "6": 1,
+            "666": 2
+        }
+        self.assertDictEqual(
+            expected_voca, featurizer.tfidf_vectorizer.vocabulary_)
+
+        expected_diag = diag[kept_indexes].tolist()
+        self.assertListEqual(
+            expected_diag, featurizer.tfidf_vectorizer.idf_.tolist())
+
+    def test_fit_transform_should_be_consistent_with_transform(self):
+        # Here we mainly test that the output of fit_transform is
+        # the same as the result of fit and then transform.
+        # We're trying to avoid that for some reason indexes of features
+        # get mixed up after feature selection
+
+        # Given
+        config = FeaturizerConfig(added_cooccurrence_feature_ratio=.5)
+        featurizer = Featurizer(config=config)
+
+        dataset = {
+            "intents": {
+                "intent1": {
+                    "utterances": []
+                }
+            },
+            "entities": {
+                "entity_1": {
+                    "data": [
+                        {
+                            "value": "entity 1",
+                            "synonyms": ["alternative entity 1"]
+                        },
+                        {
+                            "value": "éntity 1",
+                            "synonyms": ["alternative entity 1"]
+                        }
+                    ],
+                    "use_synonyms": False,
+                    "automatically_extensible": False,
+                    "matching_strictness": 1.0
+                },
+                "entity_2": {
+                    "data": [
+                        {
+                            "value": "Éntity 2",
+                            "synonyms": ["Éntity_2", "Alternative entity 2"]
+                        }
+                    ],
+                    "use_synonyms": True,
+                    "automatically_extensible": False,
+                    "matching_strictness": 1.0
+                },
                 "snips/number": {}
             },
             "language": "en",
@@ -217,61 +729,354 @@ class TestIntentClassifierFeaturizer(SnipsTest):
         dataset = validate_and_format_dataset(dataset)
 
         utterances = [
-            text_to_utterance("hÉllo wOrld Éntity_2"),
-            text_to_utterance("beauTiful World entity 1"),
-            text_to_utterance("Bird bïrdy"),
+            {
+                "data": [
+                    {
+                        "text": "hÉllo wOrld "
+                    },
+                    {
+                        "text": "Éntity_2",
+                        "entity": "entity_2"
+                    }
+                ]
+            },
+            {
+                "data": [
+                    {
+                        "text": "beauTiful World "
+                    },
+                    {
+                        "text": "entity 1",
+                        "entity": "entity_1"
+                    }
+                ]
+            },
+            {
+                "data": [
+                    {
+                        "text": "Bird bïrdy"
+                    }
+                ]
+            },
+            {
+                "data": [
+                    {
+                        "text": "Bird bïrdy"
+                    }
+                ]
+            }
         ]
 
-        labeled_utterance = {
-            DATA: [
-                {
-                    TEXT: "beauTiful éntity "
-                },
-                {
-                    TEXT: "1",
-                    ENTITY: "snips/number",
-                    SLOT_NAME: "number"
-                },
-                {
-                    TEXT: " bIrd Éntity_2"
-                }
-            ]
-        }
-        utterances.append(labeled_utterance)
-        labels = np.array([0, 0, 1, 1])
-
-        custom_entity_parser = CustomEntityParser.build(
-            dataset, CustomEntityParserUsage.WITH_AND_WITHOUT_STEMS)
-
-        featurizer = Featurizer(
-            language,
-            None,
-            custom_entity_parser=custom_entity_parser,
-            config=FeaturizerConfig(word_clusters_name="brown_clusters",
-                                    use_stemming=True)
-        ).fit(dataset, utterances, labels)
+        classes = [0, 0, 1, 1]
 
         # When
-        utterances = featurizer.preprocess_utterances(utterances)
+        x_0 = featurizer.fit_transform(dataset, utterances, classes)
+        x_1 = featurizer.transform(utterances)
 
         # Then
-        expected_utterances = [
-            "hello world entity_2 builtinentityfeaturesnipsnumber "
-            "entityfeatureentity_2",
-            "beauty world ent 1 builtinentityfeaturesnipsnumber "
-            "entityfeatureentity_1 entityfeatureentity_2 "
-            "cluster_1 cluster_3",
-            "bird bird",
-            "beauty ent bird entity_2 builtinentityfeaturesnipsnumber "
-            "builtinentityfeaturesnipsnumber entityfeatureentity_1 "
-            "entityfeatureentity_2 entityfeatureentity_2 cluster_1"
+        self.assertListEqual(x_0.todense().tolist(), x_1.todense().tolist())
+
+    def test_fit_with_no_utterance_should_raise(self):
+        # Given
+        utterances = []
+        classes = []
+        dataset = SAMPLE_DATASET
+
+        # When/Then
+        with self.assertRaises(_EmptyDataError) as ctx:
+            Featurizer().fit_transform(dataset, utterances, classes)
+
+        self.assertEqual(
+            "Couldn't fit because no utterance was found an",
+            str(ctx.exception))
+
+    def test_limit_tfidf_vectorizer_vocabulary_should_raise(self):
+        # Given
+        featurizer = Featurizer()
+        featurizer.tfidf_vectorizer = _get_tfidf_vectorizer("en")
+        voca = {
+            ("5",): 0,
+            ("55",): 1,
+            ("6",): 2,
+            ("66",): 3,
+            ("666",): 4
+        }
+        featurizer.tfidf_vectorizer.vocabulary_ = voca
+        diag = [1.1 for _ in voca]
+
+        num_features = len(voca)
+        featurizer.tfidf_vectorizer._tfidf._idf_diag = spdiags(
+            diag, diags=0, m=num_features, n=num_features, format="csr")
+
+        # When / Then
+        kept_indexes = [8, 9]
+
+        with self.assertRaises(ValueError) as ctx:
+            featurizer._limit_tfidf_vectorizer_vocabulary(kept_indexes)
+
+        expected_ctx = "Invalid ngrams indexes set([8, 9]), expected values" \
+                       " in set([0, 1, 2, 3, 4])"
+        self.assertEqual(expected_ctx, str(ctx.exception))
+
+    def test_cooccurrence_vectorizer_should_persist(self):
+        # Given
+        x = [("yo yo", [], [])]
+        language = "en"
+        vectorizer = CooccurrenceVectorizer().fit(x, language)
+
+        # When
+        vectorizer.persist(self.tmp_file_path)
+
+        # Then
+        metadata_path = self.tmp_file_path / "metadata.json"
+        expected_metadata = {"unit_name": "cooccurrence_vectorizer"}
+        self.assertJsonContent(metadata_path, expected_metadata)
+
+        vectorizer_path = self.tmp_file_path / "cooccurrence_vectorizer.json"
+        expected_vectorizer = {
+            "word_pairs": {
+                "0": ["yo", "yo"]
+            },
+            "language": "en",
+            "config": vectorizer.config.to_dict()
+        }
+        self.assertJsonContent(vectorizer_path, expected_vectorizer)
+
+    def test_cooccurrence_vectorizer_should_load(self):
+        # Given
+        config = CooccurrenceVectorizerConfig()
+
+        word_pairs = {
+            ("a", "b"): 0,
+            ("a", 'c'): 12
+        }
+
+        serializable_word_pairs = {
+            0: ["a", "b"],
+            12: ["a", "c"]
+        }
+
+        vectorizer_dict = {
+            "unit_name": "cooccurrence_vectorizer",
+            "language": "en",
+            "word_pairs": serializable_word_pairs,
+            "config": config.to_dict(),
+        }
+
+        self.tmp_file_path.mkdir()
+        self.writeJsonContent(
+            self.tmp_file_path / "cooccurrence_vectorizer.json",
+            vectorizer_dict
+        )
+
+        # When
+        vectorizer = CooccurrenceVectorizer.from_path(self.tmp_file_path)
+
+        # Then
+        self.assertDictEqual(config.to_dict(), vectorizer.config.to_dict())
+        self.assertEqual("en", vectorizer.language)
+        self.assertDictEqual(vectorizer.word_pairs, word_pairs)
+
+    def test_cooccurence_vectorizer_should_preprocess(self):
+        # Given
+        u = "a b c d e f"
+        builtin_ents = [
+            {
+                "value": "e",
+                "resolved_value": "e",
+                "range": {
+                    "start": 8,
+                    "end": 9
+                },
+                "entity_kind": "the_snips_e_entity"
+            }
+        ]
+        custom_ents = [
+            {
+                "value": "c",
+                "resolved_value": "c",
+                "range": {
+                    "start": 4,
+                    "end": 5
+                },
+                "entity_kind": "the_c_entity"
+            }
         ]
 
-        self.assertListEqual(utterances, expected_utterances)
+        x = [(u, builtin_ents, custom_ents)]
+        vectorizer = CooccurrenceVectorizer()
+        vectorizer.language = "en"
 
-    def test_featurizer_should_be_serialized_when_not_fitted(self):
+        # When
+        preprocessed = vectorizer._preprocess(x)
+
+        # Then
+        expected = [["a", "b", "THE_C_ENTITY", "d", "THE_SNIPS_E_ENTITY", "f"]]
+        self.assertSequenceEqual(expected, preprocessed)
+
+    def test_cooccurence_vectorizer_should_transform(self):
         # Given
-        language = LANGUAGE_EN
-        featurizer = Featurizer(language, None)
-        # When/Then
-        featurizer.to_dict()
+        config = CooccurrenceVectorizerConfig(
+            use_stop_words=True,
+            window_size=3,
+            unknown_words_replacement_string="d")
+        vectorizer = CooccurrenceVectorizer(config)
+        vectorizer.language = "en"
+        vectorizer.word_pairs = {
+            ("THE_SNIPS_E_ENTITY", "f"): 0,
+            ("a", "THE_C_ENTITY"): 1,
+            ("a", "THE_SNIPS_E_ENTITY"): 2,
+            ("b", "THE_SNIPS_E_ENTITY"): 3,
+            ("yo", "yo"): 4,
+            ("d", "THE_SNIPS_E_ENTITY"): 5
+        }
+
+        u = "yo a b c d e f yo"
+        builtin_ents = [
+            {
+                "value": "e",
+                "resolved_value": "e",
+                "range": {
+                    "start": 11,
+                    "end": 12
+                },
+                "entity_kind": "the_snips_e_entity"
+            }
+        ]
+        custom_ents = [
+            {
+                "value": "c",
+                "resolved_value": "c",
+                "range": {
+                    "start": 7,
+                    "end": 8
+                },
+                "entity_kind": "the_c_entity"
+            }
+        ]
+
+        data = [
+            (u, builtin_ents, custom_ents),
+            (u[:-5], builtin_ents, custom_ents),
+        ]
+
+        # When
+        with patch("snips_nlu.intent_classifier.featurizer.get_stop_words") \
+                as mocked_stop_words:
+            mocked_stop_words.return_value = {"b"}
+            x = vectorizer.transform(data)
+        # Then
+        expected = [[1, 1, 1, 0, 0, 0], [0, 1, 1, 0, 0, 0]]
+        self.assertEqual(expected, x.todense().tolist())
+
+    def test_cooccurence_vectorizer_should_fit(self):
+        u = "a b c d e f"
+        builtin_ents = [
+            {
+                "value": "e",
+                "resolved_value": "e",
+                "range": {
+                    "start": 8,
+                    "end": 9
+                },
+                "entity_kind": "the_snips_e_entity"
+            }
+        ]
+        custom_ents = [
+            {
+                "value": "c",
+                "resolved_value": "c",
+                "range": {
+                    "start": 4,
+                    "end": 5
+                },
+                "entity_kind": "the_c_entity"
+            }
+        ]
+
+        x = [(u, builtin_ents, custom_ents)]
+
+        config = CooccurrenceVectorizerConfig(
+            window_size=3,
+            unknown_words_replacement_string="b"
+        )
+        language = "en"
+
+        # When
+        expected_pairs = {
+            ("THE_C_ENTITY", "THE_SNIPS_E_ENTITY"): 0,
+            ("THE_C_ENTITY", "d"): 1,
+            ("THE_C_ENTITY", "f"): 2,
+            ("THE_SNIPS_E_ENTITY", "f"): 3,
+            ("a", "THE_C_ENTITY"): 4,
+            ("a", "THE_SNIPS_E_ENTITY"): 5,
+            ("a", "d"): 6,
+            ("d", "THE_SNIPS_E_ENTITY"): 7,
+            ("d", "f"): 8,
+        }
+        vectorizer = CooccurrenceVectorizer(config).fit(x, language)
+
+        # Then
+        self.assertDictEqual(expected_pairs, vectorizer.word_pairs)
+
+    def test_cooccurence_vectorizer_should_limit_vocabulary(self):
+        # Given
+        config = CooccurrenceVectorizerConfig(use_stop_words=False)
+        vectorizer = CooccurrenceVectorizer(config=config)
+        train_data = [
+            ("a b", [], []),
+            ("a c", [], []),
+            ("a d", [], []),
+            ("a e", [], []),
+        ]
+        data = [
+            ("a c e", [], []),
+            ("a d e", [], []),
+        ]
+
+        vectorizer.fit(train_data, "en")
+        x_0 = vectorizer.transform(data)
+        pairs = {
+            ("a", "b"): 0,
+            ("a", "c"): 1,
+            ("a", "d"): 2,
+            ("a", "e"): 3
+        }
+        self.assertDictEqual(pairs, vectorizer.word_pairs)
+
+        # When
+        kept_pairs_indexes = [0, 1, 2]
+        vectorizer.limit_vocabulary(kept_pairs_indexes)
+
+        # Then
+        expected_pairs = {
+            ("a", "b"): 0,
+            ("a", "c"): 1,
+            ("a", "d"): 2
+        }
+        self.assertDictEqual(expected_pairs, vectorizer.word_pairs)
+        x_1 = vectorizer.transform(data)
+        self.assertListEqual(
+            x_0[:, kept_pairs_indexes].todense().tolist(),
+            x_1.todense().tolist()
+        )
+
+    def test_cooccurence_vectorizer_limit_vocabulary_should_raise(self):
+        # Given
+        vectorizer = CooccurrenceVectorizer()
+        vectorizer.word_pairs = {
+            ("a", "b"): 0,
+            ("a", "c"): 1,
+            ("a", "d"): 2,
+            ("a", "e"): 3
+        }
+
+        # When / Then
+        with self.assertRaises(ValueError) as ctx:
+            vectorizer.limit_vocabulary([0, 8, 10])
+
+        self.assertEqual(
+            str(ctx.exception),
+            "Invalid word pairs indexes set([8, 10]), expected values in "
+            "set([0, 1, 2, 3])"
+        )

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -321,7 +321,7 @@ values:
 
         # When
         mocked_chi2.return_value = (
-            None, [0.0, 1.0, 0.0, 1.0, 0.0, 1.0] + [1.0 for _ in range(100)])
+            None, [0.1, 1.0, 0.2, 1.0, 0.3, 1.0] + [1.0 for _ in range(100)])
         featurizer._fit_cooccurrence_vectorizer(
             utterances, classes, 1, mocked_dataset)
 
@@ -999,7 +999,7 @@ class CooccurrenceVectorizerTest(FixtureTest):
         self.assertEqual("en", vectorizer.language)
         self.assertDictEqual(vectorizer.word_pairs, word_pairs)
         self.assertEqual(
-            set(["snips/datetime"]), vectorizer.builtin_entity_scope)
+            set(["snips/datetime"]  ), vectorizer.builtin_entity_scope)
 
     def test_enrich_utterance(self):
         # Given

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -24,8 +24,8 @@ from snips_nlu.pipeline.configs import FeaturizerConfig
 from snips_nlu.pipeline.configs.intent_classifier import (
     CooccurrenceVectorizerConfig, TfidfVectorizerConfig)
 from snips_nlu.preprocessing import tokenize_light
-from snips_nlu.tests.utils import FixtureTest, get_empty_dataset, \
-    EntityParserMock
+from snips_nlu.tests.utils import (
+    FixtureTest, get_empty_dataset, EntityParserMock)
 
 
 def _stem(t):

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -11,7 +11,7 @@ from snips_nlu.dataset import validate_and_format_dataset
 from snips_nlu.entity_parser import BuiltinEntityParser, CustomEntityParser
 from snips_nlu.entity_parser.custom_entity_parser_usage import (
     CustomEntityParserUsage)
-from snips_nlu.exceptions import _EmptyDataError
+from snips_nlu.exceptions import _EmptyDatasetError
 from snips_nlu.intent_classifier.featurizer import (
     CooccurrenceVectorizer, Featurizer, TfidfVectorizer)
 from snips_nlu.intent_classifier.log_reg_classifier_utils import (
@@ -706,7 +706,7 @@ class TestIntentClassifierFeaturizer(FixtureTest):
         dataset = SAMPLE_DATASET
 
         # When/Then
-        with self.assertRaises(_EmptyDataError) as ctx:
+        with self.assertRaises(_EmptyDatasetError) as ctx:
             Featurizer().fit_transform(dataset, utterances, classes, None)
 
         self.assertEqual(

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -998,7 +998,7 @@ class CooccurrenceVectorizerTest(FixtureTest):
         self.assertDictEqual(config.to_dict(), vectorizer.config.to_dict())
         self.assertEqual("en", vectorizer.language)
         self.assertDictEqual(vectorizer.word_pairs, word_pairs)
-        self.assertEqual(set(["snips/datetime"]),
+        self.assertEqual({"snips/datetime"},
                          vectorizer.builtin_entity_scope)
 
     def test_enrich_utterance(self):
@@ -1313,7 +1313,7 @@ values:
         u_1 = text_to_utterance("beauTiful World entity 1")
         u_2 = text_to_utterance("Bird bïrdy")
         u_3 = text_to_utterance("Bird birdy")
-        utterances = [u_0, u_1, u_2, u_3, ]
+        utterances = [u_0, u_1, u_2, u_3]
 
         config = CooccurrenceVectorizerConfig()
         vectorizer = CooccurrenceVectorizer(

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -19,9 +19,9 @@ from snips_nlu.intent_classifier.log_reg_classifier_utils import (
 from snips_nlu.languages import get_default_sep
 from snips_nlu.pipeline.configs import FeaturizerConfig
 from snips_nlu.pipeline.configs.intent_classifier import (
-    CooccurrenceVectorizerConfig, TfidfVectorizerConfig)
+    CooccurrenceVectorizerConfig)
 from snips_nlu.preprocessing import tokenize_light
-from snips_nlu.tests.utils import FixtureTest, SAMPLE_DATASET
+from snips_nlu.tests.utils import FixtureTest
 from snips_nlu.common.utils import json_string
 
 
@@ -703,7 +703,7 @@ class TestIntentClassifierFeaturizer(FixtureTest):
         # Given
         utterances = []
         classes = []
-        dataset = SAMPLE_DATASET
+        dataset = {"language": "en"}
 
         # When/Then
         with self.assertRaises(DatasetFormatError) as ctx:
@@ -1199,7 +1199,7 @@ class TestTfidfVectorizer(FixtureTest):
             []
         ]
 
-        vectorizer = TfidfVectorizer(config=TfidfVectorizerConfig())
+        vectorizer = TfidfVectorizer()
         vectorizer._language = "en"
 
         # When

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -312,7 +312,7 @@ class TestIntentClassifierFeaturizer(FixtureTest):
         num_0 = {
             "entity_kind": "snips/number",
             "value": "2",
-            "entity": {
+            "resolved_value": {
                 "value": 2.0,
                 "kind": "Number"
             },
@@ -334,7 +334,7 @@ class TestIntentClassifierFeaturizer(FixtureTest):
             "entity_kind": "snips/number",
             "value": "1",
             "range": {"start": 17, "end": 18},
-            "entity": {
+            "resolved_value": {
                 "value": 1.0,
                 "kind": "Number"
             },
@@ -709,9 +709,7 @@ class TestIntentClassifierFeaturizer(FixtureTest):
         with self.assertRaises(DatasetFormatError) as ctx:
             Featurizer().fit_transform(dataset, utterances, classes, None)
 
-        self.assertEqual(
-            "Couldn't fit because no utterance was found an",
-            str(ctx.exception))
+        self.assertEqual("Tokenized utterances are empty", str(ctx.exception))
 
     def test_feature_index_to_feature_name(self):
         # Given

--- a/snips_nlu/tests/test_intent_classifier_featurizer.py
+++ b/snips_nlu/tests/test_intent_classifier_featurizer.py
@@ -766,7 +766,7 @@ class CooccurrenceVectorizerTest(FixtureTest):
         expected_metadata = {"unit_name": "cooccurrence_vectorizer"}
         self.assertJsonContent(metadata_path, expected_metadata)
 
-        vectorizer_path = self.tmp_file_path / "cooccurrence_vectorizer.json"
+        vectorizer_path = self.tmp_file_path / "vectorizer.json"
         expected_vectorizer = {
             "word_pairs": {
                 "0": ["yo", "yo"]
@@ -799,7 +799,7 @@ class CooccurrenceVectorizerTest(FixtureTest):
 
         self.tmp_file_path.mkdir()
         self.writeJsonContent(
-            self.tmp_file_path / "cooccurrence_vectorizer.json",
+            self.tmp_file_path / "vectorizer.json",
             vectorizer_dict
         )
 

--- a/snips_nlu/tests/test_log_reg_intent_classifier.py
+++ b/snips_nlu/tests/test_log_reg_intent_classifier.py
@@ -459,9 +459,12 @@ utterances:
 
         text = "yo"
         utterances = [text_to_utterance(text)]
-        x = intent_classifier.featurizer.transform(utterances)[0]
+        intent_classifier = LogRegIntentClassifier()
+        self.assertIsNone(intent_classifier.log_activation_weights(text, None))
 
         # When
+        intent_classifier.fit(SAMPLE_DATASET)
+        x = intent_classifier.featurizer.transform(utterances)[0]
         log = intent_classifier.log_activation_weights(text, x, top_n=42)
 
         # Then
@@ -470,6 +473,7 @@ utterances:
 
     def test_log_best_features(self):
         # Given
+        intent_classifier = LogRegIntentClassifier()
         dataset_stream = io.StringIO("""
         ---
         type: intent
@@ -486,6 +490,8 @@ utterances:
         intent_classifier = LogRegIntentClassifier().fit(dataset)
 
         # When
+        self.assertIsNone(intent_classifier.log_best_features(20))
+        intent_classifier.fit(SAMPLE_DATASET)
         log = intent_classifier.log_best_features(20)
 
         # Then

--- a/snips_nlu/tests/test_log_reg_intent_classifier.py
+++ b/snips_nlu/tests/test_log_reg_intent_classifier.py
@@ -394,8 +394,6 @@ utterances:
     def test_empty_vocabulary_should_fit_and_return_none_intent(
             self, mocked_build_training):
         # Given
-        language = LANGUAGE_EN
-
         dataset_stream = io.StringIO("""
 ---
 type: intent

--- a/snips_nlu/tests/test_log_reg_intent_classifier.py
+++ b/snips_nlu/tests/test_log_reg_intent_classifier.py
@@ -270,7 +270,7 @@ utterances:
     @patch('snips_nlu.intent_classifier.featurizer.Featurizer.from_dict')
     def test_should_be_deserializable(self, mock_from_dict):
         # Given
-        mocked_featurizer = Featurizer(LANGUAGE_EN, None)
+        mocked_featurizer = Featurizer(LANGUAGE_EN)
         mock_from_dict.return_value = mocked_featurizer
 
         intent_list = ["MakeCoffee", "MakeTea", None]

--- a/snips_nlu/tests/test_log_reg_intent_classifier.py
+++ b/snips_nlu/tests/test_log_reg_intent_classifier.py
@@ -455,15 +455,13 @@ name: intent2
 utterances:
   - lorem ipsum""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        intent_classifier = LogRegIntentClassifier().fit(dataset)
-
         text = "yo"
         utterances = [text_to_utterance(text)]
         intent_classifier = LogRegIntentClassifier()
         self.assertIsNone(intent_classifier.log_activation_weights(text, None))
 
         # When
-        intent_classifier.fit(SAMPLE_DATASET)
+        intent_classifier.fit(dataset)
         x = intent_classifier.featurizer.transform(utterances)[0]
         log = intent_classifier.log_activation_weights(text, x, top_n=42)
 
@@ -475,23 +473,23 @@ utterances:
         # Given
         intent_classifier = LogRegIntentClassifier()
         dataset_stream = io.StringIO("""
-        ---
-        type: intent
-        name: intent1
-        utterances:
-          - foo bar
+---
+type: intent
+name: intent1
+utterances:
+  - foo bar
 
-        ---
-        type: intent
-        name: intent2
-        utterances:
-          - lorem ipsum""")
+---
+type: intent
+name: intent2
+utterances:
+  - lorem ipsum""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        intent_classifier = LogRegIntentClassifier().fit(dataset)
+        intent_classifier = LogRegIntentClassifier()
 
         # When
         self.assertIsNone(intent_classifier.log_best_features(20))
-        intent_classifier.fit(SAMPLE_DATASET)
+        intent_classifier.fit(dataset)
         log = intent_classifier.log_best_features(20)
 
         # Then

--- a/snips_nlu/tests/test_log_reg_intent_classifier.py
+++ b/snips_nlu/tests/test_log_reg_intent_classifier.py
@@ -395,38 +395,24 @@ utterances:
             self, mocked_build_training):
         # Given
         language = LANGUAGE_EN
-        dataset = {
-            "entities": {
-                "dummy_entity_1": {
-                    "automatically_extensible": True,
-                    "use_synonyms": False,
-                    "data": [
-                        {
-                            "value": "...",
-                            "synonyms": [],
-                        }
-                    ],
-                    "matching_strictness": 1.0
-                }
-            },
-            "intents": {
-                "dummy_intent_1": {
-                    "utterances": [
-                        {
-                            "data": [
-                                {
-                                    "text": "...",
-                                    "slot_name": "dummy_slot_name",
-                                    "entity": "dummy_entity_1"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            },
-            "language": language
-        }
 
+        dataset_stream = io.StringIO("""
+---
+type: intent
+name: dummy_intent_1
+utterances:
+  - "[dummy_slot_name:dummy_entity_1](...)"
+  
+---
+type: entity
+name: dummy_entity_1
+automatically_extensible: true
+use_synonyms: false
+matching_strictness: 1.0
+values:
+  - ...
+""")
+        dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
         text = " "
         noise_size = 6
         utterances = [text] + [text] * noise_size

--- a/snips_nlu/tests/utils.py
+++ b/snips_nlu/tests/utils.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 import tempfile
 import traceback as tb
+from builtins import object
 from contextlib import contextmanager
 from pathlib import Path
 from unittest import TestCase
@@ -12,6 +13,7 @@ from unittest import TestCase
 from snips_nlu_ontology import get_all_languages
 
 from snips_nlu.common.utils import json_string, unicode_string
+from snips_nlu.entity_parser.entity_parser import EntityParser
 from snips_nlu.intent_classifier import IntentClassifier
 from snips_nlu.intent_parser import IntentParser
 from snips_nlu.resources import load_resources
@@ -201,3 +203,24 @@ class MockSlotFiller(SlotFiller):
     def from_path(cls, path, **shared):
         config = cls.config_type()  # pylint:disable=no-value-for-parameter
         return cls(config)
+
+
+class EntityParserMock(EntityParser):
+
+    def __init__(self, entities):
+        super(EntityParserMock, self).__init__()
+        self.entities = entities
+
+    def persist(self, path):
+        with path.open("r", encoding="utf-8") as f:
+            f.write(json_string(self.entities))
+
+    @classmethod
+    def from_path(cls, path):
+        path = Path(path)
+        with path.open("r", encoding="utf-8") as f:
+            entities = json.load(f)
+        return cls(entities)
+
+    def _parse(self, text, scope=None):
+        return self.entities.get(text)


### PR DESCRIPTION
## Goal

During experiments done to improve intent classification, using word cooccurrences as additional features to tf-idf was found to be helpful to improve classification performances in cases where words transitions and/or order is meaningful.

For intance, a model using a bag-of-unigram tf-idf features struggle to differentiate the following utterances: `"turn on the light" (TurnLightsOn)` and `"is the light turned on" (CheckLightsStatus)`.

Adding order cooccurence feature can help in such cases.

## Work done

### 1. Add optional cooccurence features to the intent classification
Transformed the `Featurizer` object into a `ProcessingUnit`. The featurizer now relies on a `TfidfVectorizer` `ProcessingUnit` (wrapping the `sklearn` `TfidfVectorizer`) and optionally on a `CooccurrenceVectorizer`.

The feature extraction works as following:
1. tf-idf features are extracter from the dataset
2. feature selection is applied to select the best feature
3. if configuration `added_cooccurrence_feature_ratio` parameter is `> 0` the cooccurence features will be added. The `CooccurrenceVectorizer` is fitted on all non null utterances and then cooccurrence features are ranked using the same feature selection as for tf-idf features. The `top-k` cooccurence features will be used. `k` is computed using the `added_cooccurrence_feature_ratio` config parameter: if we have `n` tf-idf features then at most `int(n * added_cooccurrence_feature_ratio)` will be added in the feature matrix

*Note*: the order of the words is kept when computing word cooccurrence. Also note that the user can restrict the size of the window in which we'll look for cooccurrence

### 2. Miscellaneoous
- Refactor the `EntityParser` class to make it more generic, and to ease implementation of other entity parsers

**Important note**: this PR is breaking

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
