### PR TITLE
Accept ambiguous results from DeterministicIntentParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Changed
 - Re-score ambiguous `DeterministicIntentParser` results based on slots [#791](https://github.com/snipsco/snips-nlu/pull/791)
+- Accept ambiguous results from `DeterministicIntentParser` when confidence score is above 0.5 [#797](https://github.com/snipsco/snips-nlu/pull/797)
 
 ## [0.19.6]
 ### Fixed

--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -203,7 +203,7 @@ class DeterministicIntentParser(IntentParser):
             if top_intents:
                 intent = top_intents[0][RES_INTENT]
                 slots = top_intents[0][RES_SLOTS]
-                if intent[RES_PROBA] < 1.0:
+                if intent[RES_PROBA] <= 0.5:
                     # return None in case of ambiguity
                     return empty_result(text, probability=1.0)
                 return parsing_result(text, intent, slots)


### PR DESCRIPTION
**Description**:
Ambiguous results (confidence score < 1.0) from the DeterministicIntentParser were systematically discarded. This PR lowers the threshold to 0.5 to allow for slight ambiguities.

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
