### PR TITLE
Fix issue with mutated config

### DIFF
--- a/snips_nlu/slot_filler/crf_slot_filler.py
+++ b/snips_nlu/slot_filler/crf_slot_filler.py
@@ -7,6 +7,7 @@ import math
 import shutil
 import tempfile
 from builtins import range
+from copy import deepcopy
 from pathlib import Path
 
 from future.utils import iteritems
@@ -48,6 +49,9 @@ class CRFSlotFiller(SlotFiller):
     def __init__(self, config=None, **shared):
         """The CRF slot filler can be configured by passing a
         :class:`.CRFSlotFillerConfig`"""
+        # The CRFSlotFillerConfig must be deep-copied as it is mutated when
+        # fitting the feature factories
+        config = deepcopy(config)
         super(CRFSlotFiller, self).__init__(config, **shared)
         self.crf_model = None
         self.features_factories = [


### PR DESCRIPTION
**Description**:
The `CRFSlotFillerConfig` passed to the `CRFSlotFiller` when initializing it, is mutated during the training. Thus, it must be deep-copied beforehand to prevent side effects.

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
