### PR TITLE
Sort resources before persisting them

### DIFF
--- a/snips_nlu/resources.py
+++ b/snips_nlu/resources.py
@@ -254,6 +254,7 @@ def _load_stop_words(stop_words_path):
 
 
 def _persist_stop_words(stop_words, path):
+    stop_words = sorted(stop_words)
     with path.open(encoding="utf8", mode="w") as f:
         for stop_word in stop_words:
             f.write("%s\n" % stop_word)
@@ -305,7 +306,7 @@ def _load_word_clusters(path):
 
 def _persist_word_clusters(word_clusters, path):
     with path.open(encoding="utf8", mode="w") as f:
-        for word, cluster in iteritems(word_clusters):
+        for word, cluster in sorted(iteritems(word_clusters)):
             f.write("%s\t%s\n" % (word, cluster))
 
 
@@ -327,6 +328,8 @@ def _load_gazetteer(path):
 
 
 def _persist_gazetteer(gazetteer, path):
+    # Sort gazetteer to avoid serialization diffs
+    gazetteer = sorted(gazetteer)
     with path.open(encoding="utf8", mode="w") as f:
         for word in gazetteer:
             f.write("%s\n" % word)
@@ -355,7 +358,7 @@ def _persist_stems(stems, path):
     for value, stem in iteritems(stems):
         reversed_stems[stem].append(value)
     with path.open(encoding="utf8", mode="w") as f:
-        for stem, values in iteritems(reversed_stems):
-            elements = [stem] + values
+        for stem, values in sorted(iteritems(reversed_stems)):
+            elements = [stem] + sorted(values)
             line = ",".join(elements)
             f.write("%s\n" % line)

--- a/snips_nlu/slot_filler/feature_factory.py
+++ b/snips_nlu/slot_filler/feature_factory.py
@@ -508,7 +508,8 @@ class BuiltinEntityMatchFactory(CRFFeatureFactory):
 
     def fit(self, dataset, intent):
         self.language = dataset[LANGUAGE]
-        self.builtin_entities = self._get_builtin_entity_scope(dataset, intent)
+        self.builtin_entities = sorted(
+            self._get_builtin_entity_scope(dataset, intent))
         self.args["entity_labels"] = self.builtin_entities
 
     def build_features(self):


### PR DESCRIPTION
**Description**:
Sort resources alphabetically before persisting them in order to avoid serialization diffs between two trainings.

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
