### PR TITLE
Improve failed linking error message after download of resources

### DIFF
--- a/snips_nlu/cli/download.py
+++ b/snips_nlu/cli/download.py
@@ -83,10 +83,10 @@ def _download_and_link(resource_alias, resource_fullname, compatibility,
             pretty_print("%s --> %s" % (str(resources_dir), str(link_path)),
                          title="Linking successful",
                          level=PrettyPrintLevel.SUCCESS)
-    except:  # pylint:disable=bare-except
+    except OSError as e:  # pylint:disable=bare-except
         pretty_print(
-            "Creating a shortcut link for '%s' didn't work." % resource_alias,
+            "Creating a shortcut link for '%s' didn't work: %s"
+            % (resource_alias, repr(e)),
             title="The language resources were successfully downloaded, "
                   "however linking failed.",
             level=PrettyPrintLevel.ERROR)
-        raise

--- a/snips_nlu/cli/download.py
+++ b/snips_nlu/cli/download.py
@@ -88,4 +88,5 @@ def _download_and_link(resource_alias, resource_fullname, compatibility,
             "Creating a shortcut link for '%s' didn't work." % resource_alias,
             title="The language resources were successfully downloaded, "
                   "however linking failed.",
-            level=PrettyPrintLevel.WARNING)
+            level=PrettyPrintLevel.ERROR)
+        raise


### PR DESCRIPTION
**Description**:
This avoids silencing underlying symbolic linking errors.

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
