### PR TITLE
Make cooccurrence order configurable

### DIFF
--- a/snips_nlu/default_configs/config_de.py
+++ b/snips_nlu/default_configs/config_de.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 CONFIG = {
     "unit_name": "nlu_engine",
     "intent_parsers_configs": [
@@ -190,7 +192,8 @@ CONFIG = {
                     "cooccurrence_vectorizer_config": {
                         "unknown_words_replacement_string": None,
                         "window_size": None,
-                        "filter_stop_words": True
+                        "filter_stop_words": True,
+                        "keep_order": True,
                     }
                 },
                 "random_seed": None

--- a/snips_nlu/default_configs/config_en.py
+++ b/snips_nlu/default_configs/config_en.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 CONFIG = {
     "unit_name": "nlu_engine",
     "intent_parsers_configs": [
@@ -167,7 +169,8 @@ CONFIG = {
                     "cooccurrence_vectorizer_config": {
                         "unknown_words_replacement_string": None,
                         "window_size": None,
-                        "filter_stop_words": True
+                        "filter_stop_words": True,
+                        "keep_order": True,
                     }
                 },
                 "random_seed": None

--- a/snips_nlu/default_configs/config_es.py
+++ b/snips_nlu/default_configs/config_es.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 CONFIG = {
     "unit_name": "nlu_engine",
     "intent_parsers_configs": [
@@ -154,7 +156,8 @@ CONFIG = {
                     "cooccurrence_vectorizer_config": {
                         "unknown_words_replacement_string": None,
                         "window_size": None,
-                        "filter_stop_words": True
+                        "filter_stop_words": True,
+                        "keep_order": True,
                     }
                 },
                 "random_seed": None

--- a/snips_nlu/default_configs/config_fr.py
+++ b/snips_nlu/default_configs/config_fr.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 CONFIG = {
     "unit_name": "nlu_engine",
     "intent_parsers_configs": [
@@ -154,7 +156,8 @@ CONFIG = {
                     "cooccurrence_vectorizer_config": {
                         "unknown_words_replacement_string": None,
                         "window_size": None,
-                        "filter_stop_words": True
+                        "filter_stop_words": True,
+                        "keep_order": True,
                     }
                 },
                 "random_seed": None

--- a/snips_nlu/default_configs/config_it.py
+++ b/snips_nlu/default_configs/config_it.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 CONFIG = {
     "unit_name": "nlu_engine",
     "intent_parsers_configs": [
@@ -154,7 +156,8 @@ CONFIG = {
                     "cooccurrence_vectorizer_config": {
                         "unknown_words_replacement_string": None,
                         "window_size": None,
-                        "filter_stop_words": True
+                        "filter_stop_words": True,
+                        "keep_order": True
                     }
                 },
                 "random_seed": None

--- a/snips_nlu/default_configs/config_ja.py
+++ b/snips_nlu/default_configs/config_ja.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 CONFIG = {
     "unit_name": "nlu_engine",
     "intent_parsers_configs": [
@@ -210,7 +212,8 @@ CONFIG = {
                     "cooccurrence_vectorizer_config": {
                         "unknown_words_replacement_string": None,
                         "window_size": None,
-                        "filter_stop_words": True
+                        "filter_stop_words": True,
+                        "keep_order": True
                     }
                 },
                 "random_seed": None

--- a/snips_nlu/default_configs/config_ko.py
+++ b/snips_nlu/default_configs/config_ko.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 CONFIG = {
     "unit_name": "nlu_engine",
     "intent_parsers_configs": [
@@ -188,7 +190,8 @@ CONFIG = {
                     "cooccurrence_vectorizer_config": {
                         "unknown_words_replacement_string": None,
                         "window_size": None,
-                        "filter_stop_words": True
+                        "filter_stop_words": True,
+                        "keep_order": True
                     }
                 },
                 "random_seed": None

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -689,7 +689,10 @@ class CooccurrenceVectorizer(ProcessingUnit):
             if self.config.window_size is not None:
                 max_index = j + self.config.window_size + 1
             for w2 in utterance[j + 1:max_index]:
-                pairs.add((w1, w2))
+                key = (w1, w2)
+                if not self.config.keep_order:
+                    key = tuple(sorted(key))
+                pairs.add(key)
         return pairs
 
     @fitted_required

--- a/snips_nlu/pipeline/configs/intent_classifier.py
+++ b/snips_nlu/pipeline/configs/intent_classifier.py
@@ -254,7 +254,7 @@ class CooccurrenceVectorizerConfig(FromDict, ProcessingUnitConfig):
     """Configuration of a :class:`.CooccurrenceVectorizer` object"""
 
     def __init__(self, window_size=None, unknown_words_replacement_string=None,
-                 filter_stop_words=True):
+                 filter_stop_words=True, keep_order=True):
         """
         Args:
             window_size (int, optional): if provided, word cooccurrences will
@@ -266,11 +266,16 @@ class CooccurrenceVectorizerConfig(FromDict, ProcessingUnitConfig):
             unknown_words_replacement_string (str, optional)
             filter_stop_words (bool, optional): if True, stop words are ignored
                 when computing cooccurrences
+            keep_order (bool, optional): if True then cooccurrence are computed
+                taking the words order into account, which means the pairs
+                (w1, w2) and (w2, w1) will count as two separate features.
+                Defaults to `True`.
         """
         self.window_size = window_size
         self.unknown_words_replacement_string = \
             unknown_words_replacement_string
         self.filter_stop_words = filter_stop_words
+        self.keep_order = keep_order
 
     @property
     def unit_name(self):
@@ -295,5 +300,6 @@ class CooccurrenceVectorizerConfig(FromDict, ProcessingUnitConfig):
             "unknown_words_replacement_string":
                 self.unknown_words_replacement_string,
             "window_size": self.window_size,
-            "filter_stop_words": self.filter_stop_words
+            "filter_stop_words": self.filter_stop_words,
+            "keep_order": self.keep_order
         }

--- a/snips_nlu/tests/test_config.py
+++ b/snips_nlu/tests/test_config.py
@@ -95,7 +95,8 @@ class TestConfig(SnipsTest):
             "unit_name": "cooccurrence_vectorizer",
             "unknown_words_replacement_string": None,
             "window_size": 5,
-            "filter_stop_words": True
+            "filter_stop_words": True,
+            "keep_order": True,
         }
 
         # When


### PR DESCRIPTION
**Description**:
- Added a `keep_order` boolean parameter to the `CooccurrenceVectorizerConfig`, when this parameter is `False` we look for unordered cooccurrence while if it's `True` then word order is kept for cooccurrence extraction