### PR TITLE
Fix inference CLI

### DIFF
--- a/snips_nlu/cli/inference.py
+++ b/snips_nlu/cli/inference.py
@@ -18,6 +18,7 @@ from snips_nlu.common.utils import unicode_string, json_string
 )
 def parse(training_path, query, verbose=False):
     """Load a trained NLU engine and play with its parsing API interactively"""
+    from builtins import str
     if verbose:
         set_nlu_logger(logging.DEBUG)
 
@@ -29,6 +30,8 @@ def parse(training_path, query, verbose=False):
 
     while True:
         query = input("Enter a query (type 'q' to quit): ").strip()
+        if not isinstance(query, str):
+            query = query.decode("utf-8")
         if query == "q":
             break
         print_parsing_result(engine, query)

--- a/snips_nlu/common/log_utils.py
+++ b/snips_nlu/common/log_utils.py
@@ -1,3 +1,6 @@
+from __future__ import unicode_literals
+
+from builtins import str
 from datetime import datetime
 from functools import wraps
 


### PR DESCRIPTION
**Description**:
- In Python 2.7, UTF-8 `str` input must be converted to `unicode` otherwise we can't type UTF-8 characters in the inference CLI