### PR TITLE
Fix handling of builtin entities in CRFSlotFiller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Fixed
+- Fix an issue regarding the way builtin entities were handled by the `CRFSlotFiller`
+
 ## [0.19.1] - 2019-02-04
 ### Fixed
 - Bug causing an unnecessary reloading of shared resources
@@ -232,6 +236,7 @@ several commands.
 - Fix compiling issue with `bindgen` dependency when installing from source
 - Fix issue in `CRFSlotFiller` when handling builtin entities
 
+[Unreleased]: https://github.com/snipsco/snips-nlu/compare/0.19.1...HEAD
 [0.19.1]: https://github.com/snipsco/snips-nlu/compare/0.19.0...0.19.1
 [0.19.0]: https://github.com/snipsco/snips-nlu/compare/0.18.0...0.19.0
 [0.18.0]: https://github.com/snipsco/snips-nlu/compare/0.17.4...0.18.0

--- a/snips_nlu/cli/metrics.py
+++ b/snips_nlu/cli/metrics.py
@@ -66,6 +66,7 @@ def cross_val_metrics(dataset_path, output_path, config_path=None, nb_folds=5,
         nb_folds=nb_folds,
         train_size_ratio=train_size_ratio,
         include_slot_metrics=not exclude_slot_metrics,
+        slot_matching_lambda=_match_trimmed_values
     )
 
     from snips_nlu_metrics import compute_cross_val_metrics
@@ -108,7 +109,8 @@ def train_test_metrics(train_dataset_path, test_dataset_path, output_path,
         train_dataset=train_dataset_path,
         test_dataset=test_dataset_path,
         engine_class=engine_cls,
-        include_slot_metrics=not exclude_slot_metrics
+        include_slot_metrics=not exclude_slot_metrics,
+        slot_matching_lambda=_match_trimmed_values
     )
 
     from snips_nlu_metrics import compute_train_test_metrics
@@ -119,3 +121,9 @@ def train_test_metrics(train_dataset_path, test_dataset_path, output_path,
 
     with Path(output_path).open(mode="w", encoding="utf8") as f:
         f.write(json_string(metrics))
+
+
+def _match_trimmed_values(lhs_slot, rhs_slot):
+    lhs_value = lhs_slot["text"].strip()
+    rhs_value = rhs_slot["rawValue"].strip()
+    return lhs_value == rhs_value


### PR DESCRIPTION
**Description**:
This PR removes a logic that was used in the `CRFSlotFiller` to handle builtin entities. This logic consisted in discarding the builtin tags, as found by the CRF, and instead use the results of the `BuiltinEntityParser` to create possible combinations of builtin slots, and rank those combinations based on the sequence probability given by the CRF.
This logic seems to be the cause of various issues, especially in cases where the span of builtin entities is made ambiguous by the context in the sentence (cf new `CRFSlotFiller` unit test). In such cases, the CRF is pretty good at finding the correct span, and thus the previous logic was detrimental. 

The new logic was benchmarked on a comprehensive list of datasets of various sizes, in various languages. Overall, the F1-score of slot filling is strictly improved, up to 10% in certain cases.

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
