### PR TITLE
Return probability of None intent

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -287,8 +287,8 @@ section.
 
 .. important::
 
-    Even though the term "probability" is used here, the values should rather
-    be considered as scores as they do not sum to 1.0.
+    Even though the term ``"probability"`` is used here, the values should
+    rather be considered as confidence scores as they do not sum to 1.0.
 
 
 .. _none_intent:
@@ -302,16 +302,39 @@ generates an implicit intent to cover utterances that does not correspond to
 any of your intents. We refer to it as the **None** intent.
 
 The NLU engine is trained to recognize when the input corresponds to the None
-intent. Here is what you should get if you try parsing ``"foo bar"`` with the
-engine we previously created:
+intent. Here is the kind of output you should get if you try parsing
+``"foo bar"`` with the engine we previously created:
 
-.. code-block:: json
+.. tabs::
 
-    {
-      "input": "foo bar",
-      "intent": null,
-      "slots": null
-    }
+   .. tab:: Python
+
+      .. code-block:: python
+
+          {
+            "input": "foo bar",
+            "intent": {
+              "intentName": None,
+              "probability": 0.552122
+            },
+            "slots": []
+          }
+
+   .. tab:: JSON
+
+      .. code-block:: json
+
+          {
+            "input": "foo bar",
+            "intent": {
+              "intentName": null,
+              "probability": 0.552122
+            },
+            "slots": []
+          }
+
+The **None** intent is represented by a ``None`` value in python which
+translates in JSON into a ``null`` value.
 
 Persisting
 ----------

--- a/setup.py
+++ b/setup.py
@@ -43,11 +43,11 @@ extras_require = {
         "sphinx-tabs>=1.1,<1.2"
     ],
     "metrics": [
-        "snips_nlu_metrics>=0.14,<0.15",
+        "snips_nlu_metrics>=0.14.1,<0.15",
     ],
     "test": [
         "mock>=2.0,<3.0",
-        "snips_nlu_metrics>=0.14,<0.15",
+        "snips_nlu_metrics>=0.14.1,<0.15",
         "pylint<2",
         "coverage>=4.4.2,<5.0"
     ]

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -8,7 +8,11 @@ from pathlib import Path
 import numpy as np
 from sklearn.linear_model import SGDClassifier
 
-from snips_nlu.constants import LANGUAGE, RES_INTENT_NAME, RES_PROBA
+from snips_nlu.common.log_utils import DifferedLoggingMessage, log_elapsed_time
+from snips_nlu.common.utils import (
+    check_persisted_path, check_random_state,
+    fitted_required, json_string)
+from snips_nlu.constants import LANGUAGE, RES_PROBA
 from snips_nlu.dataset import validate_and_format_dataset
 from snips_nlu.exceptions import _EmptyDatasetUtterancesError
 from snips_nlu.intent_classifier.featurizer import Featurizer
@@ -17,10 +21,6 @@ from snips_nlu.intent_classifier.log_reg_classifier_utils import (
     build_training_data, get_regularization_factor, text_to_utterance)
 from snips_nlu.pipeline.configs import LogRegIntentClassifierConfig
 from snips_nlu.result import intent_classification_result
-from snips_nlu.common.utils import (
-    check_persisted_path, check_random_state,
-    fitted_required, json_string)
-from snips_nlu.common.log_utils import DifferedLoggingMessage, log_elapsed_time
 
 logger = logging.getLogger(__name__)
 

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -117,10 +117,7 @@ class LogRegIntentClassifier(IntentClassifier):
                 classifier is not fitted
 
         """
-        intents_results = self._get_intents(text, intents_filter)
-        if not intents_results or intents_results[0][RES_INTENT_NAME] is None:
-            return None
-        return intents_results[0]
+        return self._get_intents(text, intents_filter)[0]
 
     @fitted_required
     def get_intents(self, text):

--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -192,7 +192,7 @@ class DeterministicIntentParser(IntentParser):
                 intent = top_intents[0][RES_INTENT]
                 slots = top_intents[0][RES_SLOTS]
                 return parsing_result(text, intent, slots)
-            return empty_result(text)
+            return empty_result(text, probability=1.0)
         return self._parse_top_intents(text, top_n=top_n, intents=intents)
 
     def _parse_top_intents(self, text, top_n, intents=None):

--- a/snips_nlu/intent_parser/probabilistic_intent_parser.py
+++ b/snips_nlu/intent_parser/probabilistic_intent_parser.py
@@ -18,7 +18,7 @@ from snips_nlu.exceptions import IntentNotFoundError
 from snips_nlu.intent_classifier import IntentClassifier
 from snips_nlu.intent_parser.intent_parser import IntentParser
 from snips_nlu.pipeline.configs import ProbabilisticIntentParserConfig
-from snips_nlu.result import empty_result, parsing_result, extraction_result
+from snips_nlu.result import parsing_result, extraction_result
 from snips_nlu.slot_filler import SlotFiller
 
 logger = logging.getLogger(__name__)
@@ -132,18 +132,21 @@ class ProbabilisticIntentParser(IntentParser):
 
         if top_n is None:
             intent_result = self.intent_classifier.get_intent(text, intents)
-            if intent_result is None:
-                return empty_result(text)
-
             intent_name = intent_result[RES_INTENT_NAME]
-            slots = self.slot_fillers[intent_name].get_slots(text)
+            if intent_name is not None:
+                slots = self.slot_fillers[intent_name].get_slots(text)
+            else:
+                slots = []
             return parsing_result(text, intent_result, slots)
 
         results = []
         intents_results = self.intent_classifier.get_intents(text)
         for intent_result in intents_results[:top_n]:
             intent_name = intent_result[RES_INTENT_NAME]
-            slots = self.slot_fillers[intent_name].get_slots(text)
+            if intent_name is not None:
+                slots = self.slot_fillers[intent_name].get_slots(text)
+            else:
+                slots = []
             results.append(extraction_result(intent_result, slots))
         return results
 

--- a/snips_nlu/nlu_engine/nlu_engine.py
+++ b/snips_nlu/nlu_engine/nlu_engine.py
@@ -160,14 +160,16 @@ class SnipsNLUEngine(ProcessingUnit):
             intents = set(intents)
 
         if top_n is None:
+            none_proba = 0.0
             for parser in self.intent_parsers:
                 res = parser.parse(text, intents)
                 if is_empty(res):
+                    none_proba = res[RES_INTENT][RES_PROBA]
                     continue
                 resolved_slots = self._resolve_slots(text, res[RES_SLOTS])
                 return parsing_result(text, intent=res[RES_INTENT],
                                       slots=resolved_slots)
-            return empty_result(text)
+            return empty_result(text, none_proba)
 
         intents_results = self.get_intents(text)
         if intents is not None:

--- a/snips_nlu/result.py
+++ b/snips_nlu/result.py
@@ -289,12 +289,12 @@ def empty_result(input, probability):  # pylint:disable=redefined-builtin
         >>> from snips_nlu.common.utils import json_string
         >>> print(json_string(res, indent=4, sort_keys=True))
         {
-            'input': 'foo bar',
-            'intent': {
-                'intentName': None,
-                'probability': 0.8
+            "input": "foo bar",
+            "intent": {
+                "intentName": null,
+                "probability": 0.8
             },
-            'slots': []
+            "slots": []
         }
     """
     intent = intent_classification_result(None, probability)

--- a/snips_nlu/result.py
+++ b/snips_nlu/result.py
@@ -269,14 +269,14 @@ def is_empty(result):
 
     Example:
 
-        >>> res = empty_result("foo bar")
+        >>> res = empty_result("foo bar", 1.0)
         >>> is_empty(res)
         True
     """
-    return result[RES_INTENT] is None and result[RES_SLOTS] is None
+    return result[RES_INTENT][RES_INTENT_NAME] is None
 
 
-def empty_result(input):  # pylint:disable=redefined-builtin
+def empty_result(input, probability):  # pylint:disable=redefined-builtin
     """Creates an empty parsing result of the same format as the one of
     :func:`parsing_result`
 
@@ -285,11 +285,20 @@ def empty_result(input):  # pylint:disable=redefined-builtin
 
     Example:
 
-        >>> res = empty_result("foo bar")
-        >>> print(res)
-        {'input': 'foo bar', 'intent': None, 'slots': None}
+        >>> res = empty_result("foo bar", 0.8)
+        >>> from snips_nlu.common.utils import json_string
+        >>> print(json_string(res, indent=4, sort_keys=True))
+        {
+            'input': 'foo bar',
+            'intent': {
+                'intentName': None,
+                'probability': 0.8
+            },
+            'slots': []
+        }
     """
-    return parsing_result(input=input, intent=None, slots=None)
+    intent = intent_classification_result(None, probability)
+    return parsing_result(input=input, intent=intent, slots=[])
 
 
 def parsed_entity(entity_kind, entity_value, entity_resolved_value,

--- a/snips_nlu/tests/test_deterministic_intent_parser.py
+++ b/snips_nlu/tests/test_deterministic_intent_parser.py
@@ -18,7 +18,8 @@ from snips_nlu.intent_parser.deterministic_intent_parser import (
     _get_range_shift)
 from snips_nlu.pipeline.configs import DeterministicIntentParserConfig
 from snips_nlu.result import (
-    extraction_result, intent_classification_result, unresolved_slot)
+    extraction_result, intent_classification_result, unresolved_slot,
+    empty_result)
 from snips_nlu.tests.utils import FixtureTest, TEST_PATH
 
 
@@ -112,7 +113,7 @@ utterances:
         parsing = parser.parse(text, intents=["intent1"])
 
         # Then
-        self.assertIsNone(parsing[RES_INTENT])
+        self.assertEqual(empty_result(text, 1.0), parsing)
 
     def test_should_parse_top_intents(self):
         # Given
@@ -184,7 +185,7 @@ utterances:
         res = parser.parse(text)
 
         # Then
-        self.assertIsNone(res[RES_INTENT])
+        self.assertEqual(empty_result(text, 1.0), res)
 
     def test_should_not_parse_when_not_fitted(self):
         # Given

--- a/snips_nlu/tests/test_log_reg_intent_classifier.py
+++ b/snips_nlu/tests/test_log_reg_intent_classifier.py
@@ -18,6 +18,7 @@ from snips_nlu.intent_classifier.featurizer import Featurizer
 from snips_nlu.intent_classifier.log_reg_classifier_utils import (
     text_to_utterance)
 from snips_nlu.pipeline.configs import LogRegIntentClassifierConfig
+from snips_nlu.result import intent_classification_result
 from snips_nlu.tests.utils import (FixtureTest, get_empty_dataset)
 
 
@@ -89,7 +90,7 @@ utterances:
         result = classifier.get_intent(text)
 
         # Then
-        self.assertIsNone(result)
+        self.assertEqual(intent_classification_result(None, 1.0), result)
 
     def test_should_get_intent_when_filter(self):
         # Given
@@ -126,7 +127,7 @@ utterances:
         # Then
         self.assertEqual("MakeTea", res1[RES_INTENT_NAME])
         self.assertEqual("MakeCoffee", res2[RES_INTENT_NAME])
-        self.assertEqual(None, res3)
+        self.assertEqual(None, res3[RES_INTENT_NAME])
 
     def test_should_raise_when_not_fitted(self):
         # Given
@@ -147,7 +148,7 @@ utterances:
         intent = classifier.get_intent(text)
 
         # Then
-        expected_intent = None
+        expected_intent = intent_classification_result(None, 1.0)
         self.assertEqual(intent, expected_intent)
 
     def test_should_get_intents(self):
@@ -422,7 +423,7 @@ values:
         # When / Then
         intent_classifier = LogRegIntentClassifier().fit(dataset)
         intent = intent_classifier.get_intent("no intent there")
-        self.assertEqual(None, intent)
+        self.assertEqual(intent_classification_result(None, 1.0), intent)
 
     def test_log_activation_weights(self):
         # Given

--- a/snips_nlu/tests/test_nlu_engine.py
+++ b/snips_nlu/tests/test_nlu_engine.py
@@ -264,7 +264,7 @@ utterances:
             def parse(self, text, intents=None, top_n=None):
                 if text == input_text:
                     return parsing_result(text, intent, slots)
-                return empty_result(text)
+                return empty_result(text, 1.0)
 
         # pylint:enable=unused-variable
 
@@ -343,7 +343,7 @@ utterances:
         result = engine.parse("hello world")
 
         # Then
-        self.assertEqual(empty_result("hello world"), result)
+        self.assertEqual(empty_result("hello world", 1.0), result)
 
     def test_should_not_parse_slots_when_not_fitted(self):
         # Given
@@ -826,7 +826,7 @@ utterances:
                                             entity="dummy_entity_2",
                                             slot_name="other_dummy_slot_name")]
 
-        mocked_regex_parse.return_value = empty_result(text)
+        mocked_regex_parse.return_value = empty_result(text, 1.0)
         mocked_crf_parse.return_value = parsing_result(
             text, mocked_crf_intent, mocked_crf_slots)
 

--- a/snips_nlu/tests/test_result.py
+++ b/snips_nlu/tests/test_result.py
@@ -36,18 +36,3 @@ class TestResult(SnipsTest):
                          RES_VALUE: 'slot_value'}],
             RES_INPUT: input_}
         self.assertDictEqual(expected_result, result)
-
-    def test_should_serialize_results_when_none_values(self):
-        # Given
-        input_ = "hello world"
-
-        # When
-        result = parsing_result(input=input_, intent=None, slots=None)
-
-        # Then
-        expected_result = {
-            RES_INTENT: None,
-            RES_SLOTS: None,
-            RES_INPUT: input_
-        }
-        self.assertDictEqual(expected_result, result)

--- a/snips_nlu/tests/utils.py
+++ b/snips_nlu/tests/utils.py
@@ -130,7 +130,7 @@ class MockIntentParser(IntentParser):
         return hasattr(self, '_fitted') and self._fitted
 
     def parse(self, text, intents=None, top_n=None):
-        return empty_result(text)
+        return empty_result(text, 1.0)
 
     def get_intents(self, text):
         return []


### PR DESCRIPTION
**Description**:
This PR changes the way the implicit None intent is handled. More specifically, when no intent was found (i.e. when the None intent is found), the parsing output looked like:

```python
{
    "input": "foo bar",
    "intent": None,
    "slots": None
}
```

This was inconsistent compared to the parsing output when an intent was found. Thus this PR changes the parsing output in the case of a None intent to the following:

```python
{
    "input": "foo bar",
    "intent": {
        "intentName": None,
        "probability": 0.552122
    },
    "slots": []
}
```

The `"intent"` value is now ensured to be not None, and a probability is always returned. Besides, the `"slots"` value is now always a list.

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
