### PR TITLE
Fix issue with egg fragments in download cli

### DIFF
--- a/snips_nlu/cli/download.py
+++ b/snips_nlu/cli/download.py
@@ -28,7 +28,11 @@ def download(resource_name, direct=False,
              *pip_args):  # pylint:disable=keyword-arg-before-vararg
     """Download compatible language resources"""
     if direct:
-        url_tail = '{r}/{r}.tar.gz#egg={r}'.format(r=resource_name)
+        components = resource_name.split("-")
+        name = "".join(components[:-1])
+        version = components[-1]
+        url_tail = '{n}-{v}/{n}-{v}.tar.gz#egg={n}=={v}'.format(
+            n=name, v=version)
         download_url = __about__.__download_url__ + '/' + url_tail
         dl = install_remote_package(download_url, pip_args)
         if dl != 0:


### PR DESCRIPTION
**Description**:
The egg fragment must be `#egg=my_package==version` instead of `#egg=my_package-version`

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
