### PR TITLE
Fix issue with group names in deterministic parser

### DIFF
--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -314,7 +314,7 @@ class DeterministicIntentParser(IntentParser):
         for group_name in found_result.groupdict():
             ref_group_name = group_name
             if "_" in group_name:
-                ref_group_name = group_name[:(len(group_name) - 2)]
+                ref_group_name = group_name.split("_")[0]
             slot_name = self.group_names_to_slot_names[ref_group_name]
             entity = self.slot_names_to_entities[intent][slot_name]
             rng = (found_result.start(group_name),


### PR DESCRIPTION
**Description**:
This fixes an issue when handling and parsing group names in the deterministic intent parser.

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
