### PR TITLE
Increase max_queries from 100 to 500 in default configurations

### DIFF
--- a/snips_nlu/default_configs/config_de.py
+++ b/snips_nlu/default_configs/config_de.py
@@ -5,7 +5,7 @@ CONFIG = {
     "intent_parsers_configs": [
         {
             "unit_name": "deterministic_intent_parser",
-            "max_queries": 100,
+            "max_queries": 500,
             "max_pattern_length": 1000,
             "ignore_stop_words": True
         },

--- a/snips_nlu/default_configs/config_en.py
+++ b/snips_nlu/default_configs/config_en.py
@@ -5,7 +5,7 @@ CONFIG = {
     "intent_parsers_configs": [
         {
             "unit_name": "deterministic_intent_parser",
-            "max_queries": 100,
+            "max_queries": 500,
             "max_pattern_length": 1000,
             "ignore_stop_words": True
         },

--- a/snips_nlu/default_configs/config_es.py
+++ b/snips_nlu/default_configs/config_es.py
@@ -5,7 +5,7 @@ CONFIG = {
     "intent_parsers_configs": [
         {
             "unit_name": "deterministic_intent_parser",
-            "max_queries": 100,
+            "max_queries": 500,
             "max_pattern_length": 1000,
             "ignore_stop_words": True
         },

--- a/snips_nlu/default_configs/config_fr.py
+++ b/snips_nlu/default_configs/config_fr.py
@@ -5,7 +5,7 @@ CONFIG = {
     "intent_parsers_configs": [
         {
             "unit_name": "deterministic_intent_parser",
-            "max_queries": 100,
+            "max_queries": 500,
             "max_pattern_length": 1000,
             "ignore_stop_words": True
         },

--- a/snips_nlu/default_configs/config_it.py
+++ b/snips_nlu/default_configs/config_it.py
@@ -5,7 +5,7 @@ CONFIG = {
     "intent_parsers_configs": [
         {
             "unit_name": "deterministic_intent_parser",
-            "max_queries": 100,
+            "max_queries": 500,
             "max_pattern_length": 1000,
             "ignore_stop_words": True
         },

--- a/snips_nlu/default_configs/config_ja.py
+++ b/snips_nlu/default_configs/config_ja.py
@@ -5,7 +5,7 @@ CONFIG = {
     "intent_parsers_configs": [
         {
             "unit_name": "deterministic_intent_parser",
-            "max_queries": 100,
+            "max_queries": 500,
             "max_pattern_length": 1000,
             "ignore_stop_words": False
         },

--- a/snips_nlu/default_configs/config_ko.py
+++ b/snips_nlu/default_configs/config_ko.py
@@ -5,7 +5,7 @@ CONFIG = {
     "intent_parsers_configs": [
         {
             "unit_name": "deterministic_intent_parser",
-            "max_queries": 100,
+            "max_queries": 500,
             "max_pattern_length": 1000,
             "ignore_stop_words": False
         },


### PR DESCRIPTION
**Description**:
With the improvements that were made in PR https://github.com/snipsco/snips-nlu/pull/717, it now makes sense to improve the value of `"max_queries"` in the default configuration of each language.
This parameter sets the maximum number of utterances that should be kept, per intent, in order to build the regular expressions of the `DeterministicIntentParser`.
Increasing this parameters increases the chances that this parser finds a match. On the other hands, it increases the memory footprints, as we store more patterns, and it increases the time to the `SnipsNLUEngine` object.

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
