### PR TITLE
Fix issue with resources required by the deterministic intent parser

### DIFF
--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -127,6 +127,7 @@ class DeterministicIntentParser(IntentParser):
         """Fits the intent parser with a valid Snips dataset"""
         logger.info("Fitting deterministic parser...")
         dataset = validate_and_format_dataset(dataset)
+        self.load_resources_if_needed(dataset[LANGUAGE])
         self.fit_builtin_entity_parser_if_needed(dataset)
         self.fit_custom_entity_parser_if_needed(dataset)
         self.language = dataset[LANGUAGE]

--- a/snips_nlu/pipeline/configs/intent_parser.py
+++ b/snips_nlu/pipeline/configs/intent_parser.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from snips_nlu.common.from_dict import FromDict
-from snips_nlu.constants import CUSTOM_ENTITY_PARSER_USAGE
+from snips_nlu.constants import CUSTOM_ENTITY_PARSER_USAGE, STOP_WORDS
 from snips_nlu.entity_parser import CustomEntityParserUsage
 from snips_nlu.pipeline.configs import ProcessingUnitConfig
 from snips_nlu.resources import merge_required_resources
@@ -84,7 +84,8 @@ class DeterministicIntentParserConfig(FromDict, ProcessingUnitConfig):
 
     def get_required_resources(self):
         return {
-            CUSTOM_ENTITY_PARSER_USAGE: CustomEntityParserUsage.WITHOUT_STEMS
+            CUSTOM_ENTITY_PARSER_USAGE: CustomEntityParserUsage.WITHOUT_STEMS,
+            STOP_WORDS: self.ignore_stop_words
         }
 
     def to_dict(self):


### PR DESCRIPTION
**Description**:
The stop words resources are actually required by the `DeterministicIntentParser` when `ignore_stop_words` is `True` (stop words must be known to be ignored).

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
