### PR TITLE
Release 0.19.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Advanced inference logging in the `CRFSlotFiller` [#776](https://github.com/snipsco/snips-nlu/pull/776)
+- Improved failed linking error message after download of resources [#774](https://github.com/snipsco/snips-nlu/pull/774)
+- Improve handling of ambiguous utterances in DeterministicIntentParser [#773](https://github.com/snipsco/snips-nlu/pull/773)
+
+### Fixed
+- Fixed a crash due to missing resources when refitting the `CRFSlotFiller` [#771](https://github.com/snipsco/snips-nlu/pull/771)
+- Fixed issue with egg fragments in download cli [#769](https://github.com/snipsco/snips-nlu/pull/769)
+
 ## [0.19.4] - 2019-03-06
 ### Added
 - Support for Portuguese: "pt_pt" and "pt_br"
@@ -250,6 +260,7 @@ several commands.
 - Fix compiling issue with `bindgen` dependency when installing from source
 - Fix issue in `CRFSlotFiller` when handling builtin entities
 
+[Unreleased]: https://github.com/snipsco/snips-nlu/compare/0.19.4...HEAD
 [0.19.4]: https://github.com/snipsco/snips-nlu/compare/0.19.3...0.19.4
 [0.19.3]: https://github.com/snipsco/snips-nlu/compare/0.19.2...0.19.3
 [0.19.2]: https://github.com/snipsco/snips-nlu/compare/0.19.1...0.19.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.19.5]
 ### Added
 - Advanced inference logging in the `CRFSlotFiller` [#776](https://github.com/snipsco/snips-nlu/pull/776)
 - Improved failed linking error message after download of resources [#774](https://github.com/snipsco/snips-nlu/pull/774)
@@ -264,7 +264,7 @@ several commands.
 - Fix compiling issue with `bindgen` dependency when installing from source
 - Fix issue in `CRFSlotFiller` when handling builtin entities
 
-[Unreleased]: https://github.com/snipsco/snips-nlu/compare/0.19.4...HEAD
+[0.19.5]: https://github.com/snipsco/snips-nlu/compare/0.19.4...0.19.5
 [0.19.4]: https://github.com/snipsco/snips-nlu/compare/0.19.3...0.19.4
 [0.19.3]: https://github.com/snipsco/snips-nlu/compare/0.19.2...0.19.3
 [0.19.2]: https://github.com/snipsco/snips-nlu/compare/0.19.1...0.19.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Fixed a crash due to missing resources when refitting the `CRFSlotFiller` [#771](https://github.com/snipsco/snips-nlu/pull/771)
 - Fixed issue with egg fragments in download cli [#769](https://github.com/snipsco/snips-nlu/pull/769)
+- Fixed an issue causing the `None` intent to be ignored when using the `parse` API in conjunction with `intents` and `top_n` [#781](https://github.com/snipsco/snips-nlu/pull/781)
 
 ## [0.19.4] - 2019-03-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 - Improved failed linking error message after download of resources [#774](https://github.com/snipsco/snips-nlu/pull/774)
 - Improve handling of ambiguous utterances in DeterministicIntentParser [#773](https://github.com/snipsco/snips-nlu/pull/773)
 
+### Changed
+- Remove normalization of confidence scores in intent classification [#782](https://github.com/snipsco/snips-nlu/pull/782)
+
 ### Fixed
 - Fixed a crash due to missing resources when refitting the `CRFSlotFiller` [#771](https://github.com/snipsco/snips-nlu/pull/771)
 - Fixed issue with egg fragments in download cli [#769](https://github.com/snipsco/snips-nlu/pull/769)

--- a/snips_nlu/__about__.py
+++ b/snips_nlu/__about__.py
@@ -11,7 +11,7 @@ __author__ = "Clement Doumouro, Adrien Ball"
 __email__ = "clement.doumouro@snips.ai, adrien.ball@snips.ai"
 __license__ = "Apache License, Version 2.0"
 
-__version__ = "0.19.4"
+__version__ = "0.19.5"
 __model_version__ = "0.19.0"
 
 __download_url__ = "https://github.com/snipsco/snips-nlu-language-resources/releases/download"

--- a/snips_nlu/cli/download.py
+++ b/snips_nlu/cli/download.py
@@ -28,7 +28,11 @@ def download(resource_name, direct=False,
              *pip_args):  # pylint:disable=keyword-arg-before-vararg
     """Download compatible language resources"""
     if direct:
-        url_tail = '{r}/{r}.tar.gz#egg={r}'.format(r=resource_name)
+        components = resource_name.split("-")
+        name = "".join(components[:-1])
+        version = components[-1]
+        url_tail = '{n}-{v}/{n}-{v}.tar.gz#egg={n}=={v}'.format(
+            n=name, v=version)
         download_url = __about__.__download_url__ + '/' + url_tail
         dl = install_remote_package(download_url, pip_args)
         if dl != 0:

--- a/snips_nlu/cli/download.py
+++ b/snips_nlu/cli/download.py
@@ -83,9 +83,10 @@ def _download_and_link(resource_alias, resource_fullname, compatibility,
             pretty_print("%s --> %s" % (str(resources_dir), str(link_path)),
                          title="Linking successful",
                          level=PrettyPrintLevel.SUCCESS)
-    except:  # pylint:disable=bare-except
+    except OSError as e:  # pylint:disable=bare-except
         pretty_print(
-            "Creating a shortcut link for '%s' didn't work." % resource_alias,
+            "Creating a shortcut link for '%s' didn't work: %s"
+            % (resource_alias, repr(e)),
             title="The language resources were successfully downloaded, "
                   "however linking failed.",
-            level=PrettyPrintLevel.WARNING)
+            level=PrettyPrintLevel.ERROR)

--- a/snips_nlu/default_configs/config_de.py
+++ b/snips_nlu/default_configs/config_de.py
@@ -22,13 +22,7 @@ CONFIG = {
                             "n": 1
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [-2, -1, 0, 1, 2]
                     },
                     {
                         "args": {
@@ -38,101 +32,59 @@ CONFIG = {
                             "n": 2
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            1
-                        ]
+                        "offsets": [-2, 1]
                     },
                     {
                         "args": {
                             "prefix_size": 2
                         },
                         "factory_name": "prefix",
-                        "offsets": [
-                            0
-                        ]
+                        "offsets": [0]
                     },
                     {
-                        "args": {
-                            "prefix_size": 5
-                        },
+                        "args": {"prefix_size": 5},
                         "factory_name": "prefix",
-                        "offsets": [
-                            0
-                        ]
+                        "offsets": [0]
                     },
                     {
-                        "args": {
-                            "suffix_size": 2
-                        },
+                        "args": {"suffix_size": 2},
                         "factory_name": "suffix",
-                        "offsets": [
-                            0
-                        ]
+                        "offsets": [0]
                     },
                     {
-                        "args": {
-                            "suffix_size": 5
-                        },
+                        "args": {"suffix_size": 5},
                         "factory_name": "suffix",
-                        "offsets": [
-                            0
-                        ]
+                        "offsets": [0]
                     },
                     {
                         "args": {},
                         "factory_name": "is_digit",
-                        "offsets": [
-                            -1,
-                            0,
-                            1
-                        ]
+                        "offsets": [-1, 0, 1]
                     },
                     {
                         "args": {},
                         "factory_name": "is_first",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ]
+                        "offsets": [-2, -1, 0]
                     },
                     {
                         "args": {},
                         "factory_name": "is_last",
-                        "offsets": [
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [0, 1, 2]
                     },
                     {
-                        "args": {
-                            "n": 1
-                        },
+                        "args": {"n": 1},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            0
-                        ]
+                        "offsets": [0]
                     },
                     {
-                        "args": {
-                            "n": 2
-                        },
+                        "args": {"n": 2},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1,
-                            0
-                        ]
+                        "offsets": [-1, 0]
                     },
                     {
-                        "args": {
-                            "n": 3
-                        },
+                        "args": {"n": 3},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1
-                        ]
+                        "offsets": [-1]
                     },
                     {
                         "args": {
@@ -140,23 +92,13 @@ CONFIG = {
                             "tagging_scheme_code": 2
                         },
                         "factory_name": "entity_match",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ],
+                        "offsets": [-2, -1, 0],
                         "drop_out": 0.5
                     },
                     {
-                        "args": {
-                            "tagging_scheme_code": 1
-                        },
+                        "args": {"tagging_scheme_code": 1},
                         "factory_name": "builtin_entity_match",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ]
+                        "offsets": [-2, -1, 0]
                     }
                 ],
                 "crf_args": {

--- a/snips_nlu/default_configs/config_en.py
+++ b/snips_nlu/default_configs/config_en.py
@@ -22,13 +22,7 @@ CONFIG = {
                             "n": 1
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [-2, -1, 0, 1, 2]
                     },
                     {
                         "args": {
@@ -38,65 +32,37 @@ CONFIG = {
                             "n": 2
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            1
-                        ]
+                        "offsets": [-2, 1]
                     },
                     {
                         "args": {},
                         "factory_name": "is_digit",
-                        "offsets": [
-                            -1,
-                            0,
-                            1
-                        ]
+                        "offsets": [-1, 0, 1]
                     },
                     {
                         "args": {},
                         "factory_name": "is_first",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ]
+                        "offsets": [-2, -1, 0]
                     },
                     {
                         "args": {},
                         "factory_name": "is_last",
-                        "offsets": [
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [0, 1, 2]
                     },
                     {
-                        "args": {
-                            "n": 1
-                        },
+                        "args": {"n": 1},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            0
-                        ]
+                        "offsets": [0]
                     },
                     {
-                        "args": {
-                            "n": 2
-                        },
+                        "args": {"n": 2},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1,
-                            0
-                        ]
+                        "offsets": [-1, 0]
                     },
                     {
-                        "args": {
-                            "n": 3
-                        },
+                        "args": {"n": 3},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1
-                        ]
+                        "offsets": [-1]
                     },
                     {
                         "args": {
@@ -104,23 +70,13 @@ CONFIG = {
                             "tagging_scheme_code": 2
                         },
                         "factory_name": "entity_match",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ],
+                        "offsets": [-2, -1, 0],
                         "drop_out": 0.5
                     },
                     {
-                        "args": {
-                            "tagging_scheme_code": 1
-                        },
+                        "args": {"tagging_scheme_code": 1},
                         "factory_name": "builtin_entity_match",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ]
+                        "offsets": [-2, -1, 0]
                     },
                     {
                         "args": {
@@ -128,12 +84,7 @@ CONFIG = {
                             "use_stemming": False
                         },
                         "factory_name": "word_cluster",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0,
-                            1
-                        ]
+                        "offsets": [-2, -1, 0, 1]
                     }
                 ],
                 "crf_args": {

--- a/snips_nlu/default_configs/config_es.py
+++ b/snips_nlu/default_configs/config_es.py
@@ -22,13 +22,7 @@ CONFIG = {
                             "n": 1
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [-2, -1, 0, 1, 2]
                     },
                     {
                         "args": {
@@ -38,65 +32,37 @@ CONFIG = {
                             "n": 2
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            1
-                        ]
+                        "offsets": [-2, 1]
                     },
                     {
                         "args": {},
                         "factory_name": "is_digit",
-                        "offsets": [
-                            -1,
-                            0,
-                            1
-                        ]
+                        "offsets": [-1, 0, 1]
                     },
                     {
                         "args": {},
                         "factory_name": "is_first",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ]
+                        "offsets": [-2, -1, 0]
                     },
                     {
                         "args": {},
                         "factory_name": "is_last",
-                        "offsets": [
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [0, 1, 2]
                     },
                     {
-                        "args": {
-                            "n": 1
-                        },
+                        "args": {"n": 1},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            0
-                        ]
+                        "offsets": [0]
                     },
                     {
-                        "args": {
-                            "n": 2
-                        },
+                        "args": {"n": 2},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1,
-                            0
-                        ]
+                        "offsets": [-1, 0]
                     },
                     {
-                        "args": {
-                            "n": 3
-                        },
+                        "args": {"n": 3},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1
-                        ]
+                        "offsets": [-1]
                     },
                     {
                         "args": {
@@ -104,23 +70,13 @@ CONFIG = {
                             "tagging_scheme_code": 2
                         },
                         "factory_name": "entity_match",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ],
+                        "offsets": [-2, -1, 0],
                         "drop_out": 0.5
                     },
                     {
-                        "args": {
-                            "tagging_scheme_code": 1
-                        },
+                        "args": {"tagging_scheme_code": 1},
                         "factory_name": "builtin_entity_match",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ]
+                        "offsets": [-2, -1, 0]
                     }
                 ],
                 "crf_args": {

--- a/snips_nlu/default_configs/config_fr.py
+++ b/snips_nlu/default_configs/config_fr.py
@@ -22,13 +22,7 @@ CONFIG = {
                             "n": 1
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [-2, -1, 0, 1, 2]
                     },
                     {
                         "args": {
@@ -38,65 +32,37 @@ CONFIG = {
                             "n": 2
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            1
-                        ]
+                        "offsets": [-2, 1]
                     },
                     {
                         "args": {},
                         "factory_name": "is_digit",
-                        "offsets": [
-                            -1,
-                            0,
-                            1
-                        ]
+                        "offsets": [-1, 0, 1]
                     },
                     {
                         "args": {},
                         "factory_name": "is_first",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ]
+                        "offsets": [-2, -1, 0]
                     },
                     {
                         "args": {},
                         "factory_name": "is_last",
-                        "offsets": [
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [0, 1, 2]
                     },
                     {
-                        "args": {
-                            "n": 1
-                        },
+                        "args": {"n": 1},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            0
-                        ]
+                        "offsets": [0]
                     },
                     {
-                        "args": {
-                            "n": 2
-                        },
+                        "args": {"n": 2},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1,
-                            0
-                        ]
+                        "offsets": [-1, 0]
                     },
                     {
-                        "args": {
-                            "n": 3
-                        },
+                        "args": {"n": 3},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1
-                        ]
+                        "offsets": [-1]
                     },
                     {
                         "args": {
@@ -104,23 +70,13 @@ CONFIG = {
                             "tagging_scheme_code": 2
                         },
                         "factory_name": "entity_match",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ],
+                        "offsets": [-2, -1, 0],
                         "drop_out": 0.5
                     },
                     {
-                        "args": {
-                            "tagging_scheme_code": 1
-                        },
+                        "args": {"tagging_scheme_code": 1},
                         "factory_name": "builtin_entity_match",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ]
+                        "offsets": [-2, -1, 0]
                     }
                 ],
                 "crf_args": {

--- a/snips_nlu/default_configs/config_it.py
+++ b/snips_nlu/default_configs/config_it.py
@@ -22,13 +22,7 @@ CONFIG = {
                             "n": 1
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [-2, -1, 0, 1, 2]
                     },
                     {
                         "args": {
@@ -38,65 +32,37 @@ CONFIG = {
                             "n": 2
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            1
-                        ]
+                        "offsets": [-2, 1]
                     },
                     {
                         "args": {},
                         "factory_name": "is_digit",
-                        "offsets": [
-                            -1,
-                            0,
-                            1
-                        ]
+                        "offsets": [-1, 0, 1]
                     },
                     {
                         "args": {},
                         "factory_name": "is_first",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ]
+                        "offsets": [-2, -1, 0]
                     },
                     {
                         "args": {},
                         "factory_name": "is_last",
-                        "offsets": [
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [0, 1, 2]
                     },
                     {
-                        "args": {
-                            "n": 1
-                        },
+                        "args": {"n": 1},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            0
-                        ]
+                        "offsets": [0]
                     },
                     {
-                        "args": {
-                            "n": 2
-                        },
+                        "args": {"n": 2},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1,
-                            0
-                        ]
+                        "offsets": [-1, 0]
                     },
                     {
-                        "args": {
-                            "n": 3
-                        },
+                        "args": {"n": 3},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1
-                        ]
+                        "offsets": [-1]
                     },
                     {
                         "args": {
@@ -104,23 +70,13 @@ CONFIG = {
                             "tagging_scheme_code": 2
                         },
                         "factory_name": "entity_match",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ],
+                        "offsets": [-2, -1, 0],
                         "drop_out": 0.5
                     },
                     {
-                        "args": {
-                            "tagging_scheme_code": 1
-                        },
+                        "args": {"tagging_scheme_code": 1},
                         "factory_name": "builtin_entity_match",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ]
+                        "offsets": [-2, -1, 0]
                     }
                 ],
                 "crf_args": {

--- a/snips_nlu/default_configs/config_ja.py
+++ b/snips_nlu/default_configs/config_ja.py
@@ -21,13 +21,7 @@ CONFIG = {
                             "n": 1
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [-2, -1, 0, 1, 2]
                     },
                     {
                         "args": {
@@ -36,107 +30,57 @@ CONFIG = {
                             "n": 2
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [-2, 0, 1, 2]
                     },
                     {
-                        "args": {
-                            "prefix_size": 1
-                        },
+                        "args": {"prefix_size": 1},
                         "factory_name": "prefix",
-                        "offsets": [
-                            0,
-                            1
-                        ]
+                        "offsets": [0, 1]
                     },
                     {
-                        "args": {
-                            "prefix_size": 2
-                        },
+                        "args": {"prefix_size": 2},
                         "factory_name": "prefix",
-                        "offsets": [
-                            0,
-                            1
-                        ]
+                        "offsets": [0, 1]
                     },
                     {
-                        "args": {
-                            "suffix_size": 1
-                        },
+                        "args": {"suffix_size": 1},
                         "factory_name": "suffix",
-                        "offsets": [
-                            0,
-                            1
-                        ]
+                        "offsets": [0, 1]
                     },
                     {
-                        "args": {
-                            "suffix_size": 2
-                        },
+                        "args": {"suffix_size": 2},
                         "factory_name": "suffix",
-                        "offsets": [
-                            0,
-                            1
-                        ]
+                        "offsets": [0, 1]
                     },
                     {
                         "args": {},
                         "factory_name": "is_digit",
-                        "offsets": [
-                            -1,
-                            0,
-                            1
-                        ]
+                        "offsets": [-1, 0, 1]
                     },
                     {
                         "args": {},
                         "factory_name": "is_first",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ]
+                        "offsets": [-2, -1, 0]
                     },
                     {
                         "args": {},
                         "factory_name": "is_last",
-                        "offsets": [
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [0, 1, 2]
                     },
                     {
-                        "args": {
-                            "n": 1
-                        },
+                        "args": {"n": 1},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            0
-                        ]
+                        "offsets": [0]
                     },
                     {
-                        "args": {
-                            "n": 2
-                        },
+                        "args": {"n": 2},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1,
-                            0
-                        ]
+                        "offsets": [-1, 0]
                     },
                     {
-                        "args": {
-                            "n": 3
-                        },
+                        "args": {"n": 3},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1
-                        ]
+                        "offsets": [-1]
                     },
                     {
                         "args": {
@@ -144,25 +88,13 @@ CONFIG = {
                             "tagging_scheme_code": 2
                         },
                         "factory_name": "entity_match",
-                        "offsets": [
-                            -1,
-                            0,
-                            1,
-                            2
-                        ],
+                        "offsets": [-1, 0, 1, 2],
                         "drop_out": 0.5
                     },
                     {
-                        "args": {
-                            "tagging_scheme_code": 1
-                        },
+                        "args": {"tagging_scheme_code": 1},
                         "factory_name": "builtin_entity_match",
-                        "offsets": [
-                            -1,
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [-1, 0, 1, 2]
                     },
                     {
                         "args": {
@@ -170,13 +102,7 @@ CONFIG = {
                             "use_stemming": False
                         },
                         "factory_name": "word_cluster",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [-2, -1, 0, 1, 2]
                     }
                 ],
                 "crf_args": {

--- a/snips_nlu/default_configs/config_ko.py
+++ b/snips_nlu/default_configs/config_ko.py
@@ -21,13 +21,7 @@ CONFIG = {
                             "n": 1
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [-2, -1, 0, 1, 2]
                     },
                     {
                         "args": {
@@ -36,101 +30,57 @@ CONFIG = {
                             "n": 2
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            1
-                        ]
+                        "offsets": [-2, 1]
                     },
                     {
-                        "args": {
-                            "prefix_size": 1
-                        },
+                        "args": {"prefix_size": 1},
                         "factory_name": "prefix",
-                        "offsets": [
-                            0
-                        ]
+                        "offsets": [0]
                     },
                     {
-                        "args": {
-                            "prefix_size": 2
-                        },
+                        "args": {"prefix_size": 2},
                         "factory_name": "prefix",
-                        "offsets": [
-                            0
-                        ]
+                        "offsets": [0]
                     },
                     {
-                        "args": {
-                            "suffix_size": 1
-                        },
+                        "args": {"suffix_size": 1},
                         "factory_name": "suffix",
-                        "offsets": [
-                            0
-                        ]
+                        "offsets": [0]
                     },
                     {
-                        "args": {
-                            "suffix_size": 2
-                        },
+                        "args": {"suffix_size": 2},
                         "factory_name": "suffix",
-                        "offsets": [
-                            0
-                        ]
+                        "offsets": [0]
                     },
                     {
                         "args": {},
                         "factory_name": "is_digit",
-                        "offsets": [
-                            -1,
-                            0,
-                            1
-                        ]
+                        "offsets": [-1, 0, 1]
                     },
                     {
                         "args": {},
                         "factory_name": "is_first",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ]
+                        "offsets": [-2, -1, 0]
                     },
                     {
                         "args": {},
                         "factory_name": "is_last",
-                        "offsets": [
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [0, 1, 2]
                     },
                     {
-                        "args": {
-                            "n": 1
-                        },
+                        "args": {"n": 1},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            0
-                        ]
+                        "offsets": [0]
                     },
                     {
-                        "args": {
-                            "n": 2
-                        },
+                        "args": {"n": 2},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1,
-                            0
-                        ]
+                        "offsets": [-1, 0]
                     },
                     {
-                        "args": {
-                            "n": 3
-                        },
+                        "args": {"n": 3},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1
-                        ]
+                        "offsets": [-1]
                     },
                     {
                         "args": {
@@ -138,23 +88,13 @@ CONFIG = {
                             "tagging_scheme_code": 2
                         },
                         "factory_name": "entity_match",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ],
+                        "offsets": [-2, -1, 0],
                         "drop_out": 0.5
                     },
                     {
-                        "args": {
-                            "tagging_scheme_code": 1
-                        },
+                        "args": {"tagging_scheme_code": 1},
                         "factory_name": "builtin_entity_match",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ]
+                        "offsets": [-2, -1, 0]
                     }
                 ],
                 "crf_args": {

--- a/snips_nlu/default_configs/config_pt_br.py
+++ b/snips_nlu/default_configs/config_pt_br.py
@@ -22,13 +22,7 @@ CONFIG = {
                             "n": 1
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [-2, -1, 0, 1, 2]
                     },
                     {
                         "args": {
@@ -38,65 +32,37 @@ CONFIG = {
                             "n": 2
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            1
-                        ]
+                        "offsets": [-2, 1]
                     },
                     {
                         "args": {},
                         "factory_name": "is_digit",
-                        "offsets": [
-                            -1,
-                            0,
-                            1
-                        ]
+                        "offsets": [-1, 0, 1]
                     },
                     {
                         "args": {},
                         "factory_name": "is_first",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ]
+                        "offsets": [-2, -1, 0]
                     },
                     {
                         "args": {},
                         "factory_name": "is_last",
-                        "offsets": [
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [0, 1, 2]
                     },
                     {
-                        "args": {
-                            "n": 1
-                        },
+                        "args": {"n": 1},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            0
-                        ]
+                        "offsets": [0]
                     },
                     {
-                        "args": {
-                            "n": 2
-                        },
+                        "args": {"n": 2},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1,
-                            0
-                        ]
+                        "offsets": [-1, 0]
                     },
                     {
-                        "args": {
-                            "n": 3
-                        },
+                        "args": {"n": 3},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1
-                        ]
+                        "offsets": [-1]
                     },
                     {
                         "args": {
@@ -104,23 +70,13 @@ CONFIG = {
                             "tagging_scheme_code": 2
                         },
                         "factory_name": "entity_match",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ],
+                        "offsets": [-2, -1, 0],
                         "drop_out": 0.5
                     },
                     {
-                        "args": {
-                            "tagging_scheme_code": 1
-                        },
+                        "args": {"tagging_scheme_code": 1},
                         "factory_name": "builtin_entity_match",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ]
+                        "offsets": [-2, -1, 0]
                     }
                 ],
                 "crf_args": {

--- a/snips_nlu/default_configs/config_pt_pt.py
+++ b/snips_nlu/default_configs/config_pt_pt.py
@@ -22,13 +22,7 @@ CONFIG = {
                             "n": 1
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [-2, -1, 0, 1, 2]
                     },
                     {
                         "args": {
@@ -38,65 +32,37 @@ CONFIG = {
                             "n": 2
                         },
                         "factory_name": "ngram",
-                        "offsets": [
-                            -2,
-                            1
-                        ]
+                        "offsets": [-2, 1]
                     },
                     {
                         "args": {},
                         "factory_name": "is_digit",
-                        "offsets": [
-                            -1,
-                            0,
-                            1
-                        ]
+                        "offsets": [-1, 0, 1]
                     },
                     {
                         "args": {},
                         "factory_name": "is_first",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ]
+                        "offsets": [-2, -1, 0]
                     },
                     {
                         "args": {},
                         "factory_name": "is_last",
-                        "offsets": [
-                            0,
-                            1,
-                            2
-                        ]
+                        "offsets": [0, 1, 2]
                     },
                     {
-                        "args": {
-                            "n": 1
-                        },
+                        "args": {"n": 1},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            0
-                        ]
+                        "offsets": [0]
                     },
                     {
-                        "args": {
-                            "n": 2
-                        },
+                        "args": {"n": 2},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1,
-                            0
-                        ]
+                        "offsets": [-1, 0]
                     },
                     {
-                        "args": {
-                            "n": 3
-                        },
+                        "args": {"n": 3},
                         "factory_name": "shape_ngram",
-                        "offsets": [
-                            -1
-                        ]
+                        "offsets": [-1]
                     },
                     {
                         "args": {
@@ -104,23 +70,13 @@ CONFIG = {
                             "tagging_scheme_code": 2
                         },
                         "factory_name": "entity_match",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ],
+                        "offsets": [-2, -1, 0],
                         "drop_out": 0.5
                     },
                     {
-                        "args": {
-                            "tagging_scheme_code": 1
-                        },
+                        "args": {"tagging_scheme_code": 1},
                         "factory_name": "builtin_entity_match",
-                        "offsets": [
-                            -2,
-                            -1,
-                            0
-                        ]
+                        "offsets": [-2, -1, 0]
                     }
                 ],
                 "crf_args": {

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -153,7 +153,7 @@ class LogRegIntentClassifier(IntentClassifier):
         # pylint: disable=C0103
         X = self.featurizer.transform([text_to_utterance(text)])
         # pylint: enable=C0103
-        proba_vec = self._predict_proba(X, intents_filter=intents_filter)
+        proba_vec = self._predict_proba(X)
         logger.debug(
             "%s", DifferedLoggingMessage(self.log_activation_weights, text, X))
         results = [
@@ -163,14 +163,8 @@ class LogRegIntentClassifier(IntentClassifier):
 
         return sorted(results, key=lambda res: -res[RES_PROBA])
 
-    def _predict_proba(self, X, intents_filter):  # pylint: disable=C0103
+    def _predict_proba(self, X):  # pylint: disable=C0103
         self.classifier._check_proba()  # pylint: disable=W0212
-
-        filtered_out_indexes = None
-        if intents_filter is not None:
-            filtered_out_indexes = [
-                i for i, intent in enumerate(self.intent_list)
-                if intent not in intents_filter and intent is not None]
 
         prob = self.classifier.decision_function(X)
         prob *= -1
@@ -179,14 +173,7 @@ class LogRegIntentClassifier(IntentClassifier):
         np.reciprocal(prob, prob)
         if prob.ndim == 1:
             return np.vstack([1 - prob, prob]).T
-        else:
-            if filtered_out_indexes:  # not None and not empty
-                prob[:, filtered_out_indexes] = 0.
-                # OvR normalization, like LibLinear's predict_probability
-                prob /= prob.sum(axis=1).reshape((prob.shape[0], -1))
-            # We do not normalize when there is no intents filter, to keep the
-            # probabilities calibrated
-            return prob
+        return prob
 
     @check_persisted_path
     def persist(self, path):

--- a/snips_nlu/nlu_engine/nlu_engine.py
+++ b/snips_nlu/nlu_engine/nlu_engine.py
@@ -178,7 +178,8 @@ class SnipsNLUEngine(ProcessingUnit):
         intents_results = self.get_intents(text)
         if intents is not None:
             intents_results = [res for res in intents_results
-                               if res[RES_INTENT_NAME] in intents]
+                               if res[RES_INTENT_NAME] is None
+                               or res[RES_INTENT_NAME] in intents]
         intents_results = intents_results[:top_n]
         results = []
         for intent_res in intents_results:

--- a/snips_nlu/slot_filler/feature_factory.py
+++ b/snips_nlu/slot_filler/feature_factory.py
@@ -213,7 +213,7 @@ class NgramFactory(SingleFeatureFactory):
         self.use_stemming = self.args["use_stemming"]
         self.common_words_gazetteer_name = self.args[
             "common_words_gazetteer_name"]
-        self.gazetteer = None
+        self._gazetteer = None
         self._language = None
         self.language = self.args.get("language_code")
 
@@ -226,9 +226,16 @@ class NgramFactory(SingleFeatureFactory):
         if value is not None:
             self._language = value
             self.args["language_code"] = self.language
-            if self.common_words_gazetteer_name is not None:
-                self.gazetteer = get_gazetteer(
-                    self.resources, self.common_words_gazetteer_name)
+
+    @property
+    def gazetteer(self):
+        # Load the gazetteer lazily
+        if self.common_words_gazetteer_name is None:
+            return None
+        if self._gazetteer is None:
+            self._gazetteer = get_gazetteer(
+                self.resources, self.common_words_gazetteer_name)
+        return self._gazetteer
 
     @property
     def feature_name(self):

--- a/snips_nlu/tests/test_nlu_engine.py
+++ b/snips_nlu/tests/test_nlu_engine.py
@@ -105,6 +105,8 @@ utterances:
 
         # When
         results = nlu_engine.parse(text, top_n=3)
+        results_with_filter = nlu_engine.parse(
+            text, intents=["intent1", "intent3"], top_n=3)
 
         # Then
         expected_results = [
@@ -123,7 +125,23 @@ utterances:
                 []
             ),
         ]
+        expected_results_with_filter = [
+            extraction_result(
+                intent_classification_result("intent1", 0.5),
+                [custom_slot(
+                    unresolved_slot((0, 3), "foo", "entity1", "slot1"))]
+            ),
+            extraction_result(
+                intent_classification_result(None, 0.15),
+                []
+            ),
+            extraction_result(
+                intent_classification_result("intent3", 0.05),
+                []
+            ),
+        ]
         self.assertListEqual(expected_results, results)
+        self.assertListEqual(expected_results_with_filter, results_with_filter)
 
     def test_should_get_intents(self):
         # Given

--- a/tox.ini
+++ b/tox.ini
@@ -6,19 +6,7 @@ skip_install = true
 commands =
     pip install -e ".[test]"
 
-    snips-nlu download -d snips_nlu_pt_br-0.1.0
-    snips-nlu download -d snips_nlu_pt_pt-0.1.0
-    snips-nlu link snips_nlu_pt_br pt_br -f
-    snips-nlu link snips_nlu_pt_pt pt_pt -f
-
-    snips-nlu download de
-    snips-nlu download en
-    snips-nlu download es
-    snips-nlu download fr
-    snips-nlu download it
-    snips-nlu download ja
-    snips-nlu download ko
-
+    snips-nlu download-all-languages
     snips-nlu download-language-entities fr
     snips-nlu download-language-entities en
     coverage run -m unittest discover
@@ -33,18 +21,7 @@ skip_install = true
 commands =
     pip install -e ".[test]"
 
-    snips-nlu download -d snips_nlu_pt_br-0.1.0
-    snips-nlu download -d snips_nlu_pt_pt-0.1.0
-    snips-nlu link snips_nlu_pt_br pt_br -f
-    snips-nlu link snips_nlu_pt_pt pt_pt -f
-
-    snips-nlu download de
-    snips-nlu download en
-    snips-nlu download es
-    snips-nlu download fr
-    snips-nlu download it
-    snips-nlu download ja
-    snips-nlu download ko
+    snips-nlu download-all-languages
 
     python -m unittest discover -p 'linting_test*.py'
     python -m unittest discover -p 'integration_test*.py'


### PR DESCRIPTION
### Added
- Advanced inference logging in the `CRFSlotFiller` [#776](https://github.com/snipsco/snips-nlu/pull/776)
- Improved failed linking error message after download of resources [#774](https://github.com/snipsco/snips-nlu/pull/774)
- Improve handling of ambiguous utterances in DeterministicIntentParser [#773](https://github.com/snipsco/snips-nlu/pull/773)

### Changed
- Remove normalization of confidence scores in intent classification [#782](https://github.com/snipsco/snips-nlu/pull/782)

### Fixed
- Fixed a crash due to missing resources when refitting the `CRFSlotFiller` [#771](https://github.com/snipsco/snips-nlu/pull/771)
- Fixed issue with egg fragments in download cli [#769](https://github.com/snipsco/snips-nlu/pull/769)
- Fixed an issue causing the `None` intent to be ignored when using the `parse` API in conjunction with `intents` and `top_n` [#781](https://github.com/snipsco/snips-nlu/pull/781)