### PR TITLE
Fix issue with stop words in DeterministicIntentParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Fixed
 - Raise an error when using unknown intents in intents filter [#788](https://github.com/snipsco/snips-nlu/pull/788)
+- Fix issue with stop words in `DeterministicIntentParser` [#789](https://github.com/snipsco/snips-nlu/pull/789)
 
 ## [0.19.5]
 ### Added

--- a/snips_nlu/dataset/utils.py
+++ b/snips_nlu/dataset/utils.py
@@ -45,21 +45,12 @@ def extract_intent_entities(dataset, entity_filter=None):
 def extract_entity_values(dataset, apply_normalization):
     entities_per_intent = {intent: set() for intent in dataset[INTENTS]}
     intent_entities = extract_intent_entities(dataset)
-    utterance_entity_values = extract_utterance_entities(dataset)
-    declared_entity_values = {
-        ent: set(ent_data[UTTERANCES])
-        for ent, ent_data in iteritems(dataset[ENTITIES])}
-    all_entity_values = {
-        ent: set(utterance_entity_values[ent]).union(
-            declared_entity_values[ent]) for ent in dataset[ENTITIES]}
     for intent, entities in iteritems(intent_entities):
         for entity in entities:
-            entities_per_intent[intent].update(all_entity_values[entity])
-    if apply_normalization:
-        entities_per_intent = {
-            intent: {normalize(v) for v in values}
-            for intent, values in iteritems(entities_per_intent)
-        }
+            entity_values = set(dataset[ENTITIES][entity][UTTERANCES])
+            if apply_normalization:
+                entity_values = {normalize(v) for v in entity_values}
+            entities_per_intent[intent].update(entity_values)
     return entities_per_intent
 
 

--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -460,8 +460,10 @@ class DeterministicIntentParser(IntentParser):
         parser.slot_names_to_entities = unit_dict["slot_names_to_entities"]
         if parser.fitted:
             whitelist = unit_dict.get("stop_words_whitelist", dict())
+            # pylint:disable=protected-access
             parser._stop_words_whitelist = {
                 intent: set(values) for intent, values in iteritems(whitelist)}
+            # pylint:enable=protected-access
         return parser
 
 

--- a/snips_nlu/tests/test_dataset_utils.py
+++ b/snips_nlu/tests/test_dataset_utils.py
@@ -1,0 +1,60 @@
+from __future__ import unicode_literals
+
+import io
+from unittest import TestCase
+
+from snips_nlu.dataset import Dataset, validate_and_format_dataset
+from snips_nlu.dataset.utils import extract_entity_values
+
+
+class TestDatasetUtils(TestCase):
+    def test_should_extract_entity_values(self):
+        # Given
+        set_light_color_yaml = io.StringIO("""
+---
+type: intent
+name: setLightColor
+utterances:
+  - set the lights to [color](blue)
+  - change the light to [color](yellow) in the [room](bedroom)""")
+
+        turn_light_on_yaml = io.StringIO("""
+---
+type: intent
+name: turnLightOn
+utterances:
+  - turn the light on in the [room](kitchen)
+  - turn the [room](bathroom)'s lights on""")
+
+        color_yaml = io.StringIO("""
+type: entity
+name: color
+values:
+- [blue, cyan]
+- red""")
+
+        room_yaml = io.StringIO("""
+type: entity
+name: room
+values:
+- garage
+- [living room, main room]""")
+
+        dataset_files = [set_light_color_yaml, turn_light_on_yaml, color_yaml,
+                         room_yaml]
+        dataset = Dataset.from_yaml_files("en", dataset_files).json
+        dataset = validate_and_format_dataset(dataset)
+
+        # When
+        entity_values = extract_entity_values(dataset,
+                                              apply_normalization=True)
+
+        # Then
+        expected_values = {
+            "setLightColor": {"blue", "yellow", "cyan", "red", "bedroom",
+                              "garage", "living room", "main room", "kitchen",
+                              "bathroom"},
+            "turnLightOn": {"bedroom", "garage", "living room", "main room",
+                            "kitchen", "bathroom"}
+        }
+        self.assertDictEqual(expected_values, entity_values)

--- a/snips_nlu/tests/test_deterministic_intent_parser.py
+++ b/snips_nlu/tests/test_deterministic_intent_parser.py
@@ -888,7 +888,9 @@ values:
         expected_parser.group_names_to_slot_names = group_names_to_slot_names
         expected_parser.slot_names_to_entities = slot_names_to_entities
         expected_parser.patterns = patterns
+        # pylint:disable=protected-access
         expected_parser._stop_words_whitelist = dict()
+        # pylint:enable=protected-access
 
         self.assertEqual(parser.to_dict(), expected_parser.to_dict())
 
@@ -954,7 +956,9 @@ values:
         expected_parser.group_names_to_slot_names = group_names_to_slot_names
         expected_parser.slot_names_to_entities = slot_names_to_entities
         expected_parser.patterns = patterns
+        # pylint:disable=protected-access
         expected_parser._stop_words_whitelist = stop_words_whitelist
+        # pylint:enable=protected-access
 
         self.assertEqual(parser.to_dict(), expected_parser.to_dict())
 


### PR DESCRIPTION
**Description**:
The deterministic intent parser skips words that are in the stop words list. However, words that are both in the stop words list and in the list of entity values should not be skipped, and this is the goal of this PR.

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
