### PR TITLE
Change logging levels from debug to info

### DIFF
--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -52,7 +52,7 @@ class LogRegIntentClassifier(IntentClassifier):
         """Whether or not the intent classifier has already been fitted"""
         return self.intent_list is not None
 
-    @log_elapsed_time(logger, logging.DEBUG,
+    @log_elapsed_time(logger, logging.INFO,
                       "LogRegIntentClassifier in {elapsed_time}")
     def fit(self, dataset):
         """Fits the intent classifier with a valid Snips dataset
@@ -60,7 +60,7 @@ class LogRegIntentClassifier(IntentClassifier):
         Returns:
             :class:`LogRegIntentClassifier`: The same instance, trained
         """
-        logger.debug("Fitting LogRegIntentClassifier...")
+        logger.info("Fitting LogRegIntentClassifier...")
         dataset = validate_and_format_dataset(dataset)
         self.load_resources_if_needed(dataset[LANGUAGE])
         self.fit_builtin_entity_parser_if_needed(dataset)

--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -133,7 +133,7 @@ class DeterministicIntentParser(IntentParser):
         logger, logging.INFO, "Fitted deterministic parser in {elapsed_time}")
     def fit(self, dataset, force_retrain=True):
         """Fits the intent parser with a valid Snips dataset"""
-        logger.info("Fitting deterministic parser...")
+        logger.info("Fitting deterministic intent parser...")
         dataset = validate_and_format_dataset(dataset)
         self.load_resources_if_needed(dataset[LANGUAGE])
         self.fit_builtin_entity_parser_if_needed(dataset)

--- a/snips_nlu/slot_filler/crf_slot_filler.py
+++ b/snips_nlu/slot_filler/crf_slot_filler.py
@@ -95,7 +95,7 @@ class CRFSlotFiller(SlotFiller):
         """Whether or not the slot filler has already been fitted"""
         return self.slot_name_mapping is not None
 
-    @log_elapsed_time(logger, logging.DEBUG,
+    @log_elapsed_time(logger, logging.INFO,
                       "Fitted CRFSlotFiller in {elapsed_time}")
     # pylint:disable=arguments-differ
     def fit(self, dataset, intent):
@@ -109,7 +109,7 @@ class CRFSlotFiller(SlotFiller):
         Returns:
             :class:`CRFSlotFiller`: The same instance, trained
         """
-        logger.debug("Fitting %s slot filler...", intent)
+        logger.info("Fitting %s slot filler...", intent)
         dataset = validate_and_format_dataset(dataset)
         self.load_resources_if_needed(dataset[LANGUAGE])
         self.fit_builtin_entity_parser_if_needed(dataset)


### PR DESCRIPTION
**Description**
Fitting the following processing units now produces info logs, instead of debug logs:
- `CRFSlotFiller`
- `LogRegIntentClassifier`