### PR TITLE
Allow matching_strictness property to be int

### DIFF
--- a/snips_nlu/dataset/validation.py
+++ b/snips_nlu/dataset/validation.py
@@ -128,7 +128,7 @@ def _validate_and_format_custom_entity(entity, queries_entities, language,
     validate_type(entity[AUTOMATICALLY_EXTENSIBLE], bool,
                   object_label="automatically_extensible")
     validate_type(entity[DATA], list, object_label="entity data")
-    validate_type(entity[MATCHING_STRICTNESS], float,
+    validate_type(entity[MATCHING_STRICTNESS], (float, int),
                   object_label="matching_strictness")
 
     formatted_entity = dict()

--- a/snips_nlu/tests/test_dataset_validation.py
+++ b/snips_nlu/tests/test_dataset_validation.py
@@ -93,6 +93,35 @@ class TestDatasetValidation(SnipsTest):
         self.assertEqual("Expected custom entity to have key: 'use_synonyms'",
                          str(ctx.exception.args[0]))
 
+    def test_should_support_int_or_float_for_matching_strictness(self):
+        # Given
+        dataset = {
+            "intents": {},
+            "entities": {
+                "entity1": {
+                    "data": [],
+                    "automatically_extensible": False,
+                    "use_synonyms": True,
+                    "matching_strictness": 0.5
+                },
+                "entity2": {
+                    "data": [],
+                    "automatically_extensible": False,
+                    "use_synonyms": True,
+                    "matching_strictness": 1
+                }
+            },
+            "language": "en",
+        }
+
+        # When/Then
+        dataset = validate_and_format_dataset(dataset)
+
+        self.assertEqual(
+            0.5, dataset["entities"]["entity1"].get("matching_strictness"))
+        self.assertEqual(
+            1, dataset["entities"]["entity2"].get("matching_strictness"))
+
     def test_missing_matching_strictness_should_be_handled(self):
         # TODO: This test is temporary, and must be removed once the backward
         # compatibility with the previous dataset format, without


### PR DESCRIPTION
**Description**:
Allows the `matching_strictness` entity property of the dataset to take integer values, on top of float values.

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
