### PR TITLE
Fix issue when persisting resources

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,13 +134,6 @@ Or simply:
 
     snips-nlu download en
 
-Once the resources have been fetched, they can be loaded in Python using:
-
-.. code-block:: python
-
-    from snips_nlu import load_resources
-
-    load_resources("en")
 
 The list of supported languages is available at 
 `this address <https://snips-nlu.readthedocs.io/en/latest/languages.html>`_.
@@ -183,11 +176,10 @@ installed `snips-nlu`, fetched the english resources and downloaded one of the `
     >>> from __future__ import unicode_literals, print_function
     >>> import io
     >>> import json
-    >>> from snips_nlu import SnipsNLUEngine, load_resources
+    >>> from snips_nlu import SnipsNLUEngine
     >>> from snips_nlu.default_configs import CONFIG_EN
     >>> with io.open("sample_datasets/lights_dataset.json") as f:
     ...     sample_dataset = json.load(f)
-    >>> load_resources("en")
     >>> nlu_engine = SnipsNLUEngine(config=CONFIG_EN)
     >>> nlu_engine = nlu_engine.fit(sample_dataset)
     >>> text = "Please turn the light on in the kitchen"

--- a/debug/debug.py
+++ b/debug/debug.py
@@ -14,8 +14,6 @@ def debug_training(dataset_path, config_path=None):
     with Path(dataset_path).open("r", encoding="utf8") as f:
         dataset = json.load(f)
 
-    load_resources(dataset["language"])
-
     config = None
     if config_path is not None:
         with Path(config_path).open("r", encoding="utf8") as f:

--- a/debug/debug.py
+++ b/debug/debug.py
@@ -6,7 +6,7 @@ import json
 from builtins import input, bytes
 from pathlib import Path
 
-from snips_nlu import SnipsNLUEngine, load_resources
+from snips_nlu import SnipsNLUEngine
 from snips_nlu.pipeline.configs.nlu_engine import NLUEngineConfig
 
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -6,11 +6,6 @@ API reference
 This part of the documentation covers the most important interfaces of the
 Snips NLU package.
 
-Resources
----------
-
-.. autofunction:: snips_nlu.resources.load_resources
-
 
 NLU engine
 ----------

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -32,14 +32,11 @@ The format used here is json, so let's load it into a python dict:
 
 Now that we have our dataset, we can move forward to the next step which is
 building a :class:`.SnipsNLUEngine`. This is the main object of this lib.
-Before training the engine, note that you need to load language-specific
-resources used to improve performance with the :func:`.load_resources` function.
 
 .. code-block:: python
 
-    from snips_nlu import load_resources, SnipsNLUEngine
+    from snips_nlu import SnipsNLUEngine
 
-    load_resources(u"en")
     nlu_engine = SnipsNLUEngine()
 
 Now that we have our engine object created, we need to feed it with our sample

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -139,18 +139,13 @@ We have built a list of `default configurations`_, one per supported language,
 that have some language specific enhancements. In this tutorial we will use the
 `english one`_.
 
-Before training the engine, note that you need to load language specific
-resources used to improve performance with the :func:`.load_resources` function.
-
 .. code-block:: python
 
     import io
     import json
 
-    from snips_nlu import SnipsNLUEngine, load_resources
+    from snips_nlu import SnipsNLUEngine
     from snips_nlu.default_configs import CONFIG_EN
-
-    load_resources(u"en")
 
     engine = SnipsNLUEngine(config=CONFIG_EN)
 

--- a/snips_nlu/cli/download.py
+++ b/snips_nlu/cli/download.py
@@ -77,16 +77,11 @@ def _download_and_link(resource_alias, resource_fullname, compatibility,
             resources_path=package_path)
         if verbose:
             pretty_print("%s --> %s" % (str(resources_dir), str(link_path)),
-                         "You can now load the resources via "
-                         "snips_nlu.load_resources('%s')" % resource_alias,
                          title="Linking successful",
                          level=PrettyPrintLevel.SUCCESS)
     except:  # pylint:disable=bare-except
         pretty_print(
-            "Creating a shortcut link for '{r}' didn't work.\nYou can "
-            "still load the resources using the full package name: "
-            "snips_nlu.load_resources('{n}')".format(r=resource_alias,
-                                                     n=resource_fullname),
+            "Creating a shortcut link for '%s' didn't work." % resource_alias,
             title="The language resources were successfully downloaded, "
                   "however linking failed.",
             level=PrettyPrintLevel.WARNING)

--- a/snips_nlu/cli/metrics.py
+++ b/snips_nlu/cli/metrics.py
@@ -2,12 +2,11 @@ from __future__ import print_function, unicode_literals
 
 import json
 import logging
-
 from pathlib import Path
 
 import plac
 
-from snips_nlu import SnipsNLUEngine, load_resources
+from snips_nlu import SnipsNLUEngine
 from snips_nlu.cli.utils import set_nlu_logger
 from snips_nlu.common.utils import json_string
 
@@ -69,9 +68,6 @@ def cross_val_metrics(dataset_path, output_path, config_path=None, nb_folds=5,
         include_slot_metrics=not exclude_slot_metrics,
     )
 
-    with Path(dataset_path).open("r", encoding="utf8") as f:
-        load_resources(json.load(f)["language"])
-
     from snips_nlu_metrics import compute_cross_val_metrics
 
     metrics = compute_cross_val_metrics(**metrics_args)
@@ -114,9 +110,6 @@ def train_test_metrics(train_dataset_path, test_dataset_path, output_path,
         engine_class=engine_cls,
         include_slot_metrics=not exclude_slot_metrics
     )
-
-    with Path(train_dataset_path).open("r", encoding="utf8") as f:
-        load_resources(json.load(f)["language"])
 
     from snips_nlu_metrics import compute_train_test_metrics
 

--- a/snips_nlu/cli/training.py
+++ b/snips_nlu/cli/training.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import plac
 
-from snips_nlu import SnipsNLUEngine, load_resources
+from snips_nlu import SnipsNLUEngine
 from snips_nlu.cli.utils import set_nlu_logger
 
 
@@ -29,7 +29,6 @@ def train(dataset_path, output_path, config_path, verbose):
         with Path(config_path).open("r", encoding="utf8") as f:
             config = json.load(f)
 
-    load_resources(dataset["language"])
     print("Create and train the engine...")
     engine = SnipsNLUEngine(config).fit(dataset)
 

--- a/snips_nlu/common/utils.py
+++ b/snips_nlu/common/utils.py
@@ -3,13 +3,14 @@ from __future__ import unicode_literals
 import importlib
 import json
 import numbers
-from builtins import bytes
+from builtins import bytes as newbytes, str as newstr
 from datetime import datetime
 from functools import wraps
 from pathlib import Path
 
 import numpy as np
 import pkg_resources
+from future.utils import PY3
 
 from snips_nlu.constants import (
     END, START, RES_MATCH_RANGE, ENTITY_KIND, RES_VALUE)
@@ -93,7 +94,21 @@ def json_string(json_object, indent=2, sort_keys=True):
 
 
 def unicode_string(string):
-    return bytes(string, encoding="utf8").decode("utf8")
+    if PY3:
+        unicode_type = str
+    else:
+        unicode_type = unicode
+
+    if isinstance(string, unicode_type):
+        return string
+    if isinstance(string, bytes):
+        return string.decode("utf8")
+    if isinstance(string, newstr):
+        return unicode_type(string)
+    if isinstance(string, newbytes):
+        string = bytes(string).decode("utf8")
+
+    raise TypeError("Cannot convert %s into unicode string" % type(string))
 
 
 def check_persisted_path(func):

--- a/snips_nlu/constants.py
+++ b/snips_nlu/constants.py
@@ -48,6 +48,8 @@ CUSTOM_ENTITY_PARSER = "custom_entity_parser"
 MATCHING_STRICTNESS = "matching_strictness"
 
 # resources
+RESOURCES = "resources"
+METADATA = "metadata"
 STOP_WORDS = "stop_words"
 NOISE = "noise"
 GAZETTEERS = "gazetteers"
@@ -55,7 +57,6 @@ STEMS = "stems"
 CUSTOM_ENTITY_PARSER_USAGE = "custom_entity_parser_usage"
 WORD_CLUSTERS = "word_clusters"
 GAZETTEER_ENTITIES = "gazetteer_entities"
-RESOURCES_DIR = "resources_dir"
 
 # builtin entities
 SNIPS_AMOUNT_OF_MONEY = "snips/amountOfMoney"

--- a/snips_nlu/data_augmentation.py
+++ b/snips_nlu/data_augmentation.py
@@ -16,15 +16,16 @@ from snips_nlu.preprocessing import tokenize_light
 from snips_nlu.resources import get_stop_words
 
 
-def capitalize(text, language):
+def capitalize(text, language, resources):
     tokens = tokenize_light(text, language)
-    stop_words = get_stop_words(language)
+    stop_words = get_stop_words(resources)
     return get_default_sep(language).join(
         t.title() if t.lower() not in stop_words
         else t.lower() for t in tokens)
 
 
-def capitalize_utterances(utterances, entities, language, ratio, random_state):
+def capitalize_utterances(utterances, entities, language, ratio, resources,
+                          random_state):
     capitalized_utterances = []
     for utterance in utterances:
         capitalized_utterance = deepcopy(utterance)
@@ -40,7 +41,7 @@ def capitalize_utterances(utterances, entities, language, ratio, random_state):
             if random_state.rand() > ratio:
                 continue
             capitalized_utterance[DATA][i][TEXT] = capitalize(
-                chunk[TEXT], language)
+                chunk[TEXT], language, resources)
         capitalized_utterances.append(capitalized_utterance)
     return capitalized_utterances
 
@@ -97,7 +98,7 @@ def num_queries_to_generate(dataset, intent_name, min_utterances):
 
 def augment_utterances(dataset, intent_name, language, min_utterances,
                        capitalization_ratio, add_builtin_entities_examples,
-                       random_state):
+                       resources, random_state):
     contexts_it = get_contexts_iterator(dataset, intent_name, random_state)
     intent_entities = {e: dataset[ENTITIES][e]
                        for e in get_intent_entities(dataset, intent_name)}
@@ -114,6 +115,7 @@ def augment_utterances(dataset, intent_name, language, min_utterances,
 
     generated_utterances = capitalize_utterances(
         generated_utterances, dataset[ENTITIES], language,
-        ratio=capitalization_ratio, random_state=random_state)
+        ratio=capitalization_ratio, resources=resources,
+        random_state=random_state)
 
     return generated_utterances

--- a/snips_nlu/entity_parser/custom_entity_parser.py
+++ b/snips_nlu/entity_parser/custom_entity_parser.py
@@ -74,7 +74,7 @@ class CustomEntityParser(EntityParser):
         return cls(parser, language, parser_usage)
 
     @classmethod
-    def build(cls, dataset, parser_usage):
+    def build(cls, dataset, parser_usage, resources):
         from snips_nlu.dataset import validate_and_format_dataset
 
         dataset = validate_and_format_dataset(dataset)
@@ -87,13 +87,13 @@ class CustomEntityParser(EntityParser):
         if parser_usage == CustomEntityParserUsage.WITH_AND_WITHOUT_STEMS:
             for ent in viewvalues(custom_entities):
                 stemmed_utterances = _stem_entity_utterances(
-                    ent[UTTERANCES], language)
+                    ent[UTTERANCES], language, resources)
                 ent[UTTERANCES] = _merge_entity_utterances(
                     ent[UTTERANCES], stemmed_utterances)
         elif parser_usage == CustomEntityParserUsage.WITH_STEMS:
             for ent in viewvalues(custom_entities):
                 ent[UTTERANCES] = _stem_entity_utterances(
-                    ent[UTTERANCES], language)
+                    ent[UTTERANCES], language, resources)
         elif parser_usage is None:
             raise ValueError("A parser usage must be defined in order to fit "
                              "a CustomEntityParser")
@@ -103,12 +103,12 @@ class CustomEntityParser(EntityParser):
         return cls(parser, language, parser_usage)
 
 
-def _stem_entity_utterances(entity_utterances, language):
+def _stem_entity_utterances(entity_utterances, language, resources):
     values = dict()
     # Sort by resolved value, so that values conflict in a deterministic way
     for raw_value, resolved_value in sorted(
             iteritems(entity_utterances), key=operator.itemgetter(1)):
-        stemmed_value = stem(raw_value, language)
+        stemmed_value = stem(raw_value, language, resources)
         if stemmed_value not in values:
             values[stemmed_value] = resolved_value
     return values

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -30,7 +30,7 @@ from snips_nlu.pipeline.configs.intent_classifier import (
 from snips_nlu.pipeline.processing_unit import ProcessingUnit
 from snips_nlu.preprocessing import stem, tokenize_light
 from snips_nlu.resources import (
-    get_stop_words, get_word_cluster)
+    get_stop_words, get_word_cluster, load_resources)
 from snips_nlu.slot_filler.features_utils import get_all_ngrams
 
 
@@ -746,11 +746,6 @@ class CooccurrenceVectorizer(ProcessingUnit):
         return self
 
 
-def _get_tokens_clusters(tokens, language, cluster_name):
-    clusters = get_word_cluster(language, cluster_name)
-    return [clusters[t] for t in tokens if t in clusters]
-
-
 def _entity_name_to_feature(entity_name, language):
     return "entityfeature%s" % "".join(tokenize_light(
         entity_name.lower(), language))
@@ -761,19 +756,19 @@ def _builtin_entity_to_feature(builtin_entity_label, language):
         builtin_entity_label.lower(), language))
 
 
-def _normalize_stem(text, language, use_stemming):
+def _normalize_stem(text, language, resources, use_stemming):
     if use_stemming:
-        return stem(text, language)
+        return stem(text, language, resources)
     return normalize(text)
 
 
-def _get_word_cluster_features(query_tokens, clusters_name, language):
+def _get_word_cluster_features(query_tokens, clusters_name, resources):
     if not clusters_name:
         return []
     ngrams = get_all_ngrams(query_tokens)
     cluster_features = []
     for ngram in ngrams:
-        cluster = get_word_cluster(language, clusters_name).get(
+        cluster = get_word_cluster(resources, clusters_name).get(
             ngram[NGRAM].lower(), None)
         if cluster is not None:
             cluster_features.append(cluster)

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -55,7 +55,7 @@ class LogRegIntentClassifier(IntentClassifier):
     @log_elapsed_time(logger, logging.DEBUG,
                       "LogRegIntentClassifier in {elapsed_time}")
     def fit(self, dataset):
-        """Fit the intent classifier with a valid Snips dataset
+        """Fits the intent classifier with a valid Snips dataset
 
         Returns:
             :class:`LogRegIntentClassifier`: The same instance, trained
@@ -191,7 +191,7 @@ class LogRegIntentClassifier(IntentClassifier):
 
     @check_persisted_path
     def persist(self, path):
-        """Persist the object at the given path"""
+        """Persists the object at the given path"""
         path = Path(path)
         path.mkdir()
 
@@ -225,7 +225,7 @@ class LogRegIntentClassifier(IntentClassifier):
 
     @classmethod
     def from_path(cls, path, **shared):
-        """Load a :class:`LogRegIntentClassifier` instance from a path
+        """Loads a :class:`LogRegIntentClassifier` instance from a path
 
         The data at the given path must have been generated using
         :func:`~LogRegIntentClassifier.persist`

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -62,6 +62,7 @@ class LogRegIntentClassifier(IntentClassifier):
         """
         logger.debug("Fitting LogRegIntentClassifier...")
         dataset = validate_and_format_dataset(dataset)
+        self.load_resources_if_needed(dataset[LANGUAGE])
         self.fit_builtin_entity_parser_if_needed(dataset)
         self.fit_custom_entity_parser_if_needed(dataset)
         language = dataset[LANGUAGE]
@@ -69,7 +70,8 @@ class LogRegIntentClassifier(IntentClassifier):
 
         data_augmentation_config = self.config.data_augmentation_config
         utterances, classes, intent_list = build_training_data(
-            dataset, language, data_augmentation_config, random_state)
+            dataset, language, data_augmentation_config, self.resources,
+            random_state)
 
         self.intent_list = intent_list
         if len(self.intent_list) <= 1:
@@ -78,7 +80,8 @@ class LogRegIntentClassifier(IntentClassifier):
         self.featurizer = Featurizer(
             config=self.config.featurizer_config,
             builtin_entity_parser=self.builtin_entity_parser,
-            custom_entity_parser=self.custom_entity_parser
+            custom_entity_parser=self.custom_entity_parser,
+            resources=self.resources
         )
         self.featurizer.language = language
 

--- a/snips_nlu/intent_classifier/log_reg_classifier_utils.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier_utils.py
@@ -108,7 +108,7 @@ def add_unknown_word_to_utterances(utterances, replacement_string,
     return new_utterances
 
 
-def get_dataset_specific_noise(dataset, language):
+def get_dataset_specific_noise(dataset, resources):
     """Return a noise list that excludes the dataset entity values"""
     entities_values = set()
     for ent_name, ent in iteritems(dataset[ENTITIES]):
@@ -117,14 +117,14 @@ def get_dataset_specific_noise(dataset, language):
         for k, v in iteritems(ent[UTTERANCES]):
             entities_values.add(k)
             entities_values.add(v)
-    original_noise = get_noise(language)
+    original_noise = get_noise(resources)
     specific_noise = [n for n in original_noise if n not in entities_values]
     if not specific_noise:  # Avoid returning an empty noise
         return original_noise
     return specific_noise
 
 
-def build_training_data(dataset, language, data_augmentation_config,
+def build_training_data(dataset, language, data_augmentation_config, resources,
                         random_state):
     # Create class mapping
     intents = dataset[INTENTS]
@@ -150,7 +150,7 @@ def build_training_data(dataset, language, data_augmentation_config,
             capitalization_ratio=0.0,
             add_builtin_entities_examples=
             data_augmentation_config.add_builtin_entities_examples,
-            random_state=random_state)
+            resources=resources, random_state=random_state)
         augmented_utterances += utterances
         utterance_classes += [classes_mapping[intent_name] for _ in
                               range(len(utterances))]
@@ -164,7 +164,7 @@ def build_training_data(dataset, language, data_augmentation_config,
         )
 
     # Adding noise
-    noise = get_dataset_specific_noise(dataset, language)
+    noise = get_dataset_specific_noise(dataset, resources)
     noisy_utterances = generate_noise_utterances(
         augmented_utterances, noise, len(intents), data_augmentation_config,
         language, random_state)

--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -124,7 +124,7 @@ class DeterministicIntentParser(IntentParser):
     @log_elapsed_time(
         logger, logging.INFO, "Fitted deterministic parser in {elapsed_time}")
     def fit(self, dataset, force_retrain=True):
-        """Fit the intent parser with a valid Snips dataset"""
+        """Fits the intent parser with a valid Snips dataset"""
         logger.info("Fitting deterministic parser...")
         dataset = validate_and_format_dataset(dataset)
         self.fit_builtin_entity_parser_if_needed(dataset)
@@ -262,7 +262,7 @@ class DeterministicIntentParser(IntentParser):
 
     @fitted_required
     def get_slots(self, text, intent):
-        """Extract slots from a text input, with the knowledge of the intent
+        """Extracts slots from a text input, with the knowledge of the intent
 
         Args:
             text (str): input
@@ -286,7 +286,7 @@ class DeterministicIntentParser(IntentParser):
         return slots
 
     def _preprocess_text(self, string):
-        """Replace stop words and characters that are tokenized out by
+        """Replaces stop words and characters that are tokenized out by
             whitespaces"""
         tokens = tokenize(string, self.language)
         current_idx = 0
@@ -373,7 +373,7 @@ class DeterministicIntentParser(IntentParser):
 
     @check_persisted_path
     def persist(self, path):
-        """Persist the object at the given path"""
+        """Persists the object at the given path"""
         path = Path(path)
         path.mkdir()
         parser_json = json_string(self.to_dict())
@@ -385,7 +385,7 @@ class DeterministicIntentParser(IntentParser):
 
     @classmethod
     def from_path(cls, path, **shared):
-        """Load a :class:`DeterministicIntentParser` instance from a path
+        """Loads a :class:`DeterministicIntentParser` instance from a path
 
         The data at the given path must have been generated using
         :func:`~DeterministicIntentParser.persist`

--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -10,8 +10,14 @@ from pathlib import Path
 from future.utils import iteritems, iterkeys, itervalues
 from snips_nlu_utils import normalize
 
+from snips_nlu.common.dataset_utils import get_slot_name_mappings
+from snips_nlu.common.log_utils import log_elapsed_time, log_result
+from snips_nlu.common.utils import (
+    check_persisted_path, deduplicate_overlapping_items, fitted_required,
+    json_string, ranges_overlap, regex_escape,
+    replace_entities_with_placeholders)
 from snips_nlu.constants import (
-    BUILTIN_ENTITY_PARSER, CUSTOM_ENTITY_PARSER, DATA, END, ENTITIES, ENTITY,
+    DATA, END, ENTITIES, ENTITY,
     INTENTS, LANGUAGE, RES_INTENT, RES_INTENT_NAME,
     RES_MATCH_RANGE, RES_SLOTS, RES_VALUE, SLOT_NAME, START, TEXT, UTTERANCES)
 from snips_nlu.dataset import validate_and_format_dataset
@@ -24,12 +30,7 @@ from snips_nlu.resources import get_stop_words
 from snips_nlu.result import (empty_result, extraction_result,
                               intent_classification_result, parsing_result,
                               unresolved_slot)
-from snips_nlu.common.utils import (
-    check_persisted_path, deduplicate_overlapping_items, fitted_required,
-    json_string, ranges_overlap, regex_escape,
-    replace_entities_with_placeholders)
-from snips_nlu.common.dataset_utils import get_slot_name_mappings
-from snips_nlu.common.log_utils import log_elapsed_time, log_result
+
 WHITESPACE_PATTERN = r"\s*"
 
 logger = logging.getLogger(__name__)
@@ -69,7 +70,7 @@ class DeterministicIntentParser(IntentParser):
             self.stop_words = None
         else:
             if self.config.ignore_stop_words:
-                self.stop_words = get_stop_words(self.language)
+                self.stop_words = get_stop_words(self.resources)
             else:
                 self.stop_words = set()
 
@@ -417,11 +418,7 @@ class DeterministicIntentParser(IntentParser):
         :func:`~DeterministicIntentParser.to_dict`
         """
         config = cls.config_type.from_dict(unit_dict["config"])
-        parser = cls(
-            config=config,
-            builtin_entity_parser=shared.get(BUILTIN_ENTITY_PARSER),
-            custom_entity_parser=shared.get(CUSTOM_ENTITY_PARSER),
-        )
+        parser = cls(config=config, **shared)
         parser.patterns = unit_dict["patterns"]
         parser.language = unit_dict["language_code"]
         parser.group_names_to_slot_names = unit_dict[

--- a/snips_nlu/intent_parser/probabilistic_intent_parser.py
+++ b/snips_nlu/intent_parser/probabilistic_intent_parser.py
@@ -50,7 +50,7 @@ class ProbabilisticIntentParser(IntentParser):
                       "Fitted probabilistic intent parser in {elapsed_time}")
     # pylint:disable=arguments-differ
     def fit(self, dataset, force_retrain=True):
-        """Fit the slot filler
+        """Fits the probabilistic intent parser
 
         Args:
             dataset (dict): A valid Snips dataset
@@ -159,7 +159,7 @@ class ProbabilisticIntentParser(IntentParser):
 
     @fitted_required
     def get_slots(self, text, intent):
-        """Extract slots from a text input, with the knowledge of the intent
+        """Extracts slots from a text input, with the knowledge of the intent
 
         Args:
             text (str): input
@@ -181,7 +181,7 @@ class ProbabilisticIntentParser(IntentParser):
 
     @check_persisted_path
     def persist(self, path):
-        """Persist the object at the given path"""
+        """Persists the object at the given path"""
         path = Path(path)
         path.mkdir()
         sorted_slot_fillers = sorted(iteritems(self.slot_fillers))
@@ -209,7 +209,7 @@ class ProbabilisticIntentParser(IntentParser):
 
     @classmethod
     def from_path(cls, path, **shared):
-        """Load a :class:`ProbabilisticIntentParser` instance from a path
+        """Loads a :class:`ProbabilisticIntentParser` instance from a path
 
         The data at the given path must have been generated using
         :func:`~ProbabilisticIntentParser.persist`

--- a/snips_nlu/intent_parser/probabilistic_intent_parser.py
+++ b/snips_nlu/intent_parser/probabilistic_intent_parser.py
@@ -12,7 +12,7 @@ from future.utils import iteritems, itervalues
 from snips_nlu.common.log_utils import log_elapsed_time, log_result
 from snips_nlu.common.utils import (
     check_persisted_path, elapsed_since, fitted_required, json_string)
-from snips_nlu.constants import INTENTS, RES_INTENT_NAME, LANGUAGE
+from snips_nlu.constants import INTENTS, RES_INTENT_NAME
 from snips_nlu.dataset import validate_and_format_dataset
 from snips_nlu.exceptions import IntentNotFoundError
 from snips_nlu.intent_classifier import IntentClassifier

--- a/snips_nlu/nlu_engine/nlu_engine.py
+++ b/snips_nlu/nlu_engine/nlu_engine.py
@@ -80,7 +80,7 @@ class SnipsNLUEngine(ProcessingUnit):
     @log_elapsed_time(
         logger, logging.INFO, "Fitted NLU engine in {elapsed_time}")
     def fit(self, dataset, force_retrain=True):
-        """Fit the NLU engine
+        """Fits the NLU engine
 
         Args:
             dataset (dict): A valid Snips dataset
@@ -217,7 +217,7 @@ class SnipsNLUEngine(ProcessingUnit):
     @log_elapsed_time(logger, logging.DEBUG, "Parsed slots in {elapsed_time}")
     @fitted_required
     def get_slots(self, text, intent):
-        """Extract slots from a text input, with the knowledge of the intent
+        """Extracts slots from a text input, with the knowledge of the intent
 
         Args:
             text (str): input
@@ -250,7 +250,7 @@ class SnipsNLUEngine(ProcessingUnit):
 
     @check_persisted_path
     def persist(self, path):
-        """Persist the NLU engine at the given directory path
+        """Persists the NLU engine at the given directory path
 
         Args:
             path (str): the location at which the nlu engine must be persisted.
@@ -313,7 +313,7 @@ class SnipsNLUEngine(ProcessingUnit):
 
     @classmethod
     def from_path(cls, path, **shared):
-        """Load a :class:`SnipsNLUEngine` instance from a directory path
+        """Loads a :class:`SnipsNLUEngine` instance from a directory path
 
         The data at the given path must have been generated using
         :func:`~SnipsNLUEngine.persist`

--- a/snips_nlu/pipeline/configs/intent_classifier.py
+++ b/snips_nlu/pipeline/configs/intent_classifier.py
@@ -34,6 +34,8 @@ class LogRegIntentClassifierConfig(FromDict, ProcessingUnitConfig):
         self.featurizer_config = featurizer_config
         self.random_seed = random_seed
 
+    # pylint: enable=line-too-long
+
     @property
     def data_augmentation_config(self):
         return self._data_augmentation_config
@@ -158,11 +160,11 @@ class FeaturizerConfig(FromDict, ProcessingUnitConfig):
             pvalue_threshold (float): after fitting the training set to
                 extract tfidf features, a univariate feature selection is
                 applied. Features are tested for independence using a Chi-2
-                test, under the null hypothesis that the each feature should be
+                test, under the null hypothesis that each feature should be
                 equally present in each class. Only features having a p-value
-                lower that the threshold are kept
+                lower than the threshold are kept
             added_cooccurrence_feature_ratio (float, optional): proportion of
-                cooccurrence features to add with respect of the number of
+                cooccurrence features to add with respect to the number of
                 tfidf features. For instance with a ratio of 0.5, if 100 tfidf
                 features are remaining after feature selection, a maximum of 50
                 cooccurrence features will be added
@@ -184,6 +186,8 @@ class FeaturizerConfig(FromDict, ProcessingUnitConfig):
             cooccurrence_vectorizer_config = CooccurrenceVectorizerConfig \
                 .from_dict(cooccurrence_vectorizer_config)
         self.cooccurrence_vectorizer_config = cooccurrence_vectorizer_config
+
+    # pylint: enable=line-too-long
 
     @property
     def unit_name(self):
@@ -253,14 +257,14 @@ class CooccurrenceVectorizerConfig(FromDict, ProcessingUnitConfig):
                  filter_stop_words=True):
         """
         Args:
-            window_size (int, optional): if provided word cooccurrences will be
-                taken into account only in a context window of size
+            window_size (int, optional): if provided, word cooccurrences will
+                be taken into account only in a context window of size
                 :attr:`window_size`. If the window size is 3 then given a word
                 w[i], the vectorizer will only extract the following pairs:
                 (w[i], w[i + 1]), (w[i], w[i + 2]) and (w[i], w[i + 3]).
                 Defaults to None, which means that we consider all words
             unknown_words_replacement_string (str, optional)
-            filter_stop_words (bool, optional): if True, stop words are ignore
+            filter_stop_words (bool, optional): if True, stop words are ignored
                 when computing cooccurrences
         """
         self.window_size = window_size

--- a/snips_nlu/pipeline/configs/intent_classifier.py
+++ b/snips_nlu/pipeline/configs/intent_classifier.py
@@ -236,6 +236,7 @@ class TfidfVectorizerConfig(FromDict, ProcessingUnitConfig):
         resources = {STEMS: True if self.use_stemming else False}
         if self.word_clusters_name:
             resources[WORD_CLUSTERS] = self.word_clusters_name
+        return resources
 
     def to_dict(self):
         return {

--- a/snips_nlu/pipeline/configs/intent_classifier.py
+++ b/snips_nlu/pipeline/configs/intent_classifier.py
@@ -276,10 +276,10 @@ class CooccurrenceVectorizerConfig(FromDict, ProcessingUnitConfig):
         return {
             STOP_WORDS: self.filter_stop_words,
             # We require the parser to be trained without stems because we
-            # don't normalized and stem when processing in the
+            # don't normalize and stem when processing in the
             # CooccurrenceVectorizer (in order to run the builtin and
             # custom parser on the same unormalized input).
-            # Requiring no stems ensure we'll be able to parse the unstemmed
+            # Requiring no stems ensures we'll be able to parse the unstemmed
             # input
             CUSTOM_ENTITY_PARSER_USAGE: CustomEntityParserUsage.WITHOUT_STEMS
         }

--- a/snips_nlu/pipeline/processing_unit.py
+++ b/snips_nlu/pipeline/processing_unit.py
@@ -117,7 +117,10 @@ class ProcessingUnit(with_metaclass(ABCMeta, Registrable)):
 
     def load_resources_if_needed(self, language):
         if self.resources is None or self.fitted:
-            self.resources = load_resources(language)
+            required_resources = None
+            if self.config is not None:
+                required_resources = self.config.get_required_resources()
+            self.resources = load_resources(language, required_resources)
 
     def fit_builtin_entity_parser_if_needed(self, dataset):
         # We only fit a builtin entity parser when the unit has already been

--- a/snips_nlu/pipeline/processing_unit.py
+++ b/snips_nlu/pipeline/processing_unit.py
@@ -9,13 +9,15 @@ from pathlib import Path
 
 from future.utils import with_metaclass
 
+from snips_nlu.resources import load_resources
 from snips_nlu.common.abc_utils import abstractclassmethod, classproperty
 from snips_nlu.common.io_utils import temp_dir, unzip_archive
 from snips_nlu.common.registrable import Registrable
 from snips_nlu.common.utils import (
     json_string)
 from snips_nlu.constants import (
-    BUILTIN_ENTITY_PARSER, CUSTOM_ENTITY_PARSER, CUSTOM_ENTITY_PARSER_USAGE)
+    BUILTIN_ENTITY_PARSER, CUSTOM_ENTITY_PARSER, CUSTOM_ENTITY_PARSER_USAGE,
+    RESOURCES, LANGUAGE)
 from snips_nlu.entity_parser import (
     BuiltinEntityParser, CustomEntityParser, CustomEntityParserUsage)
 from snips_nlu.pipeline.configs import ProcessingUnitConfig
@@ -45,6 +47,7 @@ class ProcessingUnit(with_metaclass(ABCMeta, Registrable)):
             self.config.set_unit_name(self.unit_name)
         self.builtin_entity_parser = shared.get(BUILTIN_ENTITY_PARSER)
         self.custom_entity_parser = shared.get(CUSTOM_ENTITY_PARSER)
+        self.resources = shared.get(RESOURCES)
 
     @classproperty
     def config_type(cls):  # pylint:disable=no-self-argument
@@ -112,6 +115,10 @@ class ProcessingUnit(with_metaclass(ABCMeta, Registrable)):
         """Whether or not the processing unit has already been trained"""
         pass
 
+    def load_resources_if_needed(self, language):
+        if self.resources is None or self.fitted:
+            self.resources = load_resources(language)
+
     def fit_builtin_entity_parser_if_needed(self, dataset):
         # We only fit a builtin entity parser when the unit has already been
         # fitted or if the parser is none.
@@ -135,8 +142,9 @@ class ProcessingUnit(with_metaclass(ABCMeta, Registrable)):
             parser_usage = required_resources[CUSTOM_ENTITY_PARSER_USAGE]
 
         if self.custom_entity_parser is None or self.fitted:
+            self.load_resources_if_needed(dataset[LANGUAGE])
             self.custom_entity_parser = CustomEntityParser.build(
-                dataset, parser_usage)
+                dataset, parser_usage, self.resources)
         return self
 
     def persist_metadata(self, path, **kwargs):

--- a/snips_nlu/preprocessing.py
+++ b/snips_nlu/preprocessing.py
@@ -9,19 +9,19 @@ from snips_nlu_utils import (
 from snips_nlu.resources import get_stems
 
 
-def stem(string, language):
+def stem(string, language, resources):
     normalized_string = normalize(string)
     tokens = tokenize_light(normalized_string, language)
-    stemmed_tokens = [_stem(token, language) for token in tokens]
+    stemmed_tokens = [_stem(token, resources) for token in tokens]
     return " ".join(stemmed_tokens)
 
 
-def stem_token(token, language):
+def stem_token(token, resources):
     if token.stemmed_value:
         return token.stemmed_value
     if not token.normalized_value:
         token.normalized_value = normalize(token.value)
-    token.stemmed_value = _stem(token.normalized_value, language)
+    token.stemmed_value = _stem(token.normalized_value, resources)
     return token.stemmed_value
 
 
@@ -32,8 +32,8 @@ def normalize_token(token):
     return token.normalized_value
 
 
-def _stem(string, language):
-    return get_stems(language).get(string, string)
+def _stem(string, resources):
+    return get_stems(resources).get(string, string)
 
 
 class Token(object):

--- a/snips_nlu/slot_filler/crf_slot_filler.py
+++ b/snips_nlu/slot_filler/crf_slot_filler.py
@@ -100,7 +100,7 @@ class CRFSlotFiller(SlotFiller):
                       "Fitted CRFSlotFiller in {elapsed_time}")
     # pylint:disable=arguments-differ
     def fit(self, dataset, intent):
-        """Fit the slot filler
+        """Fits the slot filler
 
         Args:
             dataset (dict): A valid Snips dataset
@@ -199,7 +199,7 @@ class CRFSlotFiller(SlotFiller):
         return self._augment_slots(text, tokens, tags, builtin_slots_names)
 
     def compute_features(self, tokens, drop_out=False):
-        """Compute features on the provided tokens
+        """Computes features on the provided tokens
 
         The *drop_out* parameters allows to activate drop out on features that
         have a positive drop out ratio. This should only be used during
@@ -254,7 +254,7 @@ class CRFSlotFiller(SlotFiller):
 
     @fitted_required
     def log_weights(self):
-        """Return a logs for both the label-to-label and label-to-features
+        """Returns a logs for both the label-to-label and label-to-features
          weights"""
         if not self.slot_name_mapping:
             return "No weights to display: intent '%s' has no slots" \
@@ -335,7 +335,7 @@ class CRFSlotFiller(SlotFiller):
 
     @check_persisted_path
     def persist(self, path):
-        """Persist the object at the given path"""
+        """Persists the object at the given path"""
         path = Path(path)
         path.mkdir()
 
@@ -360,7 +360,7 @@ class CRFSlotFiller(SlotFiller):
 
     @classmethod
     def from_path(cls, path, **shared):
-        """Load a :class:`CRFSlotFiller` instance from a path
+        """Loads a :class:`CRFSlotFiller` instance from a path
 
         The data at the given path must have been generated using
         :func:`~CRFSlotFiller.persist`
@@ -523,14 +523,15 @@ def _crf_model_from_path(crf_model_path):
 
 # pylint: disable=invalid-name
 def _ensure_safe(X, Y):
-    """Ensure that Y has at least one not empty label, otherwise the CRF model
+    """Ensures that Y has at least one not empty label, otherwise the CRF model
     does not contain any label and crashes at
+
     Args:
         X: features
         Y: labels
 
-    Returns: (safe_X, safe_Y) a pair of safe features and labels
-
+    Returns:
+        (safe_X, safe_Y): a pair of safe features and labels
     """
     safe_X = list(X)
     safe_Y = list(Y)

--- a/snips_nlu/slot_filler/crf_slot_filler.py
+++ b/snips_nlu/slot_filler/crf_slot_filler.py
@@ -14,6 +14,14 @@ from pathlib import Path
 from future.utils import iteritems
 from sklearn_crfsuite import CRF
 
+from snips_nlu.common.dataset_utils import get_slot_name_mapping
+from snips_nlu.common.dict_utils import UnupdatableDict
+from snips_nlu.common.io_utils import mkdir_p
+from snips_nlu.common.log_utils import DifferedLoggingMessage, log_elapsed_time
+from snips_nlu.common.utils import (
+    check_persisted_path,
+    check_random_state, fitted_required, json_string,
+    ranges_overlap)
 from snips_nlu.constants import (
     DATA, END, ENTITY_KIND, LANGUAGE, RES_ENTITY,
     RES_MATCH_RANGE, RES_VALUE, START)
@@ -28,14 +36,6 @@ from snips_nlu.slot_filler.crf_utils import (
 from snips_nlu.slot_filler.feature import TOKEN_NAME
 from snips_nlu.slot_filler.feature_factory import CRFFeatureFactory
 from snips_nlu.slot_filler.slot_filler import SlotFiller
-from snips_nlu.common.utils import (
-    check_persisted_path,
-    check_random_state, fitted_required, json_string,
-    ranges_overlap)
-from snips_nlu.common.dataset_utils import get_slot_name_mapping
-from snips_nlu.common.log_utils import DifferedLoggingMessage, log_elapsed_time
-from snips_nlu.common.io_utils import mkdir_p
-from snips_nlu.common.dict_utils import UnupdatableDict
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ class CRFSlotFiller(SlotFiller):
         super(CRFSlotFiller, self).__init__(config, **shared)
         self.crf_model = None
         self.features_factories = [
-            CRFFeatureFactory.from_config(conf)
+            CRFFeatureFactory.from_config(conf, **shared)
             for conf in self.config.feature_factory_configs]
         self._features = None
         self.language = None
@@ -70,8 +70,7 @@ class CRFSlotFiller(SlotFiller):
             self._features = []
             feature_names = set()
             for factory in self.features_factories:
-                for feature in factory.build_features(
-                        self.builtin_entity_parser, self.custom_entity_parser):
+                for feature in factory.build_features():
                     if feature.name in feature_names:
                         raise KeyError("Duplicated feature: %s" % feature.name)
                     feature_names.add(feature.name)
@@ -113,8 +112,15 @@ class CRFSlotFiller(SlotFiller):
         """
         logger.debug("Fitting %s slot filler...", intent)
         dataset = validate_and_format_dataset(dataset)
+        self.load_resources_if_needed(dataset[LANGUAGE])
         self.fit_builtin_entity_parser_if_needed(dataset)
         self.fit_custom_entity_parser_if_needed(dataset)
+
+        for factory in self.features_factories:
+            factory.custom_entity_parser = self.custom_entity_parser
+            factory.builtin_entity_parser = self.builtin_entity_parser
+            factory.resources = self.resources
+
         self.language = dataset[LANGUAGE]
         self.intent = intent
         self.slot_name_mapping = get_slot_name_mapping(dataset, intent)
@@ -126,7 +132,7 @@ class CRFSlotFiller(SlotFiller):
         random_state = check_random_state(self.config.random_seed)
         augmented_intent_utterances = augment_utterances(
             dataset, self.intent, language=self.language,
-            random_state=random_state,
+            resources=self.resources, random_state=random_state,
             **self.config.data_augmentation_config.to_dict())
 
         crf_samples = [

--- a/snips_nlu/tests/test_builtin_entity_parser.py
+++ b/snips_nlu/tests/test_builtin_entity_parser.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from mock import patch
 from snips_nlu_ontology import get_all_languages
 
-from snips_nlu.constants import ENTITIES, ENTITY_KIND, LANGUAGE
+from snips_nlu.constants import ENTITIES, LANGUAGE
 from snips_nlu.entity_parser.builtin_entity_parser import (
     BuiltinEntityParser, _BUILTIN_ENTITY_PARSERS)
 from snips_nlu.tests.utils import SnipsTest
@@ -75,64 +75,6 @@ class TestBuiltinEntityParser(SnipsTest):
                 # When / Then
                 parser.parse(text)
 
-    def test_should_respect_scope(self):
-        # Given
-        text = "meet me at 10 p.m."
-
-        # When
-        scope = ["snips/number"]
-        parser = BuiltinEntityParser.build(language="en")
-        parse = parser.parse(text, scope=scope)
-
-        # Then
-        self.assertEqual(len(parse), 1)
-        self.assertEqual(parse[0][ENTITY_KIND], "snips/number")
-
-    def test_should_respect_scope_with_gazetteer_entity(self):
-        # Given
-        text = "je veux écouter metallica"
-
-        # When
-        gazetteer_entities = ["snips/musicArtist", "snips/musicAlbum"]
-        parser = BuiltinEntityParser.build(
-            language="fr", gazetteer_entity_scope=gazetteer_entities)
-        scope1 = ["snips/musicArtist"]
-        parse1 = parser.parse(text, scope=scope1)
-        scope2 = ["snips/musicAlbum"]
-        parse2 = parser.parse(text, scope=scope2)
-
-        # Then
-        expected_parse1 = [
-            {
-                "resolved_value": {
-                    "kind": "MusicArtist",
-                    "value": "Metallica"
-                },
-                "entity_kind": "snips/musicArtist",
-                "range": {
-                    "end": 25,
-                    "start": 16
-                },
-                "value": "metallica"
-            }
-        ]
-        expected_parse2 = [
-            {
-                "resolved_value": {
-                    "kind": "MusicAlbum",
-                    "value": "Metallica"
-                },
-                "entity_kind": "snips/musicAlbum",
-                "range": {
-                    "end": 25,
-                    "start": 16
-                },
-                "value": "metallica"
-            }
-        ]
-        self.assertEqual(expected_parse1, parse1)
-        self.assertEqual(expected_parse2, parse2)
-
     def test_should_not_disambiguate_grammar_and_gazetteer_entities(self):
         # Given
         text = "trois nuits par semaine"
@@ -173,9 +115,14 @@ class TestBuiltinEntityParser(SnipsTest):
         self.assertListEqual(expected_result, result)
 
     @patch("snips_nlu.entity_parser.builtin_entity_parser"
-           ".BuiltinEntityParser")
-    def test_should_share_parser(self, mocked_parser):
+           "._build_builtin_parser")
+    def test_should_share_parser(self, mocked_build_builtin_parser):
         # Given
+        def mock_build_builtin_parser(language, gazetteer_entity_scope):
+            return None
+
+        mocked_build_builtin_parser.side_effect = mock_build_builtin_parser
+
         dataset1 = {
             LANGUAGE: "fr",
             ENTITIES: {
@@ -208,4 +155,4 @@ class TestBuiltinEntityParser(SnipsTest):
         BuiltinEntityParser.build(dataset=dataset3)
 
         # Then
-        self.assertEqual(2, mocked_parser.call_count)
+        self.assertEqual(2, mocked_build_builtin_parser.call_count)

--- a/snips_nlu/tests/test_builtin_entity_parser.py
+++ b/snips_nlu/tests/test_builtin_entity_parser.py
@@ -118,8 +118,12 @@ class TestBuiltinEntityParser(SnipsTest):
            "._build_builtin_parser")
     def test_should_share_parser(self, mocked_build_builtin_parser):
         # Given
+
+        # pylint:disable=unused-argument
         def mock_build_builtin_parser(language, gazetteer_entity_scope):
             return None
+
+        # pylint:enable=unused-argument
 
         mocked_build_builtin_parser.side_effect = mock_build_builtin_parser
 

--- a/snips_nlu/tests/test_cli.py
+++ b/snips_nlu/tests/test_cli.py
@@ -6,9 +6,9 @@ import tempfile
 from snips_nlu import SnipsNLUEngine
 from snips_nlu.cli import (
     cross_val_metrics, parse, train, train_test_metrics, generate_dataset)
+from snips_nlu.common.utils import unicode_string, json_string
 from snips_nlu.dataset import Dataset
 from snips_nlu.tests.utils import SnipsTest, TEST_PATH, redirect_stdout
-from snips_nlu.common.utils import unicode_string, json_string
 
 
 def mk_sys_argv(args):

--- a/snips_nlu/tests/test_config.py
+++ b/snips_nlu/tests/test_config.py
@@ -238,7 +238,8 @@ utterances:
             self.assertIsNotNone(config, "Missing default config for '%s'"
                                  % language)
             dataset[LANGUAGE] = language
-            engine = SnipsNLUEngine(config).fit(dataset)
+            shared = self.get_shared_data(dataset)
+            engine = SnipsNLUEngine(config, **shared).fit(dataset)
             result = engine.parse("Please give me the weather in Paris")
 
             # Then

--- a/snips_nlu/tests/test_crf_slot_filler.py
+++ b/snips_nlu/tests/test_crf_slot_filler.py
@@ -41,8 +41,9 @@ utterances:
 - please I want [number_of_cups](two) cups of tea""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
         config = CRFSlotFillerConfig(random_seed=42)
+        shared = self.get_shared_data(dataset)
+        slot_filler = CRFSlotFiller(config, **shared)
         intent = "MakeTea"
-        slot_filler = CRFSlotFiller(config, **self.get_shared_data(dataset))
         slot_filler.fit(dataset, intent)
 
         # When

--- a/snips_nlu/tests/test_crf_slot_filler.py
+++ b/snips_nlu/tests/test_crf_slot_filler.py
@@ -12,7 +12,8 @@ from snips_nlu.constants import (
     DATA, END, ENTITY, ENTITY_KIND, LANGUAGE_EN, RES_MATCH_RANGE, SLOT_NAME,
     SNIPS_DATETIME, START, TEXT, VALUE)
 from snips_nlu.dataset import Dataset
-from snips_nlu.entity_parser import BuiltinEntityParser
+from snips_nlu.entity_parser import BuiltinEntityParser, \
+    CustomEntityParserUsage
 from snips_nlu.exceptions import NotTrained
 from snips_nlu.pipeline.configs import CRFSlotFillerConfig
 from snips_nlu.preprocessing import Token, tokenize
@@ -41,7 +42,7 @@ utterances:
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
         config = CRFSlotFillerConfig(random_seed=42)
         intent = "MakeTea"
-        slot_filler = CRFSlotFiller(config)
+        slot_filler = CRFSlotFiller(config, **self.get_shared_data(dataset))
         slot_filler.fit(dataset, intent)
 
         # When
@@ -70,7 +71,7 @@ utterances:
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
         config = CRFSlotFillerConfig(random_seed=42)
         intent = "GetWeather"
-        slot_filler = CRFSlotFiller(config)
+        slot_filler = CRFSlotFiller(config, **self.get_shared_data(dataset))
         slot_filler.fit(dataset, intent)
 
         # When
@@ -109,7 +110,7 @@ utterances:
             },
             "entities": {}
         }
-        slot_filler = CRFSlotFiller()
+        slot_filler = CRFSlotFiller(**self.get_shared_data(dataset))
         mock_compute_features = MagicMock()
         slot_filler.compute_features = mock_compute_features
 
@@ -141,7 +142,8 @@ utterances:
             },
             "entities": {}
         }
-        slot_filler = CRFSlotFiller().fit(dataset, "intent1")
+        shared = self.get_shared_data(dataset)
+        slot_filler = CRFSlotFiller(**shared).fit(dataset, "intent1")
         tokens = tokenize("hello world foo bar", "en")
 
         # When
@@ -168,7 +170,8 @@ utterances:
             naughty_strings = [line.strip("\n") for line in f.readlines()]
 
         # When
-        slot_filler = CRFSlotFiller().fit(dataset, "my_intent")
+        shared = self.get_shared_data(dataset)
+        slot_filler = CRFSlotFiller(**shared).fit(dataset, "my_intent")
 
         # Then
         for s in naughty_strings:
@@ -222,7 +225,8 @@ utterances:
 
         # Then
         with self.fail_if_exception("Naughty string crashes"):
-            CRFSlotFiller().fit(naughty_dataset, "naughty_intent")
+            shared = self.get_shared_data(naughty_dataset)
+            CRFSlotFiller(**shared).fit(naughty_dataset, "naughty_intent")
 
     def test_should_fit_and_parse_with_non_ascii_tags(self):
         # Given
@@ -255,7 +259,8 @@ utterances:
 
         # Then
         with self.fail_if_exception("Naughty string make NLU crash"):
-            slot_filler = CRFSlotFiller()
+            shared = self.get_shared_data(naughty_dataset)
+            slot_filler = CRFSlotFiller(**shared)
             slot_filler.fit(naughty_dataset, "naughty_intent")
             slots = slot_filler.get_slots("string0")
             expected_slot = {
@@ -282,18 +287,13 @@ utterances:
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
         config = CRFSlotFillerConfig(random_seed=42)
         intent = "MakeTea"
-        slot_filler = CRFSlotFiller(config)
+        shared = self.get_shared_data(dataset)
+        slot_filler = CRFSlotFiller(config, **shared)
         slot_filler.fit(dataset, intent)
         slot_filler.persist(self.tmp_file_path)
 
-        custom_entity_parser = slot_filler.custom_entity_parser
-        builtin_entity_parser = slot_filler.builtin_entity_parser
-
         deserialized_slot_filler = CRFSlotFiller.from_path(
-            self.tmp_file_path,
-            custom_entity_parser=custom_entity_parser,
-            builtin_entity_parser=builtin_entity_parser
-        )
+            self.tmp_file_path, **shared)
 
         # When
         slots = deserialized_slot_filler.get_slots("make me two cups of tea")
@@ -429,7 +429,8 @@ utterances:
         config = CRFSlotFillerConfig(
             tagging_scheme=TaggingScheme.BILOU,
             feature_factory_configs=features_factories)
-        slot_filler = CRFSlotFiller(config)
+        shared = self.get_shared_data(dataset)
+        slot_filler = CRFSlotFiller(config, **shared)
         intent = "my_intent"
         slot_filler.fit(dataset, intent=intent)
 
@@ -579,7 +580,7 @@ utterances:
             "entities": {}
         }
 
-        slot_filler = CRFSlotFiller(config)
+        slot_filler = CRFSlotFiller(config, **self.get_shared_data(dataset))
         slot_filler.fit(dataset, intent="intent1")
 
         # When
@@ -611,10 +612,12 @@ utterances:
             "entities": {}
         }
 
-        slot_filler = CRFSlotFiller()
+        shared = self.get_shared_data(dataset)
+        slot_filler = CRFSlotFiller(**shared)
         slot_filler.fit(dataset, intent="intent1")
         slot_filler.persist(self.tmp_file_path)
-        loaded_slot_filler = CRFSlotFiller.from_path(self.tmp_file_path)
+        loaded_slot_filler = CRFSlotFiller.from_path(
+            self.tmp_file_path, **shared)
 
         # When
         slots = loaded_slot_filler.get_slots(
@@ -634,17 +637,13 @@ utterances:
 - i want [number_of_cups] cups of tea please
 - can you prepare [number_of_cups] cups of tea ?""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        slot_filler = CRFSlotFiller().fit(dataset, "MakeTea")
-        builtin_intent_parser = slot_filler.builtin_entity_parser
-        custom_entity_parser = slot_filler.custom_entity_parser
+        shared = self.get_shared_data(dataset)
+        slot_filler = CRFSlotFiller(**shared).fit(dataset, "MakeTea")
 
         # When
         slot_filler_bytes = slot_filler.to_byte_array()
         loaded_slot_filler = CRFSlotFiller.from_byte_array(
-            slot_filler_bytes,
-            builtin_entity_parser=builtin_intent_parser,
-            custom_entity_parser=custom_entity_parser
-        )
+            slot_filler_bytes, **shared)
         slots = loaded_slot_filler.get_slots("make me two cups of tea")
 
         # Then
@@ -671,7 +670,6 @@ utterances:
         ]
         slot_filler_config = CRFSlotFillerConfig(
             feature_factory_configs=features_factories, random_seed=40)
-        slot_filler = CRFSlotFiller(slot_filler_config)
 
         tokens = tokenize("foo hello world bar", LANGUAGE_EN)
         dataset_stream = io.StringIO("""
@@ -682,6 +680,9 @@ utterances:
 - this is [slot1:entity1](my first entity)
 - this is [slot2:entity2](second_entity)""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
+        shared = self.get_shared_data(
+            dataset, CustomEntityParserUsage.WITHOUT_STEMS)
+        slot_filler = CRFSlotFiller(slot_filler_config, **shared)
         slot_filler.fit(dataset, intent="my_intent")
 
         # When
@@ -979,7 +980,7 @@ utterances:
             "entities": dict()
         }
 
-        slot_filler = CRFSlotFiller()
+        slot_filler = CRFSlotFiller(**self.get_shared_data(dataset))
 
         # When
         slot_filler.fit(dataset, "dummy_intent")

--- a/snips_nlu/tests/test_custom_entity_parser.py
+++ b/snips_nlu/tests/test_custom_entity_parser.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from mock import patch
 
+from snips_nlu.constants import STEMS
 from snips_nlu.dataset import validate_and_format_dataset
 from snips_nlu.entity_parser import CustomEntityParser
 from snips_nlu.entity_parser.custom_entity_parser import (
@@ -48,7 +49,7 @@ class TestCustomEntityParser(FixtureTest):
     def test_should_parse_without_stems(self):
         # Given
         parser = CustomEntityParser.build(
-            DATASET, CustomEntityParserUsage.WITHOUT_STEMS)
+            DATASET, CustomEntityParserUsage.WITHOUT_STEMS, resources=dict())
         text = "dummy_entity_1 dummy_1 dummy_entity_2 dummy_2"
 
         # When
@@ -96,12 +97,16 @@ class TestCustomEntityParser(FixtureTest):
         ]
         self.assertListEqual(expected_entities, result)
 
-    @patch("snips_nlu.entity_parser.custom_entity_parser.stem")
-    def test_should_parse_with_stems(self, mocked_stem):
+    def test_should_parse_with_stems(self):
         # Given
-        mocked_stem.side_effect = _stem
+        resources = {
+            STEMS: {
+                "dummy_entity_1": "dummy_entity_",
+                "dummy_1": "dummy_"
+            }
+        }
         parser = CustomEntityParser.build(
-            DATASET, CustomEntityParserUsage.WITH_STEMS)
+            DATASET, CustomEntityParserUsage.WITH_STEMS, resources)
         text = "dummy_entity_ dummy_1"
         scope = ["dummy_entity_1"]
 
@@ -122,12 +127,11 @@ class TestCustomEntityParser(FixtureTest):
         ]
         self.assertListEqual(expected_entities, result)
 
-    @patch("snips_nlu.entity_parser.custom_entity_parser.stem")
-    def test_should_parse_with_and_without_stems(self, mocked_stem):
+    def test_should_parse_with_and_without_stems(self):
         # Given
-        mocked_stem.side_effect = _stem
+        resources = {STEMS: {"dummy_entity_1": "dummy_entity_"}}
         parser = CustomEntityParser.build(
-            DATASET, CustomEntityParserUsage.WITH_AND_WITHOUT_STEMS)
+            DATASET, CustomEntityParserUsage.WITH_AND_WITHOUT_STEMS, resources)
         scope = ["dummy_entity_1"]
         text = "dummy_entity_ dummy_1"
 
@@ -160,7 +164,7 @@ class TestCustomEntityParser(FixtureTest):
     def test_should_parse_with_proper_tokenization(self):
         # Given
         parser = CustomEntityParser.build(
-            DATASET, CustomEntityParserUsage.WITHOUT_STEMS)
+            DATASET, CustomEntityParserUsage.WITHOUT_STEMS, resources=dict())
         text = "  dummy_1?dummy_2"
 
         # When
@@ -193,7 +197,7 @@ class TestCustomEntityParser(FixtureTest):
     def test_should_respect_scope(self):
         # Given
         parser = CustomEntityParser.build(
-            DATASET, CustomEntityParserUsage.WITHOUT_STEMS)
+            DATASET, CustomEntityParserUsage.WITHOUT_STEMS, resources=dict())
         scope = ["dummy_entity_1"]
         text = "dummy_entity_2"
 
@@ -208,7 +212,7 @@ class TestCustomEntityParser(FixtureTest):
         # Given
         mocked_parse.return_value = []
         parser = CustomEntityParser.build(
-            DATASET, CustomEntityParserUsage.WITHOUT_STEMS)
+            DATASET, CustomEntityParserUsage.WITHOUT_STEMS, resources=dict())
 
         text = ""
 
@@ -222,7 +226,7 @@ class TestCustomEntityParser(FixtureTest):
     def test_should_be_serializable(self):
         # Given
         parser = CustomEntityParser.build(
-            DATASET, CustomEntityParserUsage.WITHOUT_STEMS)
+            DATASET, CustomEntityParserUsage.WITHOUT_STEMS, resources=dict())
         self.tmp_file_path.mkdir()
         parser_path = self.tmp_file_path / "custom_entity_parser"
         parser.persist(parser_path)

--- a/snips_nlu/tests/test_data_augmentation.py
+++ b/snips_nlu/tests/test_data_augmentation.py
@@ -5,7 +5,6 @@ from builtins import next, range
 import numpy as np
 from mock import patch
 
-from snips_nlu import load_resources
 from snips_nlu.constants import LANGUAGE_EN, STOP_WORDS
 from snips_nlu.data_augmentation import (
     capitalize, capitalize_utterances, generate_utterance,

--- a/snips_nlu/tests/test_deterministic_intent_parser.py
+++ b/snips_nlu/tests/test_deterministic_intent_parser.py
@@ -77,8 +77,7 @@ name: intent2
 utterances:
   - foo bar ban""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        shared = self.get_shared_data(dataset)
-        parser = DeterministicIntentParser(**shared).fit(dataset)
+        parser = DeterministicIntentParser().fit(dataset)
         text = "foo bar ban"
 
         # When
@@ -106,8 +105,7 @@ name: intent2
 utterances:
   - foo bar ban""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        shared = self.get_shared_data(dataset)
-        parser = DeterministicIntentParser(**shared).fit(dataset)
+        parser = DeterministicIntentParser().fit(dataset)
         text = "foo bar ban"
 
         # When
@@ -131,8 +129,7 @@ name: intent2
 utterances:
   - foo bar""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        shared = self.get_shared_data(dataset)
-        parser = DeterministicIntentParser(**shared).fit(dataset)
+        parser = DeterministicIntentParser().fit(dataset)
         text = "hello world"
 
         # When
@@ -151,8 +148,7 @@ utterances:
         mock_get_stop_words.return_value = {"a", "hey"}
         dataset = self.slots_dataset
         config = DeterministicIntentParserConfig(ignore_stop_words=True)
-        shared = self.get_shared_data(dataset)
-        parser = DeterministicIntentParser(config, **shared).fit(dataset)
+        parser = DeterministicIntentParser(config).fit(dataset)
         text = "Hey this is dummy_a query with another dummy_c at 10p.m. or " \
                "at 12p.m."
 
@@ -181,8 +177,7 @@ name: dummy_intent_2
 utterances:
   - Hello world""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        shared = self.get_shared_data(dataset)
-        parser = DeterministicIntentParser(**shared).fit(dataset)
+        parser = DeterministicIntentParser().fit(dataset)
         text = "Hello world"
 
         # When
@@ -223,8 +218,7 @@ utterances:
     def test_should_parse_slots(self):
         # Given
         dataset = self.slots_dataset
-        shared = self.get_shared_data(dataset)
-        parser = DeterministicIntentParser(**shared).fit(dataset)
+        parser = DeterministicIntentParser().fit(dataset)
         texts = [
             (
                 "this is a dummy a query with another dummy_c at 10p.m. or at"
@@ -320,8 +314,7 @@ utterances:
   - Hi [name](Robert)""")
 
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        shared = self.get_shared_data(dataset)
-        parser = DeterministicIntentParser(**shared).fit(dataset)
+        parser = DeterministicIntentParser().fit(dataset)
 
         # When
         top_intents = parser.get_intents("Hello John")
@@ -365,8 +358,7 @@ name: goodbye
 utterances:
   - Goodbye [name](Eric)""")
         dataset = Dataset.from_yaml_files("en", [slots_dataset_stream]).json
-        shared = self.get_shared_data(dataset)
-        parser = DeterministicIntentParser(**shared).fit(dataset)
+        parser = DeterministicIntentParser().fit(dataset)
 
         # When
         slots_greeting1 = parser.get_slots("Hello John", "greeting1")
@@ -392,8 +384,7 @@ name: greeting
 utterances:
   - Hello [name](John)""")
         dataset = Dataset.from_yaml_files("en", [slots_dataset_stream]).json
-        shared = self.get_shared_data(dataset)
-        parser = DeterministicIntentParser(**shared).fit(dataset)
+        parser = DeterministicIntentParser().fit(dataset)
 
         # When
         slots = parser.get_slots("Hello John", None)
@@ -416,8 +407,7 @@ name: goodbye
 utterances:
   - Goodbye [name](Eric)""")
         dataset = Dataset.from_yaml_files("en", [slots_dataset_stream]).json
-        shared = self.get_shared_data(dataset)
-        parser = DeterministicIntentParser(**shared).fit(dataset)
+        parser = DeterministicIntentParser().fit(dataset)
 
         # When / Then
         with self.assertRaises(IntentNotFoundError):
@@ -540,8 +530,7 @@ utterances:
             naughty_strings = [line.strip("\n") for line in f.readlines()]
 
         # When
-        shared = self.get_shared_data(dataset)
-        parser = DeterministicIntentParser(**shared).fit(dataset)
+        parser = DeterministicIntentParser().fit(dataset)
 
         # Then
         for s in naughty_strings:
@@ -570,8 +559,7 @@ utterances:
 
         # Then
         with self.fail_if_exception("Exception raised"):
-            shared = self.get_shared_data(naughty_dataset)
-            DeterministicIntentParser(**shared).fit(naughty_dataset)
+            DeterministicIntentParser().fit(naughty_dataset)
 
     def test_should_fit_and_parse_with_non_ascii_tags(self):
         # Given
@@ -604,9 +592,7 @@ utterances:
 
         # Then
         with self.fail_if_exception("Exception raised"):
-            shared = self.get_shared_data(naughty_dataset)
-            parser = DeterministicIntentParser(**shared)
-            parser.fit(naughty_dataset)
+            parser = DeterministicIntentParser().fit(naughty_dataset)
             parsing = parser.parse("string0")
 
             expected_slot = {
@@ -684,9 +670,7 @@ values:
         mock_get_stop_words.return_value = {"a", "me"}
         config = DeterministicIntentParserConfig(
             max_queries=42, max_pattern_length=100, ignore_stop_words=True)
-        shared = self.get_shared_data(dataset)
-        parser = DeterministicIntentParser(config=config, **shared)
-        parser.fit(dataset)
+        parser = DeterministicIntentParser(config=config).fit(dataset)
 
         # When
         parser.persist(self.tmp_file_path)
@@ -884,9 +868,7 @@ utterances:
                                                  max_pattern_length=1000)
 
         # When
-        shared = self.get_shared_data(dataset)
-        parser = DeterministicIntentParser(config=config, **shared)
-        parser.fit(dataset)
+        parser = DeterministicIntentParser(config=config).fit(dataset)
 
         # Then
         self.assertEqual(len(parser.regexes_per_intent["my_first_intent"]), 2)
@@ -916,9 +898,7 @@ utterances:
                                                  ignore_stop_words=False)
 
         # When
-        shared = self.get_shared_data(dataset)
-        parser = DeterministicIntentParser(config=config, **shared)
-        parser.fit(dataset)
+        parser = DeterministicIntentParser(config=config).fit(dataset)
 
         # Then
         self.assertEqual(2, len(parser.regexes_per_intent["my_first_intent"]))

--- a/snips_nlu/tests/test_log_reg_classifier_utils.py
+++ b/snips_nlu/tests/test_log_reg_classifier_utils.py
@@ -6,12 +6,12 @@ from copy import deepcopy
 from itertools import cycle
 
 import numpy as np
-from numpy.random.mtrand import RandomState
-
 from future.utils import itervalues
 from mock import MagicMock, patch
+from numpy.random.mtrand import RandomState
 
-from snips_nlu.constants import INTENTS, LANGUAGE_EN, UTTERANCES
+from snips_nlu.constants import INTENTS, LANGUAGE_EN, UTTERANCES, LANGUAGE, \
+    NOISE
 from snips_nlu.dataset import validate_and_format_dataset, Dataset
 from snips_nlu.intent_classifier.log_reg_classifier_utils import (
     add_unknown_word_to_utterances, build_training_data,
@@ -47,6 +47,7 @@ utterances:
 - does it rain
 - will it rain tomorrow""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
+        resources = self.get_resources(dataset[LANGUAGE])
         mocked_augment_utterances.side_effect = get_mocked_augment_utterances
         random_state = np.random.RandomState(1)
 
@@ -54,7 +55,8 @@ utterances:
         data_augmentation_config = IntentClassifierDataAugmentationConfig(
             noise_factor=0)
         utterances, _, intent_mapping = build_training_data(
-            dataset, LANGUAGE_EN, data_augmentation_config, random_state)
+            dataset, LANGUAGE_EN, data_augmentation_config, resources,
+            random_state)
 
         # Then
         expected_utterances = [utterance for intent
@@ -64,14 +66,15 @@ utterances:
         self.assertListEqual(expected_utterances, utterances)
         self.assertListEqual(expected_intent_mapping, intent_mapping)
 
-    @patch("snips_nlu.intent_classifier.log_reg_classifier_utils.get_noise")
     @patch("snips_nlu.intent_classifier.log_reg_classifier_utils"
            ".augment_utterances")
     def test_should_build_training_data_with_noise(
-            self, mocked_augment_utterances, mocked_get_noise):
+            self, mocked_augment_utterances):
         # Given
         mocked_noises = ["mocked_noise_%s" % i for i in range(100)]
-        mocked_get_noise.return_value = mocked_noises
+        resources = {
+            NOISE: mocked_noises
+        }
         mocked_augment_utterances.side_effect = get_mocked_augment_utterances
 
         num_intents = 3
@@ -99,16 +102,16 @@ utterances:
             noise_factor=noise_factor, unknown_word_prob=0,
             unknown_words_replacement_string=None)
         utterances, _, intent_mapping = build_training_data(
-            dataset, LANGUAGE_EN, data_augmentation_config, random_state)
+            dataset, LANGUAGE_EN, data_augmentation_config, resources,
+            random_state)
 
         # Then
         expected_utterances = [utterance
                                for intent in itervalues(dataset[INTENTS])
                                for utterance in intent[UTTERANCES]]
         np.random.seed(42)
-        noise = list(mocked_noises)
         noise_size = int(min(noise_factor * num_queries_per_intent,
-                             len(noise)))
+                             len(mocked_noises)))
         noise_it = get_noise_it(mocked_noises, utterances_length, 0,
                                 random_state)
         noisy_utterances = [text_to_utterance(next(noise_it))
@@ -335,14 +338,15 @@ utterances:
                           replacement_string]
         self.assertEqual(noise, expected_noise)
 
-    @patch("snips_nlu.intent_classifier.log_reg_classifier_utils.get_noise")
     @patch("snips_nlu.intent_classifier.log_reg_classifier_utils"
            ".augment_utterances")
     def test_should_build_training_data_with_unknown_noise(
-            self, mocked_augment_utterances, mocked_get_noise):
+            self, mocked_augment_utterances):
         # Given
         mocked_noises = ["mocked_noise_%s" % i for i in range(100)]
-        mocked_get_noise.return_value = mocked_noises
+        resources = {
+            NOISE: mocked_noises
+        }
         mocked_augment_utterances.side_effect = get_mocked_augment_utterances
 
         num_intents = 3
@@ -371,7 +375,8 @@ utterances:
             noise_factor=noise_factor, unknown_word_prob=0,
             unknown_words_replacement_string=replacement_string)
         utterances, _, intent_mapping = build_training_data(
-            dataset, LANGUAGE_EN, data_augmentation_config, random_state)
+            dataset, LANGUAGE_EN, data_augmentation_config, resources,
+            random_state)
 
         # Then
         expected_utterances = [utterance
@@ -392,6 +397,8 @@ utterances:
     def test_should_build_training_data_with_no_data(self):
         # Given
         language = LANGUAGE_EN
+        resources = self.get_resources(language)
+
         dataset = validate_and_format_dataset(get_empty_dataset(language))
         random_state = np.random.RandomState(1)
 
@@ -399,7 +406,8 @@ utterances:
         data_augmentation_config = LogRegIntentClassifierConfig() \
             .data_augmentation_config
         utterances, _, intent_mapping = build_training_data(
-            dataset, language, data_augmentation_config, random_state)
+            dataset, language, data_augmentation_config, resources,
+            random_state)
 
         # Then
         expected_utterances = []
@@ -529,8 +537,7 @@ utterances:
 
         self.assertDictEqual(expected_dataset, filtered_dataset)
 
-    @patch("snips_nlu.intent_classifier.log_reg_classifier_utils.get_noise")
-    def test_get_dataset_specific_noise(self, mocked_noise):
+    def test_get_dataset_specific_noise(self):
         # Given
         dataset_stream = io.StringIO("""
 ---
@@ -542,10 +549,12 @@ utterances:
 - does it rain in [city](tokyo)?""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
         dataset = validate_and_format_dataset(dataset)
-        language = "en"
-        mocked_noise.return_value = ["paris", "tokyo", "yo"]
+        resources = {
+            NOISE: ["paris", "tokyo", "yo"]
+        }
+
         # When
-        noise = get_dataset_specific_noise(dataset, language)
+        noise = get_dataset_specific_noise(dataset, resources)
 
         # Then
         self.assertEqual(["yo"], noise)
@@ -560,7 +569,7 @@ utterances:
 
         # When / Then
         with self.fail_if_exception(
-            "Failed to augment utterances with max_unknownword=None"):
+                "Failed to augment utterances with max_unknownword=None"):
             add_unknown_word_to_utterances(
                 utterances, replacement_string, unknown_word_prob,
                 max_unknown_words, random_state
@@ -576,7 +585,7 @@ utterances:
 
         # When / Then
         with self.fail_if_exception(
-            "Failed to augment utterances with unknown_word_prob=0"):
+                "Failed to augment utterances with unknown_word_prob=0"):
             add_unknown_word_to_utterances(
                 utterances, replacement_string, unknown_word_prob,
                 max_unknown_words, random_state

--- a/snips_nlu/tests/test_log_reg_classifier_utils.py
+++ b/snips_nlu/tests/test_log_reg_classifier_utils.py
@@ -8,10 +8,9 @@ from itertools import cycle
 import numpy as np
 from future.utils import itervalues
 from mock import MagicMock, patch
-from numpy.random.mtrand import RandomState
 
-from snips_nlu.constants import INTENTS, LANGUAGE_EN, UTTERANCES, LANGUAGE, \
-    NOISE
+from snips_nlu.constants import (
+    INTENTS, LANGUAGE_EN, UTTERANCES, LANGUAGE, NOISE)
 from snips_nlu.dataset import validate_and_format_dataset, Dataset
 from snips_nlu.intent_classifier.log_reg_classifier_utils import (
     add_unknown_word_to_utterances, build_training_data,
@@ -565,11 +564,11 @@ utterances:
         replacement_string = "yo"
         unknown_word_prob = 1
         max_unknown_words = None
-        random_state = RandomState()
+        random_state = np.random.RandomState()
 
         # When / Then
-        with self.fail_if_exception(
-                "Failed to augment utterances with max_unknownword=None"):
+        with self.fail_if_exception("Failed to augment utterances with "
+                                    "max_unknownword=None"):
             add_unknown_word_to_utterances(
                 utterances, replacement_string, unknown_word_prob,
                 max_unknown_words, random_state
@@ -581,11 +580,11 @@ utterances:
         replacement_string = "yo"
         unknown_word_prob = 1
         max_unknown_words = 0
-        random_state = RandomState()
+        random_state = np.random.RandomState
 
         # When / Then
-        with self.fail_if_exception(
-                "Failed to augment utterances with unknown_word_prob=0"):
+        with self.fail_if_exception("Failed to augment utterances with "
+                                    "unknown_word_prob=0"):
             add_unknown_word_to_utterances(
                 utterances, replacement_string, unknown_word_prob,
                 max_unknown_words, random_state

--- a/snips_nlu/tests/test_log_reg_intent_classifier.py
+++ b/snips_nlu/tests/test_log_reg_intent_classifier.py
@@ -9,9 +9,6 @@ from mock import patch
 from snips_nlu.constants import (
     INTENTS, LANGUAGE_EN, RES_INTENT_NAME, RES_PROBA, UTTERANCES)
 from snips_nlu.dataset import Dataset
-from snips_nlu.entity_parser import BuiltinEntityParser, CustomEntityParser
-from snips_nlu.entity_parser.custom_entity_parser_usage import (
-    CustomEntityParserUsage)
 from snips_nlu.exceptions import NotTrained
 from snips_nlu.intent_classifier import LogRegIntentClassifier
 from snips_nlu.intent_classifier.featurizer import Featurizer
@@ -26,7 +23,7 @@ from snips_nlu.tests.utils import (FixtureTest, get_empty_dataset)
 def get_mocked_augment_utterances(dataset, intent_name, language,
                                   min_utterances, capitalization_ratio,
                                   add_builtin_entities_examples,
-                                  random_state):
+                                  resources, random_state):
     return dataset[INTENTS][intent_name][UTTERANCES]
 
 
@@ -337,17 +334,13 @@ utterances:
 - brew two cups of coffee
 - can you prepare one cup of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        classifier = LogRegIntentClassifier().fit(dataset)
+        shared = self.get_shared_data(dataset)
+        classifier = LogRegIntentClassifier(**shared).fit(dataset)
         classifier.persist(self.tmp_file_path)
 
         # When
-        builtin_entity_parser = BuiltinEntityParser.build(language="en")
-        custom_entity_parser = CustomEntityParser.build(
-            dataset, CustomEntityParserUsage.WITHOUT_STEMS)
         loaded_classifier = LogRegIntentClassifier.from_path(
-            self.tmp_file_path,
-            builtin_entity_parser=builtin_entity_parser,
-            custom_entity_parser=custom_entity_parser)
+            self.tmp_file_path, **shared)
         result = loaded_classifier.get_intent("Make me two cups of tea")
 
         # Then
@@ -373,17 +366,13 @@ utterances:
 - brew two cups of coffee
 - can you prepare one cup of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        intent_classifier = LogRegIntentClassifier().fit(dataset)
+        shared = self.get_shared_data(dataset)
+        intent_classifier = LogRegIntentClassifier(**shared).fit(dataset)
 
         # When
         intent_classifier_bytes = intent_classifier.to_byte_array()
-        custom_entity_parser = CustomEntityParser.build(
-            dataset, CustomEntityParserUsage.WITHOUT_STEMS)
-        builtin_entity_parser = BuiltinEntityParser.build(language="en")
         loaded_classifier = LogRegIntentClassifier.from_byte_array(
-            intent_classifier_bytes,
-            builtin_entity_parser=builtin_entity_parser,
-            custom_entity_parser=custom_entity_parser)
+            intent_classifier_bytes, **shared)
         result = loaded_classifier.get_intent("make me two cups of tea")
 
         # Then

--- a/snips_nlu/tests/test_log_reg_intent_classifier.py
+++ b/snips_nlu/tests/test_log_reg_intent_classifier.py
@@ -51,8 +51,7 @@ utterances:
 - will it rain tomorrow""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
         config = LogRegIntentClassifierConfig(random_seed=42)
-        shared = self.get_shared_data(dataset)
-        classifier = LogRegIntentClassifier(config, **shared).fit(dataset)
+        classifier = LogRegIntentClassifier(config).fit(dataset)
         text = "hey how are you doing ?"
 
         # When
@@ -81,8 +80,7 @@ utterances:
 - does it rain
 - will it rain tomorrow""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        shared = self.get_shared_data(dataset)
-        classifier = LogRegIntentClassifier(**shared).fit(dataset)
+        classifier = LogRegIntentClassifier().fit(dataset)
         text = ""
 
         # When
@@ -111,8 +109,7 @@ utterances:
 - can you prepare one cup of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
         config = LogRegIntentClassifierConfig(random_seed=42)
-        shared = self.get_shared_data(dataset)
-        classifier = LogRegIntentClassifier(config, **shared).fit(dataset)
+        classifier = LogRegIntentClassifier(config).fit(dataset)
 
         # When
         text1 = "Make me two cups of tea"
@@ -141,8 +138,7 @@ utterances:
     def test_should_get_none_intent_when_empty_dataset(self):
         # Given
         dataset = get_empty_dataset(LANGUAGE_EN)
-        shared = self.get_shared_data(dataset)
-        classifier = LogRegIntentClassifier(**shared).fit(dataset)
+        classifier = LogRegIntentClassifier().fit(dataset)
         text = "this is a dummy query"
 
         # When
@@ -174,8 +170,7 @@ utterances:
   - yili yulu yele""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
         config = LogRegIntentClassifierConfig(random_seed=42)
-        shared = self.get_shared_data(dataset)
-        classifier = LogRegIntentClassifier(config, **shared).fit(dataset)
+        classifier = LogRegIntentClassifier(config).fit(dataset)
         text = "yala yili yulu"
 
         # When
@@ -190,8 +185,7 @@ utterances:
     def test_should_get_intents_when_empty_dataset(self):
         # Given
         dataset = get_empty_dataset(LANGUAGE_EN)
-        shared = self.get_shared_data(dataset)
-        classifier = LogRegIntentClassifier(**shared).fit(dataset)
+        classifier = LogRegIntentClassifier().fit(dataset)
         text = "this is a dummy query"
 
         # When
@@ -216,8 +210,7 @@ name: intent2
 utterances:
   - lorem ipsum""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        shared = self.get_shared_data(dataset)
-        classifier = LogRegIntentClassifier(**shared).fit(dataset)
+        classifier = LogRegIntentClassifier().fit(dataset)
         text = ""
 
         # When
@@ -246,8 +239,7 @@ name: intent2
 utterances:
   - lorem ipsum""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        shared = self.get_shared_data(dataset)
-        intent_classifier = LogRegIntentClassifier(**shared).fit(dataset)
+        intent_classifier = LogRegIntentClassifier().fit(dataset)
         coeffs = intent_classifier.classifier.coef_.tolist()
         intercept = intent_classifier.classifier.intercept_.tolist()
 
@@ -418,8 +410,7 @@ values:
         mocked_build_training.return_value = utterances, labels, intent_list
 
         # When / Then
-        shared = self.get_shared_data(dataset)
-        intent_classifier = LogRegIntentClassifier(**shared).fit(dataset)
+        intent_classifier = LogRegIntentClassifier().fit(dataset)
         intent = intent_classifier.get_intent("no intent there")
         self.assertEqual(intent_classification_result(None, 1.0), intent)
 
@@ -438,8 +429,7 @@ name: intent2
 utterances:
   - lorem ipsum""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        shared = self.get_shared_data(dataset)
-        intent_classifier = LogRegIntentClassifier(**shared).fit(dataset)
+        intent_classifier = LogRegIntentClassifier().fit(dataset)
 
         text = "yo"
         utterances = [text_to_utterance(text)]

--- a/snips_nlu/tests/test_log_reg_intent_classifier.py
+++ b/snips_nlu/tests/test_log_reg_intent_classifier.py
@@ -429,7 +429,8 @@ name: intent2
 utterances:
   - lorem ipsum""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        intent_classifier = LogRegIntentClassifier().fit(dataset)
+        shared = self.get_shared_data(dataset)
+        intent_classifier = LogRegIntentClassifier(**shared)
 
         text = "yo"
         utterances = [text_to_utterance(text)]

--- a/snips_nlu/tests/test_log_reg_intent_classifier.py
+++ b/snips_nlu/tests/test_log_reg_intent_classifier.py
@@ -16,7 +16,7 @@ from snips_nlu.intent_classifier.log_reg_classifier_utils import (
     text_to_utterance)
 from snips_nlu.pipeline.configs import LogRegIntentClassifierConfig
 from snips_nlu.result import intent_classification_result
-from snips_nlu.tests.utils import (FixtureTest, get_empty_dataset)
+from snips_nlu.tests.utils import FixtureTest, get_empty_dataset
 
 
 # pylint: disable=unused-argument
@@ -51,7 +51,8 @@ utterances:
 - will it rain tomorrow""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
         config = LogRegIntentClassifierConfig(random_seed=42)
-        classifier = LogRegIntentClassifier(config).fit(dataset)
+        shared = self.get_shared_data(dataset)
+        classifier = LogRegIntentClassifier(config, **shared).fit(dataset)
         text = "hey how are you doing ?"
 
         # When
@@ -80,7 +81,8 @@ utterances:
 - does it rain
 - will it rain tomorrow""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        classifier = LogRegIntentClassifier().fit(dataset)
+        shared = self.get_shared_data(dataset)
+        classifier = LogRegIntentClassifier(**shared).fit(dataset)
         text = ""
 
         # When
@@ -109,7 +111,8 @@ utterances:
 - can you prepare one cup of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
         config = LogRegIntentClassifierConfig(random_seed=42)
-        classifier = LogRegIntentClassifier(config).fit(dataset)
+        shared = self.get_shared_data(dataset)
+        classifier = LogRegIntentClassifier(config, **shared).fit(dataset)
 
         # When
         text1 = "Make me two cups of tea"
@@ -138,7 +141,8 @@ utterances:
     def test_should_get_none_intent_when_empty_dataset(self):
         # Given
         dataset = get_empty_dataset(LANGUAGE_EN)
-        classifier = LogRegIntentClassifier().fit(dataset)
+        shared = self.get_shared_data(dataset)
+        classifier = LogRegIntentClassifier(**shared).fit(dataset)
         text = "this is a dummy query"
 
         # When
@@ -170,7 +174,8 @@ utterances:
   - yili yulu yele""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
         config = LogRegIntentClassifierConfig(random_seed=42)
-        classifier = LogRegIntentClassifier(config).fit(dataset)
+        shared = self.get_shared_data(dataset)
+        classifier = LogRegIntentClassifier(config, **shared).fit(dataset)
         text = "yala yili yulu"
 
         # When
@@ -185,7 +190,8 @@ utterances:
     def test_should_get_intents_when_empty_dataset(self):
         # Given
         dataset = get_empty_dataset(LANGUAGE_EN)
-        classifier = LogRegIntentClassifier().fit(dataset)
+        shared = self.get_shared_data(dataset)
+        classifier = LogRegIntentClassifier(**shared).fit(dataset)
         text = "this is a dummy query"
 
         # When
@@ -210,7 +216,8 @@ name: intent2
 utterances:
   - lorem ipsum""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        classifier = LogRegIntentClassifier().fit(dataset)
+        shared = self.get_shared_data(dataset)
+        classifier = LogRegIntentClassifier(**shared).fit(dataset)
         text = ""
 
         # When
@@ -239,7 +246,8 @@ name: intent2
 utterances:
   - lorem ipsum""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        intent_classifier = LogRegIntentClassifier().fit(dataset)
+        shared = self.get_shared_data(dataset)
+        intent_classifier = LogRegIntentClassifier(**shared).fit(dataset)
         coeffs = intent_classifier.classifier.coef_.tolist()
         intercept = intent_classifier.classifier.intercept_.tolist()
 
@@ -410,7 +418,8 @@ values:
         mocked_build_training.return_value = utterances, labels, intent_list
 
         # When / Then
-        intent_classifier = LogRegIntentClassifier().fit(dataset)
+        shared = self.get_shared_data(dataset)
+        intent_classifier = LogRegIntentClassifier(**shared).fit(dataset)
         intent = intent_classifier.get_intent("no intent there")
         self.assertEqual(intent_classification_result(None, 1.0), intent)
 
@@ -429,9 +438,11 @@ name: intent2
 utterances:
   - lorem ipsum""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
+        shared = self.get_shared_data(dataset)
+        intent_classifier = LogRegIntentClassifier(**shared).fit(dataset)
+
         text = "yo"
         utterances = [text_to_utterance(text)]
-        intent_classifier = LogRegIntentClassifier()
         self.assertIsNone(intent_classifier.log_activation_weights(text, None))
 
         # When
@@ -445,7 +456,6 @@ utterances:
 
     def test_log_best_features(self):
         # Given
-        intent_classifier = LogRegIntentClassifier()
         dataset_stream = io.StringIO("""
 ---
 type: intent
@@ -459,7 +469,8 @@ name: intent2
 utterances:
   - lorem ipsum""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        intent_classifier = LogRegIntentClassifier()
+        shared = self.get_shared_data(dataset)
+        intent_classifier = LogRegIntentClassifier(**shared)
 
         # When
         self.assertIsNone(intent_classifier.log_best_features(20))

--- a/snips_nlu/tests/test_nlu_engine.py
+++ b/snips_nlu/tests/test_nlu_engine.py
@@ -14,16 +14,12 @@ from snips_nlu.constants import (
     RES_INTENT_NAME, RES_MATCH_RANGE, RES_RAW_VALUE, RES_SLOTS, RES_SLOT_NAME,
     RES_VALUE, START)
 from snips_nlu.dataset import Dataset, validate_and_format_dataset
-from snips_nlu.entity_parser import BuiltinEntityParser, CustomEntityParser
-from snips_nlu.entity_parser.custom_entity_parser_usage import \
-    CustomEntityParserUsage
 from snips_nlu.exceptions import (
     IntentNotFoundError, InvalidInputError, NotTrained)
 from snips_nlu.intent_parser import IntentParser
 from snips_nlu.nlu_engine import SnipsNLUEngine
 from snips_nlu.pipeline.configs import (
     NLUEngineConfig, ProbabilisticIntentParserConfig)
-from snips_nlu.resources import clear_resources
 from snips_nlu.result import (
     custom_slot, empty_result, intent_classification_result, parsing_result,
     resolved_slot, unresolved_slot, extraction_result)
@@ -622,9 +618,7 @@ utterances:
                 }
             ]
         }
-        # pylint:disable=protected-access
-        self.assertDictEqual(dataset_metadata, engine._dataset_metadata)
-        # pylint:enable=protected-access
+        self.assertDictEqual(dataset_metadata, engine.dataset_metadata)
         self.assertDictEqual(expected_engine_config, engine.config.to_dict())
         self.assertIsInstance(engine.intent_parsers[0], TestIntentParser1)
         self.assertIsInstance(engine.intent_parsers[1], TestIntentParser2)
@@ -738,12 +732,7 @@ utterances:
 
         # When
         engine_bytes = engine.to_byte_array()
-        builtin_entity_parser = BuiltinEntityParser.build(dataset=dataset)
-        custom_entity_parser = CustomEntityParser.build(
-            dataset, parser_usage=CustomEntityParserUsage.WITHOUT_STEMS)
-        loaded_engine = SnipsNLUEngine.from_byte_array(
-            engine_bytes, builtin_entity_parser=builtin_entity_parser,
-            custom_entity_parser=custom_entity_parser)
+        loaded_engine = SnipsNLUEngine.from_byte_array(engine_bytes)
         result = loaded_engine.parse("Make me two cups of coffee")
 
         # Then
@@ -771,7 +760,6 @@ utterances:
         engine.persist(dir_temp_engine)
 
         # When
-        clear_resources()
         loaded_engine = SnipsNLUEngine.from_path(dir_temp_engine)
         shutil.rmtree(str(dir_temp_engine))
 

--- a/snips_nlu/tests/test_nlu_engine.py
+++ b/snips_nlu/tests/test_nlu_engine.py
@@ -348,7 +348,7 @@ utterances:
 
     def test_should_handle_empty_dataset(self):
         # Given
-        dataset = validate_and_format_dataset(get_empty_dataset(LANGUAGE_EN))
+        dataset = get_empty_dataset(LANGUAGE_EN)
         shared = self.get_shared_data(dataset)
         engine = SnipsNLUEngine(**shared).fit(dataset)
 
@@ -1057,7 +1057,7 @@ utterances:
 
     def test_engine_should_fit_with_builtins_entities(self):
         # Given
-        dataset = validate_and_format_dataset({
+        dataset = {
             "intents": {
                 "dummy": {
                     "utterances": [
@@ -1077,7 +1077,7 @@ utterances:
                 "snips/datetime": {}
             },
             "language": "en",
-        })
+        }
 
         # When / Then
         # This should not raise any error

--- a/snips_nlu/tests/test_nlu_engine.py
+++ b/snips_nlu/tests/test_nlu_engine.py
@@ -13,7 +13,7 @@ from snips_nlu.constants import (
     END, LANGUAGE, LANGUAGE_EN, RES_ENTITY, RES_INPUT, RES_INTENT,
     RES_INTENT_NAME, RES_MATCH_RANGE, RES_RAW_VALUE, RES_SLOTS, RES_SLOT_NAME,
     RES_VALUE, START)
-from snips_nlu.dataset import Dataset, validate_and_format_dataset
+from snips_nlu.dataset import Dataset
 from snips_nlu.exceptions import (
     IntentNotFoundError, InvalidInputError, NotTrained)
 from snips_nlu.intent_parser import IntentParser

--- a/snips_nlu/tests/test_nlu_engine.py
+++ b/snips_nlu/tests/test_nlu_engine.py
@@ -97,7 +97,8 @@ utterances:
 
         config = NLUEngineConfig(
             ["first_intent_parser", "second_intent_parser"])
-        nlu_engine = SnipsNLUEngine(config).fit(dataset)
+        resources = self.get_resources("en")
+        nlu_engine = SnipsNLUEngine(config, resources=resources).fit(dataset)
 
         # When
         results = nlu_engine.parse(text, top_n=3)
@@ -160,7 +161,8 @@ utterances:
         # pylint:enable=unused-variable
         config = NLUEngineConfig(["first_intent_parser",
                                   "second_intent_parser"])
-        engine = SnipsNLUEngine(config).fit(dataset)
+        resources = self.get_resources("en")
+        engine = SnipsNLUEngine(config, resources=resources).fit(dataset)
 
         # When
         res_intents = engine.get_intents(input_text)
@@ -205,7 +207,8 @@ utterances:
 
         config = NLUEngineConfig(
             ["first_intent_parser", "second_intent_parser"])
-        engine = SnipsNLUEngine(config).fit(dataset)
+        resources = self.get_resources("en")
+        engine = SnipsNLUEngine(config, resources=resources).fit(dataset)
 
         # When
         res_slots = engine.get_slots(input_text, greeting_intent)
@@ -229,7 +232,8 @@ name: goodbye
 utterances:
   - Goodbye [name](Eric)""")
         dataset = Dataset.from_yaml_files("en", [slots_dataset_stream]).json
-        nlu_engine = SnipsNLUEngine().fit(dataset)
+        shared = self.get_shared_data(dataset)
+        nlu_engine = SnipsNLUEngine(**shared).fit(dataset)
 
         # When / Then
         with self.assertRaises(IntentNotFoundError):
@@ -268,7 +272,8 @@ utterances:
 
         config = NLUEngineConfig(["first_intent_parser",
                                   "second_intent_parser"])
-        engine = SnipsNLUEngine(config).fit(dataset)
+        resources = self.get_resources("en")
+        engine = SnipsNLUEngine(config, resources=resources).fit(dataset)
 
         # When
         parse = engine.parse(input_text)
@@ -317,7 +322,8 @@ utterances:
                        self.sub_unit_2["fitted"]
 
         nlu_engine_config = NLUEngineConfig(["test_intent_parser"])
-        nlu_engine = SnipsNLUEngine(nlu_engine_config)
+        resources = self.get_resources("en")
+        nlu_engine = SnipsNLUEngine(nlu_engine_config, resources=resources)
 
         intent_parser = TestIntentParser()
         intent_parser.sub_unit_1.update(dict(fitted=True, calls=0))
@@ -335,7 +341,8 @@ utterances:
     def test_should_handle_empty_dataset(self):
         # Given
         dataset = validate_and_format_dataset(get_empty_dataset(LANGUAGE_EN))
-        engine = SnipsNLUEngine().fit(dataset)
+        resources = self.get_resources("en")
+        engine = SnipsNLUEngine(resources=resources).fit(dataset)
 
         # When
         result = engine.parse("hello world")
@@ -391,7 +398,8 @@ utterances:
         }
         parsers_configs = [parser1_config, parser2_config]
         config = NLUEngineConfig(parsers_configs)
-        engine = SnipsNLUEngine(config).fit(dataset)
+        resources = self.get_resources("en")
+        engine = SnipsNLUEngine(config, resources=resources).fit(dataset)
 
         # When
         engine.persist(self.tmp_file_path)
@@ -474,7 +482,8 @@ utterances:
 
         parsers_configs = ["my_intent_parser", "my_intent_parser"]
         config = NLUEngineConfig(parsers_configs)
-        engine = SnipsNLUEngine(config).fit(dataset)
+        resources = self.get_resources("en")
+        engine = SnipsNLUEngine(config, resources=resources).fit(dataset)
 
         # When
         engine.persist(self.tmp_file_path)
@@ -679,13 +688,14 @@ utterances:
 - brew [number_of_cups] cups of coffee
 - can you prepare [number_of_cups] cup of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        engine = SnipsNLUEngine().fit(dataset)
-        input_ = "Give me 3 cups of hot tea please"
+        shared = self.get_shared_data(dataset)
+        engine = SnipsNLUEngine(**shared).fit(dataset)
+        text = "Give me 3 cups of hot tea please"
 
         # When
         engine.persist(self.tmp_file_path)
         deserialized_engine = SnipsNLUEngine.from_path(self.tmp_file_path)
-        result = deserialized_engine.parse(input_)
+        result = deserialized_engine.parse(text)
 
         # Then
         expected_slots = [
@@ -696,7 +706,7 @@ utterances:
                 unresolved_slot({START: 18, END: 21}, "hot", "Temperature",
                                 "beverage_temperature"))
         ]
-        self.assertEqual(result[RES_INPUT], input_)
+        self.assertEqual(result[RES_INPUT], text)
         self.assertEqual(result[RES_INTENT][RES_INTENT_NAME], "MakeTea")
         self.assertListEqual(result[RES_SLOTS], expected_slots)
 
@@ -728,7 +738,8 @@ utterances:
 - make me [number_of_cups:snips/number](one) cup of coffee please
 - brew [number_of_cups] cups of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        engine = SnipsNLUEngine().fit(dataset)
+        shared = self.get_shared_data(dataset)
+        engine = SnipsNLUEngine(**shared).fit(dataset)
 
         # When
         engine_bytes = engine.to_byte_array()
@@ -755,7 +766,8 @@ utterances:
 - make me [number_of_cups:snips/number](one) cup of coffee please
 - brew [number_of_cups] cups of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        engine = SnipsNLUEngine().fit(dataset)
+        shared = self.get_shared_data(dataset)
+        engine = SnipsNLUEngine(**shared).fit(dataset)
         dir_temp_engine = self.fixture_dir / "temp_engine"
         engine.persist(dir_temp_engine)
 
@@ -849,7 +861,8 @@ utterances:
         mocked_crf_parse.return_value = parsing_result(
             text, mocked_crf_intent, mocked_crf_slots)
 
-        engine = SnipsNLUEngine()
+        shared = self.get_shared_data(dataset)
+        engine = SnipsNLUEngine(**shared)
 
         # When
         engine = engine.fit(dataset)
@@ -915,7 +928,8 @@ utterances:
             text, mocked_proba_parser_intent, mocked_proba_parser_slots)
 
         config = NLUEngineConfig([ProbabilisticIntentParserConfig()])
-        engine = SnipsNLUEngine(config).fit(dataset)
+        resources = self.get_resources("en")
+        engine = SnipsNLUEngine(config, resources=resources).fit(dataset)
 
         # When
         result = engine.parse(text)
@@ -998,7 +1012,8 @@ utterances:
         mocked_proba_parse.side_effect = mock_proba_parse
 
         config = NLUEngineConfig([ProbabilisticIntentParserConfig()])
-        engine = SnipsNLUEngine(config).fit(dataset)
+        resources = self.get_resources("en")
+        engine = SnipsNLUEngine(config, resources=resources).fit(dataset)
 
         # When
         result1 = engine.parse("favorite")
@@ -1065,7 +1080,9 @@ utterances:
         })
 
         # When / Then
-        SnipsNLUEngine().fit(dataset)  # This should not raise any error
+        shared = self.get_shared_data(dataset)
+        # This should not raise any error
+        SnipsNLUEngine(**shared).fit(dataset)
 
     def test_nlu_engine_should_train_and_parse_in_all_languages(self):
         # Given
@@ -1120,7 +1137,8 @@ utterances:
 - brew [number_of_cups] cups of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
         bytes_input = b"brew me an espresso"
-        engine = SnipsNLUEngine().fit(dataset)
+        shared = self.get_shared_data(dataset)
+        engine = SnipsNLUEngine(**shared).fit(dataset)
 
         # When / Then
         with self.assertRaises(InvalidInputError) as cm:
@@ -1148,7 +1166,7 @@ utterances:
             "entities": dict()
         }
 
-        engine = SnipsNLUEngine()
+        engine = SnipsNLUEngine(resources=self.get_resources("en"))
 
         # When / Then
         engine.fit(dataset)

--- a/snips_nlu/tests/test_probabilistic_intent_parser.py
+++ b/snips_nlu/tests/test_probabilistic_intent_parser.py
@@ -46,7 +46,9 @@ utterances:
         slot_filler_config = CRFSlotFillerConfig(random_seed=42)
         parser_config = ProbabilisticIntentParserConfig(
             classifier_config, slot_filler_config)
-        parser = ProbabilisticIntentParser(parser_config).fit(dataset)
+        resources = self.get_resources("en")
+        parser = ProbabilisticIntentParser(parser_config, resources=resources)
+        parser.fit(dataset)
         text = "foo bar baz"
 
         # When
@@ -84,7 +86,9 @@ utterances:
         slot_filler_config = CRFSlotFillerConfig(random_seed=42)
         parser_config = ProbabilisticIntentParserConfig(
             classifier_config, slot_filler_config)
-        parser = ProbabilisticIntentParser(parser_config).fit(dataset)
+        resources = self.get_resources("en")
+        parser = ProbabilisticIntentParser(parser_config, resources=resources)
+        parser.fit(dataset)
         text = "foo bar baz"
 
         # When
@@ -123,7 +127,9 @@ utterances:
         slot_filler_config = CRFSlotFillerConfig(random_seed=42)
         parser_config = ProbabilisticIntentParserConfig(
             classifier_config, slot_filler_config)
-        parser = ProbabilisticIntentParser(parser_config).fit(dataset)
+        resources = self.get_resources("en")
+        parser = ProbabilisticIntentParser(parser_config, resources=resources)
+        parser.fit(dataset)
         text = "foo bar baz"
 
         # When
@@ -161,7 +167,9 @@ utterances:
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
         classifier_config = LogRegIntentClassifierConfig(random_seed=42)
         parser_config = ProbabilisticIntentParserConfig(classifier_config)
-        parser = ProbabilisticIntentParser(parser_config).fit(dataset)
+        resources = self.get_resources("en")
+        parser = ProbabilisticIntentParser(parser_config, resources=resources)
+        parser.fit(dataset)
         text = "yala yili yulu"
 
         # When
@@ -195,7 +203,8 @@ utterances:
   - Hello John""")
         dataset = Dataset.from_yaml_files("en",
                                           [slots_dataset_stream]).json
-        parser = ProbabilisticIntentParser().fit(dataset)
+        resources = self.get_resources("en")
+        parser = ProbabilisticIntentParser(resources=resources).fit(dataset)
 
         # When
         slots_greeting1 = parser.get_slots("Hello John", "greeting1")
@@ -221,7 +230,8 @@ name: greeting
 utterances:
   - Hello [name](John)""")
         dataset = Dataset.from_yaml_files("en", [slots_dataset_stream]).json
-        parser = ProbabilisticIntentParser().fit(dataset)
+        resources = self.get_resources("en")
+        parser = ProbabilisticIntentParser(resources=resources).fit(dataset)
 
         # When
         slots = parser.get_slots("Hello John", None)
@@ -244,7 +254,8 @@ name: goodbye
 utterances:
   - Goodbye [name](Eric)""")
         dataset = Dataset.from_yaml_files("en", [slots_dataset_stream]).json
-        parser = ProbabilisticIntentParser().fit(dataset)
+        resources = self.get_resources("en")
+        parser = ProbabilisticIntentParser(resources=resources).fit(dataset)
 
         # When / Then
         with self.assertRaises(IntentNotFoundError):
@@ -267,8 +278,9 @@ utterances:
 - make me [number_of_cups:snips/number](one) cup of coffee please
 - brew [number_of_cups] cups of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        parser = ProbabilisticIntentParser()
-        intent_classifier = LogRegIntentClassifier()
+        resources = self.get_resources("en")
+        parser = ProbabilisticIntentParser(resources=resources)
+        intent_classifier = LogRegIntentClassifier(resources=resources)
         intent_classifier.fit(dataset)
         parser.intent_classifier = intent_classifier
 
@@ -295,8 +307,9 @@ utterances:
 - make me [number_of_cups:snips/number](one) cup of coffee please
 - brew [number_of_cups] cups of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        parser = ProbabilisticIntentParser()
-        intent_classifier = LogRegIntentClassifier()
+        resources = self.get_resources("en")
+        parser = ProbabilisticIntentParser(resources=resources)
+        intent_classifier = LogRegIntentClassifier(resources=resources)
         intent_classifier.fit(dataset)
         parser.intent_classifier = intent_classifier
 
@@ -323,8 +336,9 @@ utterances:
 - make me [number_of_cups:snips/number](one) cup of coffee please
 - brew [number_of_cups] cups of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        parser = ProbabilisticIntentParser()
-        slot_filler = CRFSlotFiller()
+        resources = self.get_resources("en")
+        parser = ProbabilisticIntentParser(resources=resources)
+        slot_filler = CRFSlotFiller(resources=resources)
         slot_filler.fit(dataset, "MakeCoffee")
         parser.slot_fillers["MakeCoffee"] = slot_filler
 
@@ -351,8 +365,9 @@ utterances:
 - make me [number_of_cups:snips/number](one) cup of coffee please
 - brew [number_of_cups] cups of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        parser = ProbabilisticIntentParser()
-        slot_filler = CRFSlotFiller()
+        resources = self.get_resources("en")
+        parser = ProbabilisticIntentParser(resources=resources)
+        slot_filler = CRFSlotFiller(resources=resources)
         slot_filler.fit(dataset, "MakeCoffee")
         parser.slot_fillers["MakeCoffee"] = slot_filler
 
@@ -449,7 +464,8 @@ utterances:
             intent_classifier_config="my_intent_classifier",
             slot_filler_config="my_slot_filler"
         )
-        parser = ProbabilisticIntentParser(parser_config).fit(dataset)
+        parser = ProbabilisticIntentParser(parser_config)
+        parser.fit(dataset)
 
         # When
         parser.persist(self.tmp_file_path)
@@ -567,17 +583,14 @@ utterances:
 - make me [number_of_cups:snips/number](one) cup of coffee please
 - brew [number_of_cups] cups of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        intent_parser = ProbabilisticIntentParser().fit(dataset)
-        builtin_entity_parser = intent_parser.builtin_entity_parser
-        custom_entity_parser = intent_parser.custom_entity_parser
+        shared = self.get_shared_data(dataset)
+        intent_parser = ProbabilisticIntentParser(**shared)
+        intent_parser.fit(dataset)
 
         # When
         intent_parser_bytes = intent_parser.to_byte_array()
         loaded_intent_parser = ProbabilisticIntentParser.from_byte_array(
-            intent_parser_bytes,
-            builtin_entity_parser=builtin_entity_parser,
-            custom_entity_parser=custom_entity_parser
-        )
+            intent_parser_bytes, **shared)
         result = loaded_intent_parser.parse("make me two cups of tea")
 
         # Then
@@ -608,15 +621,16 @@ utterances:
                 random_seed=seed1),
             slot_filler_config=CRFSlotFillerConfig(random_seed=seed2)
         )
-        parser = ProbabilisticIntentParser(config)
+        shared = self.get_shared_data(dataset)
+        parser = ProbabilisticIntentParser(config, **shared)
         parser.persist(self.tmp_file_path)
 
         # When
         fitted_parser_1 = ProbabilisticIntentParser.from_path(
-            self.tmp_file_path).fit(dataset)
+            self.tmp_file_path, **shared).fit(dataset)
 
         fitted_parser_2 = ProbabilisticIntentParser.from_path(
-            self.tmp_file_path).fit(dataset)
+            self.tmp_file_path, **shared).fit(dataset)
 
         # Then
         feature_weights_1 = fitted_parser_1.slot_fillers[

--- a/snips_nlu/tests/test_probabilistic_intent_parser.py
+++ b/snips_nlu/tests/test_probabilistic_intent_parser.py
@@ -15,7 +15,7 @@ from snips_nlu.intent_parser import ProbabilisticIntentParser
 from snips_nlu.pipeline.configs import (
     CRFSlotFillerConfig, LogRegIntentClassifierConfig,
     ProbabilisticIntentParserConfig)
-from snips_nlu.result import unresolved_slot
+from snips_nlu.result import unresolved_slot, intent_classification_result
 from snips_nlu.slot_filler import CRFSlotFiller, SlotFiller
 from snips_nlu.tests.utils import (
     FixtureTest, MockIntentClassifier, MockSlotFiller)
@@ -46,8 +46,7 @@ utterances:
         slot_filler_config = CRFSlotFillerConfig(random_seed=42)
         parser_config = ProbabilisticIntentParserConfig(
             classifier_config, slot_filler_config)
-        resources = self.get_resources("en")
-        parser = ProbabilisticIntentParser(parser_config, resources=resources)
+        parser = ProbabilisticIntentParser(parser_config)
         parser.fit(dataset)
         text = "foo bar baz"
 
@@ -86,8 +85,7 @@ utterances:
         slot_filler_config = CRFSlotFillerConfig(random_seed=42)
         parser_config = ProbabilisticIntentParserConfig(
             classifier_config, slot_filler_config)
-        resources = self.get_resources("en")
-        parser = ProbabilisticIntentParser(parser_config, resources=resources)
+        parser = ProbabilisticIntentParser(parser_config)
         parser.fit(dataset)
         text = "foo bar baz"
 
@@ -127,8 +125,7 @@ utterances:
         slot_filler_config = CRFSlotFillerConfig(random_seed=42)
         parser_config = ProbabilisticIntentParserConfig(
             classifier_config, slot_filler_config)
-        resources = self.get_resources("en")
-        parser = ProbabilisticIntentParser(parser_config, resources=resources)
+        parser = ProbabilisticIntentParser(parser_config)
         parser.fit(dataset)
         text = "foo bar baz"
 
@@ -167,9 +164,7 @@ utterances:
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
         classifier_config = LogRegIntentClassifierConfig(random_seed=42)
         parser_config = ProbabilisticIntentParserConfig(classifier_config)
-        resources = self.get_resources("en")
-        parser = ProbabilisticIntentParser(parser_config, resources=resources)
-        parser.fit(dataset)
+        parser = ProbabilisticIntentParser(parser_config).fit(dataset)
         text = "yala yili yulu"
 
         # When
@@ -203,8 +198,7 @@ utterances:
   - Hello John""")
         dataset = Dataset.from_yaml_files("en",
                                           [slots_dataset_stream]).json
-        resources = self.get_resources("en")
-        parser = ProbabilisticIntentParser(resources=resources).fit(dataset)
+        parser = ProbabilisticIntentParser().fit(dataset)
 
         # When
         slots_greeting1 = parser.get_slots("Hello John", "greeting1")
@@ -230,8 +224,7 @@ name: greeting
 utterances:
   - Hello [name](John)""")
         dataset = Dataset.from_yaml_files("en", [slots_dataset_stream]).json
-        resources = self.get_resources("en")
-        parser = ProbabilisticIntentParser(resources=resources).fit(dataset)
+        parser = ProbabilisticIntentParser().fit(dataset)
 
         # When
         slots = parser.get_slots("Hello John", None)
@@ -254,8 +247,21 @@ name: goodbye
 utterances:
   - Goodbye [name](Eric)""")
         dataset = Dataset.from_yaml_files("en", [slots_dataset_stream]).json
-        resources = self.get_resources("en")
-        parser = ProbabilisticIntentParser(resources=resources).fit(dataset)
+
+        # pylint:disable=unused-variable
+        @IntentClassifier.register("my_intent_classifier", True)
+        class MyIntentClassifier(MockIntentClassifier):
+            pass
+
+        @SlotFiller.register("my_slot_filler", True)
+        class MySlotFiller(MockSlotFiller):
+            pass
+
+        # pylint:enable=unused-variable
+        config = ProbabilisticIntentParserConfig(
+            intent_classifier_config="my_intent_classifier",
+            slot_filler_config="my_slot_filler")
+        parser = ProbabilisticIntentParser(config).fit(dataset)
 
         # When / Then
         with self.assertRaises(IntentNotFoundError):
@@ -278,9 +284,8 @@ utterances:
 - make me [number_of_cups:snips/number](one) cup of coffee please
 - brew [number_of_cups] cups of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        resources = self.get_resources("en")
-        parser = ProbabilisticIntentParser(resources=resources)
-        intent_classifier = LogRegIntentClassifier(resources=resources)
+        parser = ProbabilisticIntentParser()
+        intent_classifier = LogRegIntentClassifier()
         intent_classifier.fit(dataset)
         parser.intent_classifier = intent_classifier
 
@@ -307,9 +312,8 @@ utterances:
 - make me [number_of_cups:snips/number](one) cup of coffee please
 - brew [number_of_cups] cups of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        resources = self.get_resources("en")
-        parser = ProbabilisticIntentParser(resources=resources)
-        intent_classifier = LogRegIntentClassifier(resources=resources)
+        parser = ProbabilisticIntentParser()
+        intent_classifier = LogRegIntentClassifier()
         intent_classifier.fit(dataset)
         parser.intent_classifier = intent_classifier
 
@@ -336,17 +340,34 @@ utterances:
 - make me [number_of_cups:snips/number](one) cup of coffee please
 - brew [number_of_cups] cups of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        resources = self.get_resources("en")
-        parser = ProbabilisticIntentParser(resources=resources)
-        slot_filler = CRFSlotFiller(resources=resources)
+
+        # pylint:disable=unused-variable
+        @IntentClassifier.register("my_intent_classifier", True)
+        class MyIntentClassifier(MockIntentClassifier):
+            pass
+
+        @SlotFiller.register("my_slot_filler", True)
+        class MySlotFiller(MockSlotFiller):
+            fit_call_count = 0
+
+            def fit(self, dataset, intent):
+                MySlotFiller.fit_call_count += 1
+                return super(MySlotFiller, self).fit(dataset, intent)
+
+        # pylint:enable=unused-variable
+
+        parser_config = ProbabilisticIntentParserConfig(
+            intent_classifier_config="my_intent_classifier",
+            slot_filler_config="my_slot_filler"
+        )
+        parser = ProbabilisticIntentParser(parser_config)
+        slot_filler = MySlotFiller(None)
         slot_filler.fit(dataset, "MakeCoffee")
         parser.slot_fillers["MakeCoffee"] = slot_filler
 
         # When / Then
-        with patch("snips_nlu.slot_filler.crf_slot_filler.CRFSlotFiller.fit") \
-                as mock_fit:
-            parser.fit(dataset, force_retrain=True)
-            self.assertEqual(2, mock_fit.call_count)
+        parser.fit(dataset, force_retrain=True)
+        self.assertEqual(3, MySlotFiller.fit_call_count)
 
     def test_should_not_retrain_slot_filler_when_no_force_retrain(self):
         # Given
@@ -365,17 +386,34 @@ utterances:
 - make me [number_of_cups:snips/number](one) cup of coffee please
 - brew [number_of_cups] cups of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        resources = self.get_resources("en")
-        parser = ProbabilisticIntentParser(resources=resources)
-        slot_filler = CRFSlotFiller(resources=resources)
+
+        # pylint:disable=unused-variable
+        @IntentClassifier.register("my_intent_classifier", True)
+        class MyIntentClassifier(MockIntentClassifier):
+            pass
+
+        @SlotFiller.register("my_slot_filler", True)
+        class MySlotFiller(MockSlotFiller):
+            fit_call_count = 0
+
+            def fit(self, dataset, intent):
+                MySlotFiller.fit_call_count += 1
+                return super(MySlotFiller, self).fit(dataset, intent)
+
+        # pylint:enable=unused-variable
+
+        parser_config = ProbabilisticIntentParserConfig(
+            intent_classifier_config="my_intent_classifier",
+            slot_filler_config="my_slot_filler"
+        )
+        parser = ProbabilisticIntentParser(parser_config)
+        slot_filler = MySlotFiller(None)
         slot_filler.fit(dataset, "MakeCoffee")
         parser.slot_fillers["MakeCoffee"] = slot_filler
 
         # When / Then
-        with patch("snips_nlu.slot_filler.crf_slot_filler.CRFSlotFiller.fit") \
-                as mock_fit:
-            parser.fit(dataset, force_retrain=False)
-            self.assertEqual(1, mock_fit.call_count)
+        parser.fit(dataset, force_retrain=False)
+        self.assertEqual(2, MySlotFiller.fit_call_count)
 
     def test_should_not_parse_when_not_fitted(self):
         # Given
@@ -464,8 +502,7 @@ utterances:
             intent_classifier_config="my_intent_classifier",
             slot_filler_config="my_slot_filler"
         )
-        parser = ProbabilisticIntentParser(parser_config)
-        parser.fit(dataset)
+        parser = ProbabilisticIntentParser(parser_config).fit(dataset)
 
         # When
         parser.persist(self.tmp_file_path)
@@ -489,9 +526,17 @@ utterances:
                 }
             ]
         }
-        metadata = {"unit_name": "probabilistic_intent_parser"}
-        metadata_slot_filler = {"unit_name": "my_slot_filler"}
-        metadata_intent_classifier = {"unit_name": "my_intent_classifier"}
+        metadata = {
+            "unit_name": "probabilistic_intent_parser",
+        }
+        metadata_slot_filler = {
+            "unit_name": "my_slot_filler",
+            "fitted": True
+        }
+        metadata_intent_classifier = {
+            "unit_name": "my_intent_classifier",
+            "fitted": True
+        }
 
         self.assertJsonContent(self.tmp_file_path / "metadata.json", metadata)
         self.assertJsonContent(self.tmp_file_path / "intent_parser.json",
@@ -547,13 +592,13 @@ utterances:
                               parser_dict)
         self.writeJsonContent(
             self.tmp_file_path / "intent_classifier" / "metadata.json",
-            {"unit_name": "my_intent_classifier"})
+            {"unit_name": "my_intent_classifier", "fitted": True})
         self.writeJsonContent(
             self.tmp_file_path / "slot_filler_MakeCoffee" / "metadata.json",
-            {"unit_name": "my_slot_filler"})
+            {"unit_name": "my_slot_filler", "fitted": True})
         self.writeJsonContent(
             self.tmp_file_path / "slot_filler_MakeTea" / "metadata.json",
-            {"unit_name": "my_slot_filler"})
+            {"unit_name": "my_slot_filler", "fitted": True})
 
         # When
         parser = ProbabilisticIntentParser.from_path(self.tmp_file_path)
@@ -583,14 +628,33 @@ utterances:
 - make me [number_of_cups:snips/number](one) cup of coffee please
 - brew [number_of_cups] cups of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        shared = self.get_shared_data(dataset)
-        intent_parser = ProbabilisticIntentParser(**shared)
-        intent_parser.fit(dataset)
+
+        # pylint:disable=unused-variable
+        @IntentClassifier.register("my_intent_classifier", True)
+        class MyIntentClassifier(MockIntentClassifier):
+            def get_intent(self, text, intents_filter):
+                if "tea" in text:
+                    return intent_classification_result("MakeTea", 1.0)
+                elif "coffee" in text:
+                    return intent_classification_result("MakeCoffee", 1.0)
+                return intent_classification_result(None, 1.0)
+
+        @SlotFiller.register("my_slot_filler", True)
+        class MySlotFiller(MockSlotFiller):
+            pass
+
+        # pylint:enable=unused-variable
+
+        parser_config = ProbabilisticIntentParserConfig(
+            intent_classifier_config="my_intent_classifier",
+            slot_filler_config="my_slot_filler"
+        )
+        parser = ProbabilisticIntentParser(parser_config).fit(dataset)
 
         # When
-        intent_parser_bytes = intent_parser.to_byte_array()
+        intent_parser_bytes = parser.to_byte_array()
         loaded_intent_parser = ProbabilisticIntentParser.from_byte_array(
-            intent_parser_bytes, **shared)
+            intent_parser_bytes)
         result = loaded_intent_parser.parse("make me two cups of tea")
 
         # Then

--- a/snips_nlu/tests/test_probabilistic_intent_parser.py
+++ b/snips_nlu/tests/test_probabilistic_intent_parser.py
@@ -16,7 +16,7 @@ from snips_nlu.pipeline.configs import (
     CRFSlotFillerConfig, LogRegIntentClassifierConfig,
     ProbabilisticIntentParserConfig)
 from snips_nlu.result import unresolved_slot, intent_classification_result
-from snips_nlu.slot_filler import CRFSlotFiller, SlotFiller
+from snips_nlu.slot_filler import SlotFiller
 from snips_nlu.tests.utils import (
     FixtureTest, MockIntentClassifier, MockSlotFiller)
 

--- a/snips_nlu/tests/test_resources.py
+++ b/snips_nlu/tests/test_resources.py
@@ -1,16 +1,17 @@
 from __future__ import unicode_literals
 
-import unittest
-
 from mock import patch
 
 from snips_nlu.constants import DATA_PATH
 from snips_nlu.resources import (
     MissingResource, _RESOURCES, _get_resource, clear_resources,
-    load_resources)
+    load_resources, _persist_stop_words, _load_stop_words, _load_noise,
+    _persist_noise, _load_word_clusters, _persist_word_clusters,
+    _load_gazetteer, _persist_gazetteer, _load_stems, _persist_stems)
+from snips_nlu.tests.utils import FixtureTest
 
 
-class TestResources(unittest.TestCase):
+class TestResources(FixtureTest):
     def test_should_load_resources_from_data_path(self):
         # Given
         clear_resources()
@@ -67,6 +68,67 @@ class TestResources(unittest.TestCase):
         with patch("snips_nlu.resources._RESOURCES", mocked_value):
             with self.assertRaises(MissingResource):
                 _get_resource("en", "foobar")
+
+    def test_should_persist_stop_words(self):
+        # Given
+        stop_words = _load_stop_words(DATA_PATH / "en" / "stop_words.txt")
+
+        # When
+        _persist_stop_words(stop_words, self.fixture_dir / "stop_words.txt")
+        loaded_stop_words = _load_stop_words(
+            self.fixture_dir / "stop_words.txt")
+
+        # Then
+        self.assertSetEqual(stop_words, loaded_stop_words)
+
+    def test_should_persist_noise(self):
+        # Given
+        noise = _load_noise(DATA_PATH / "en" / "noise.txt")
+
+        # When
+        _persist_noise(noise, self.fixture_dir / "noise.txt")
+        loaded_noise = _load_noise(self.fixture_dir / "noise.txt")
+
+        # Then
+        self.assertListEqual(noise, loaded_noise)
+
+    def test_should_persist_word_clusters(self):
+        # Given
+        word_clusters = _load_word_clusters(
+            DATA_PATH / "en" / "word_clusters" / "brown_clusters.txt")
+
+        # When
+        _persist_word_clusters(word_clusters,
+                               self.fixture_dir / "brown_clusters.txt")
+        loaded_word_clusters = _load_word_clusters(
+            self.fixture_dir / "brown_clusters.txt")
+
+        # Then
+        self.assertDictEqual(word_clusters, loaded_word_clusters)
+
+    def test_should_persist_gazetteer(self):
+        # Given
+        gazetteer = _load_gazetteer(
+            DATA_PATH / "en" / "gazetteers" / "top_10000_words.txt")
+
+        # When
+        _persist_gazetteer(gazetteer, self.fixture_dir / "top_10000_words.txt")
+        loaded_gazetteer = _load_gazetteer(
+            self.fixture_dir / "top_10000_words.txt")
+
+        # Then
+        self.assertSetEqual(gazetteer, loaded_gazetteer)
+
+    def test_should_persist_stems(self):
+        # Given
+        stems = _load_stems(DATA_PATH / "en" / "stemming" / "stems.txt")
+
+        # When
+        _persist_stems(stems, self.fixture_dir / "stems.txt")
+        loaded_stems = _load_stems(self.fixture_dir / "stems.txt")
+
+        # Then
+        self.assertDictEqual(stems, loaded_stems)
 
 
 def resource_exists(language, resource_name):

--- a/snips_nlu/tests/test_resources.py
+++ b/snips_nlu/tests/test_resources.py
@@ -1,47 +1,38 @@
 from __future__ import unicode_literals
 
-from mock import patch
-
 from snips_nlu.constants import DATA_PATH
 from snips_nlu.resources import (
-    MissingResource, _RESOURCES, _get_resource, clear_resources,
-    load_resources, _persist_stop_words, _load_stop_words, _load_noise,
-    _persist_noise, _load_word_clusters, _persist_word_clusters,
-    _load_gazetteer, _persist_gazetteer, _load_stems, _persist_stems)
+    MissingResource, _get_resource, load_resources, _persist_stop_words,
+    _load_stop_words, _load_noise, _persist_noise, _load_word_clusters,
+    _persist_word_clusters, _load_gazetteer, _persist_gazetteer, _load_stems,
+    _persist_stems, get_stems)
 from snips_nlu.tests.utils import FixtureTest
 
 
 class TestResources(FixtureTest):
     def test_should_load_resources_from_data_path(self):
-        # Given
-        clear_resources()
-
         # When
-        load_resources("en")
+        resources = load_resources("en")
 
         # Then
-        self.assertTrue(resource_exists("en", "gazetteers"))
+        self.assertGreater(len(get_stems(resources)), 0)
 
     def test_should_load_resources_from_package(self):
-        # Given
-        clear_resources()
-
         # When
-        load_resources("snips_nlu_en")
+        resources = load_resources("snips_nlu_en")
 
         # Then
-        self.assertTrue(resource_exists("en", "gazetteers"))
+        self.assertGreater(len(get_stems(resources)), 0)
 
     def test_should_load_resources_from_path(self):
         # Given
-        clear_resources()
         resources_path = DATA_PATH / "en"
 
         # When
-        load_resources(str(resources_path))
+        resources = load_resources(str(resources_path))
 
         # Then
-        self.assertTrue(resource_exists("en", "gazetteers"))
+        self.assertGreater(len(get_stems(resources)), 0)
 
     def test_should_fail_loading_unknown_resources(self):
         # Given
@@ -51,23 +42,13 @@ class TestResources(FixtureTest):
         with self.assertRaises(MissingResource):
             load_resources(unknown_resource_name)
 
-    def test_should_raise_missing_resource_when_language_not_found(self):
-        # Given
-        mocked_value = dict()
-
-        # When
-        with patch("snips_nlu.resources._RESOURCES", mocked_value):
-            with self.assertRaises(MissingResource):
-                _get_resource("en", "foobar")
-
     def test_should_raise_missing_resource_when_resource_not_found(self):
         # Given
-        mocked_value = {"en": dict()}
+        resources = dict()
 
         # When
-        with patch("snips_nlu.resources._RESOURCES", mocked_value):
-            with self.assertRaises(MissingResource):
-                _get_resource("en", "foobar")
+        with self.assertRaises(MissingResource):
+            _get_resource(resources, "foobar")
 
     def test_should_persist_stop_words(self):
         # Given
@@ -129,8 +110,3 @@ class TestResources(FixtureTest):
 
         # Then
         self.assertDictEqual(stems, loaded_stems)
-
-
-def resource_exists(language, resource_name):
-    return resource_name in _RESOURCES[language] \
-           and _RESOURCES[language][resource_name] is not None

--- a/snips_nlu/tests/utils.py
+++ b/snips_nlu/tests/utils.py
@@ -157,7 +157,7 @@ class MockProcessingUnitMixin(object):
             f.write(json_string(unit_dict))
 
     @classmethod
-    def from_path(cls, path, **shared):
+    def from_path(cls, path, **shared):  # pylint:disable=unused-argument
         with (path / "metadata.json").open(encoding="utf8") as f:
             metadata = json.load(f)
         fitted = metadata["fitted"]

--- a/snips_nlu_samples/sample.py
+++ b/snips_nlu_samples/sample.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals, print_function
 import json
 from pathlib import Path
 
-from snips_nlu import SnipsNLUEngine, load_resources
+from snips_nlu import SnipsNLUEngine
 from snips_nlu.default_configs import CONFIG_EN
 
 SAMPLE_DATASET_PATH = Path(__file__).parent / "sample_dataset.json"
@@ -11,7 +11,6 @@ SAMPLE_DATASET_PATH = Path(__file__).parent / "sample_dataset.json"
 with SAMPLE_DATASET_PATH.open(encoding="utf8") as f:
     sample_dataset = json.load(f)
 
-load_resources("en")
 nlu_engine = SnipsNLUEngine(config=CONFIG_EN)
 nlu_engine.fit(sample_dataset)
 


### PR DESCRIPTION
**Description**:
When persisting a `SnipsNLUEngine` object, the resources are copied to the destination path from the path where they were initially fetched. This is wrong as, once loaded, a `SnipsNLUEngine` instance should be self contained in memory, which means that deleting the underlying resources directory should not affect its behavior.
This PR fixes this by persisting the resources by serializing the resources objects that are loaded in memory. Each engine now owns its resources.

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
