### PR TITLE
Avoid generating number variations when not needed

### DIFF
--- a/snips_nlu/string_variations.py
+++ b/snips_nlu/string_variations.py
@@ -155,7 +155,8 @@ def flatten(results):
     return set(i for r in results for i in r)
 
 
-def get_string_variations(string, language, builtin_entity_parser):
+def get_string_variations(string, language, builtin_entity_parser,
+                          number_variations=True):
     variations = {string}
     variations.update(flatten(case_variations(v) for v in variations))
     variations.update(flatten(normalization_variations(v) for v in variations))
@@ -165,9 +166,14 @@ def get_string_variations(string, language, builtin_entity_parser):
     variations.update(flatten(and_variations(v, language) for v in variations))
     variations.update(
         flatten(punctuation_variations(v, language) for v in variations))
-    variations.update(
-        flatten(numbers_variations(v, language, builtin_entity_parser)
-                for v in variations))
+
+    # Special case of number variation which are long to generate due to the
+    # BuilinEntityParser running on each variation
+    if number_variations:
+        variations.update(
+            flatten(numbers_variations(v, language, builtin_entity_parser)
+                    for v in variations)
+        )
     # Add single space variations
     single_space_variations = set(" ".join(v.split()) for v in variations)
     variations.update(single_space_variations)

--- a/snips_nlu/tests/test_string_variations.py
+++ b/snips_nlu/tests/test_string_variations.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 from __future__ import unicode_literals
 
+from mock import MagicMock
+
 from snips_nlu.constants import (LANGUAGE_EN, LANGUAGE_FR, RES_MATCH_RANGE,
                                  SNIPS_NUMBER, START)
 from snips_nlu.entity_parser import BuiltinEntityParser
@@ -164,3 +166,17 @@ class TestStringVariations(SnipsTest):
             "7.62 mm caliber two and 6",
         }
         self.assertSetEqual(variations, expected_variations)
+
+    def test_get_string_variations_should_not_generate_number_variations(self):
+        # Given
+        builtin_entity_parser = MagicMock()
+        mocked_parse = MagicMock(return_value=[])
+        builtin_entity_parser.parse = mocked_parse
+
+        # When/Then
+        get_string_variations("", "en", builtin_entity_parser,
+                              number_variations=False)
+        mocked_parse.assert_not_called()
+        get_string_variations(
+            "", "en", builtin_entity_parser, number_variations=True)
+        self.assertGreater(mocked_parse.call_count, 0)

--- a/snips_nlu/tests/utils.py
+++ b/snips_nlu/tests/utils.py
@@ -221,4 +221,4 @@ class EntityParserMock(EntityParser):
         return cls(entities)
 
     def _parse(self, text, scope=None):
-        return self.entities.get(text)
+        return self.entities.get(text, [])


### PR DESCRIPTION
**Description**:

After analysis generating number entity values variations when validating the dataset can take a very long time when the entity as a lot of value. This is mostly due to running Rustling on each entity value.

To be able to validate the dataset in a reasonable amount of time, number variations are computed only when there are less than 10000 entity values in the entity data.

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
