### PR TITLE
Reduce custom entity parser footprint in training time

### DIFF
--- a/snips_nlu/dataset/validation.py
+++ b/snips_nlu/dataset/validation.py
@@ -192,7 +192,7 @@ def _validate_and_format_custom_entity(entity, queries_entities, language,
         }
 
     variations_args["numbers"] = (
-            len(entity[DATA]) < NUMBER_VARIATIONS_THRESHOLD)
+        len(entity[DATA]) < NUMBER_VARIATIONS_THRESHOLD)
 
     variations = dict()
     for data in entity[DATA]:

--- a/snips_nlu/entity_parser/custom_entity_parser.py
+++ b/snips_nlu/entity_parser/custom_entity_parser.py
@@ -198,8 +198,8 @@ def _compute_char_shifts(tokens):
         else:
             previous_token_end = tokens[token_index - 1].end
             previous_space_len = 1
-        current_shift -= (token.start - previous_token_end
-                          ) - previous_space_len
+        offset = (token.start - previous_token_end) - previous_space_len
+        current_shift -= offset
         token_len = token.end - token.start
         index_shift = token_len + previous_space_len
         characters_shifts += [current_shift for _ in range(index_shift)]

--- a/snips_nlu/entity_parser/custom_entity_parser.py
+++ b/snips_nlu/entity_parser/custom_entity_parser.py
@@ -19,6 +19,8 @@ from snips_nlu.entity_parser.entity_parser import EntityParser
 from snips_nlu.preprocessing import stem, tokenize, tokenize_light
 from snips_nlu.result import parsed_entity
 
+STOPWORDS_FRACTION = 0.01
+
 
 class CustomEntityParser(EntityParser):
     def __init__(self, parser, language, parser_usage):
@@ -98,7 +100,10 @@ class CustomEntityParser(EntityParser):
             raise ValueError("A parser usage must be defined in order to fit "
                              "a CustomEntityParser")
         configuration = _create_custom_entity_parser_configuration(
-            custom_entities)
+            custom_entities,
+            language=dataset[LANGUAGE],
+            stopwords_fraction=STOPWORDS_FRACTION,
+        )
         parser = GazetteerEntityParser.build(configuration)
         return cls(parser, language, parser_usage)
 

--- a/snips_nlu/entity_parser/custom_entity_parser.py
+++ b/snips_nlu/entity_parser/custom_entity_parser.py
@@ -6,7 +6,7 @@ import operator
 from copy import deepcopy
 from pathlib import Path
 
-from future.utils import iteritems, viewvalues
+from future.utils import iteritems, itervalues, viewvalues
 from snips_nlu_parsers import GazetteerEntityParser
 
 from snips_nlu.common.utils import json_string
@@ -16,7 +16,7 @@ from snips_nlu.entity_parser.builtin_entity_parser import is_builtin_entity
 from snips_nlu.entity_parser.custom_entity_parser_usage import (
     CustomEntityParserUsage)
 from snips_nlu.entity_parser.entity_parser import EntityParser
-from snips_nlu.preprocessing import stem, tokenize
+from snips_nlu.preprocessing import stem, tokenize, tokenize_light
 from snips_nlu.result import parsed_entity
 
 
@@ -123,23 +123,53 @@ def _merge_entity_utterances(raw_utterances, stemmed_utterances):
     return raw_utterances
 
 
-def _create_custom_entity_parser_configuration(entities):
-    return {
-        "entity_parsers": [
-            {
-                "entity_identifier": entity_name,
-                "entity_parser": {
-                    "threshold": entity[MATCHING_STRICTNESS],
-                    "gazetteer": [
-                        {
-                            "raw_value": k,
-                            "resolved_value": v
-                        } for k, v in sorted(iteritems(entity[UTTERANCES]))
-                    ]
-                }
-            } for entity_name, entity in sorted(iteritems(entities))
-        ]
+def _create_custom_entity_parser_configuration(
+        entities, stopwords_fraction, language):
+    """Dynamically creates the gazetteer parser configuration.
+
+    Args:
+        entities (dict): entity for the dataset
+        stopwords_fraction (float): fraction of the vocabulary of
+            the entity values that will be considered as stop words (
+            the top n_vocabulary * stopwords_fraction most frequent words will
+            be considered stop words)
+        language (str): language of the entities
+
+    Returns: the parser configuration as dictionary
+    """
+
+    if not 0 < stopwords_fraction < 1:
+        raise ValueError("stopwords_fraction must be in ]0.0, 1.0[")
+
+    parser_configurations = []
+    for entity_name, entity in sorted(iteritems(entities)):
+        vocabulary = set()
+        entity_tokens = set(
+            t for raw_value in itervalues(entity[UTTERANCES])
+            for t in tokenize_light(raw_value, language)
+        )
+        vocabulary.update(entity_tokens)
+        num_stopwords = int(stopwords_fraction * len(vocabulary))
+        config = {
+            "entity_identifier": entity_name,
+            "entity_parser": {
+                "threshold": entity[MATCHING_STRICTNESS],
+                "n_gazetteer_stop_words": num_stopwords,
+                "gazetteer": [
+                    {
+                        "raw_value": k,
+                        "resolved_value": v
+                    } for k, v in sorted(iteritems(entity[UTTERANCES]))
+                ]
+            }
+        }
+        parser_configurations.append(config)
+
+    configuration = {
+        "entity_parsers": parser_configurations
     }
+
+    return configuration
 
 
 def _compute_char_shifts(tokens):
@@ -163,8 +193,8 @@ def _compute_char_shifts(tokens):
         else:
             previous_token_end = tokens[token_index - 1].end
             previous_space_len = 1
-        current_shift -= (token.start - previous_token_end) - \
-                         previous_space_len
+        current_shift -= (token.start - previous_token_end
+                          ) - previous_space_len
         token_len = token.end - token.start
         index_shift = token_len + previous_space_len
         characters_shifts += [current_shift for _ in range(index_shift)]

--- a/snips_nlu/entity_parser/custom_entity_parser.py
+++ b/snips_nlu/entity_parser/custom_entity_parser.py
@@ -19,7 +19,7 @@ from snips_nlu.entity_parser.entity_parser import EntityParser
 from snips_nlu.preprocessing import stem, tokenize, tokenize_light
 from snips_nlu.result import parsed_entity
 
-STOPWORDS_FRACTION = 0.01
+STOPWORDS_FRACTION = 1e-3
 
 
 class CustomEntityParser(EntityParser):

--- a/snips_nlu/entity_parser/custom_entity_parser.py
+++ b/snips_nlu/entity_parser/custom_entity_parser.py
@@ -6,7 +6,7 @@ import operator
 from copy import deepcopy
 from pathlib import Path
 
-from future.utils import iteritems, itervalues, viewvalues
+from future.utils import iteritems, viewvalues
 from snips_nlu_parsers import GazetteerEntityParser
 
 from snips_nlu.common.utils import json_string
@@ -148,12 +148,10 @@ def _create_custom_entity_parser_configuration(
 
     parser_configurations = []
     for entity_name, entity in sorted(iteritems(entities)):
-        vocabulary = set()
-        entity_tokens = set(
-            t for raw_value in itervalues(entity[UTTERANCES])
+        vocabulary = set(
+            t for raw_value in entity[UTTERANCES]
             for t in tokenize_light(raw_value, language)
         )
-        vocabulary.update(entity_tokens)
         num_stopwords = int(stopwords_fraction * len(vocabulary))
         config = {
             "entity_identifier": entity_name,

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -267,7 +267,7 @@ class LogRegIntentClassifier(IntentClassifier):
                 log += "\n{} -> {}".format(feature_name, feature_weight)
         return log
 
-    def log_activation_weights(self, text, x, top_n=50):
+    def log_activation_weights(self, text, x, top_n=400):
         if not hasattr(self.featurizer, "feature_index_to_feature_name"):
             return None
 

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -267,7 +267,7 @@ class LogRegIntentClassifier(IntentClassifier):
                 log += "\n{} -> {}".format(feature_name, feature_weight)
         return log
 
-    def log_activation_weights(self, text, x, top_n=400):
+    def log_activation_weights(self, text, x, top_n=50):
         if not hasattr(self.featurizer, "feature_index_to_feature_name"):
             return None
 

--- a/snips_nlu/string_variations.py
+++ b/snips_nlu/string_variations.py
@@ -9,9 +9,9 @@ from future.utils import iteritems
 from num2words import num2words
 from snips_nlu_utils import normalize
 
-from snips_nlu.constants import (
-    END, LANGUAGE_DE, LANGUAGE_EN, LANGUAGE_ES, LANGUAGE_FR, RES_MATCH_RANGE,
-    SNIPS_NUMBER, START, VALUE, RESOLVED_VALUE)
+from snips_nlu.constants import (END, LANGUAGE_DE, LANGUAGE_EN, LANGUAGE_ES,
+                                 LANGUAGE_FR, RESOLVED_VALUE, RES_MATCH_RANGE,
+                                 SNIPS_NUMBER, START, VALUE)
 from snips_nlu.languages import (
     get_default_sep, get_punctuation_regex, supports_num2words)
 from snips_nlu.preprocessing import tokenize_light
@@ -156,24 +156,32 @@ def flatten(results):
 
 
 def get_string_variations(string, language, builtin_entity_parser,
-                          number_variations=True):
+                          numbers=True, case=True, and_=True,
+                          punctuation=True):
     variations = {string}
-    variations.update(flatten(case_variations(v) for v in variations))
+    if case:
+        variations.update(flatten(case_variations(v) for v in variations))
+
     variations.update(flatten(normalization_variations(v) for v in variations))
     # We re-generate case variations as normalization can produce new
     # variations
-    variations.update(flatten(case_variations(v) for v in variations))
-    variations.update(flatten(and_variations(v, language) for v in variations))
-    variations.update(
-        flatten(punctuation_variations(v, language) for v in variations))
+    if case:
+        variations.update(flatten(case_variations(v) for v in variations))
+    if and_:
+        variations.update(
+            flatten(and_variations(v, language) for v in variations))
+    if punctuation:
+        variations.update(
+            flatten(punctuation_variations(v, language) for v in variations))
 
     # Special case of number variation which are long to generate due to the
     # BuilinEntityParser running on each variation
-    if number_variations:
+    if numbers:
         variations.update(
             flatten(numbers_variations(v, language, builtin_entity_parser)
                     for v in variations)
         )
+
     # Add single space variations
     single_space_variations = set(" ".join(v.split()) for v in variations)
     variations.update(single_space_variations)

--- a/snips_nlu/string_variations.py
+++ b/snips_nlu/string_variations.py
@@ -9,9 +9,9 @@ from future.utils import iteritems
 from num2words import num2words
 from snips_nlu_utils import normalize
 
-from snips_nlu.constants import (END, LANGUAGE_DE, LANGUAGE_EN, LANGUAGE_ES,
-                                 LANGUAGE_FR, RESOLVED_VALUE, RES_MATCH_RANGE,
-                                 SNIPS_NUMBER, START, VALUE)
+from snips_nlu.constants import (
+    END, LANGUAGE_DE, LANGUAGE_EN, LANGUAGE_ES, LANGUAGE_FR, RESOLVED_VALUE,
+    RES_MATCH_RANGE, SNIPS_NUMBER, START, VALUE)
 from snips_nlu.languages import (
     get_default_sep, get_punctuation_regex, supports_num2words)
 from snips_nlu.preprocessing import tokenize_light

--- a/snips_nlu/tests/test_custom_entity_parser.py
+++ b/snips_nlu/tests/test_custom_entity_parser.py
@@ -9,7 +9,8 @@ from snips_nlu.constants import STEMS
 from snips_nlu.dataset import validate_and_format_dataset
 from snips_nlu.entity_parser import CustomEntityParser
 from snips_nlu.entity_parser.custom_entity_parser import (
-    CustomEntityParserUsage, _compute_char_shifts)
+    CustomEntityParserUsage, _compute_char_shifts,
+    _create_custom_entity_parser_configuration)
 from snips_nlu.preprocessing import tokenize
 from snips_nlu.tests.utils import FixtureTest
 
@@ -272,6 +273,70 @@ class TestCustomEntityParser(FixtureTest):
         expected_shifts = [-2, -2, -2, -2, -2, -1, -1, -3, -3, -3, -3, -3, -3]
         self.assertListEqual(expected_shifts, shifts)
 
+    def test_create_custom_entity_parser_configuration(self):
+        # Given
+        entities = {
+            "a": {
+                "utterances":
+                    {
+                        "a a": "a",
+                        "aa": "a",
+                        "c": "c"
+                    },
+                "matching_strictness": 1.0
+            },
+            "b": {
+                "utterances":{
+                    "b": "b"
+                },
+                "matching_strictness": 1.0
+            },
+        }
+
+        # When
+        config = _create_custom_entity_parser_configuration(
+            entities, stopwords_fraction=.5, language="en")
+
+        # Then
+        expected_dict = {
+            "entity_parsers": [
+                {
+                    "entity_identifier": "a",
+                    "entity_parser": {
+                        "threshold": 1.0,
+                        "n_gazetteer_stop_words": 1,
+                        "gazetteer": [
+                            {
+                                "raw_value": "a a",
+                                "resolved_value": "a",
+                            },
+                            {
+                                "raw_value": "aa",
+                                "resolved_value": "a",
+                            },
+                            {
+                                "raw_value": "c",
+                                "resolved_value": "c",
+                            },
+                        ]
+                    }
+                },
+                {
+                    "entity_identifier": "b",
+                    "entity_parser": {
+                        "threshold": 1.0,
+                        "n_gazetteer_stop_words": 0,
+                        "gazetteer": [
+                            {
+                                "raw_value": "b",
+                                "resolved_value": "b",
+                            },
+                        ]
+                    }
+                }
+            ]
+        }
+        self.assertDictEqual(expected_dict, config)
 
 # pylint: disable=unused-argument
 def _persist_parser(path):

--- a/snips_nlu/tests/test_dataset_validation.py
+++ b/snips_nlu/tests/test_dataset_validation.py
@@ -191,10 +191,11 @@ class TestDatasetValidation(SnipsTest):
         # Given
         # pylint: disable=unused-argument
         def mock_get_string_variations(
-                variation, language, builtin_entity_parser,
-                number_variations
+                string, language, builtin_entity_parser,
+                numbers=True, case=True, and_=True,
+                punctuation=True
         ):
-            return {variation.lower(), variation.title()}
+            return {string.lower(), string.title()}
 
         mocked_get_string_variations.side_effect = mock_get_string_variations
         dataset = {
@@ -246,10 +247,11 @@ class TestDatasetValidation(SnipsTest):
         # Given
         # pylint: disable=unused-argument
         def mock_get_string_variations(
-                variation, language, builtin_entity_parser,
-                number_variations
+                string, language, builtin_entity_parser,
+                numbers=True, case=True, and_=True,
+                punctuation=True
         ):
-            return {variation, variation.title()}
+            return {string, string.title()}
 
         mocked_get_string_variations.side_effect = mock_get_string_variations
         dataset = {
@@ -361,10 +363,11 @@ class TestDatasetValidation(SnipsTest):
         # Given
         # pylint: disable=unused-argument
         def mock_get_string_variations(
-                variation, language, builtin_entity_parser,
-                number_variations
+                string, language, builtin_entity_parser,
+                numbers=True, case=True, and_=True,
+                punctuation=True
         ):
-            return {variation}
+            return {string}
 
         mocked_get_string_variations.side_effect = mock_get_string_variations
         dataset = {
@@ -504,10 +507,11 @@ class TestDatasetValidation(SnipsTest):
         # Given
         # pylint: disable=unused-argument
         def mock_get_string_variations(
-                variation, language, builtin_entity_parser,
-                number_variations
+                string, language, builtin_entity_parser,
+                numbers=True, case=True, and_=True,
+                punctuation=True
         ):
-            return {variation, variation.title()}
+            return {string, string.title()}
 
         mocked_get_string_variations.side_effect = mock_get_string_variations
         dataset = {
@@ -620,10 +624,11 @@ class TestDatasetValidation(SnipsTest):
         # Given
         # pylint: disable=unused-argument
         def mock_get_string_variations(
-                variation, language, builtin_entity_parser,
-                number_variations
+                string, language, builtin_entity_parser,
+                numbers=True, case=True, and_=True,
+                punctuation=True
         ):
-            return {variation, variation.title()}
+            return {string, string.title()}
 
         mocked_get_string_variations.side_effect = mock_get_string_variations
         dataset = {
@@ -798,10 +803,11 @@ class TestDatasetValidation(SnipsTest):
         # Given
         # pylint: disable=unused-argument
         def mock_get_string_variations(
-                variation, language, builtin_entity_parser,
-                number_variations
+                string, language, builtin_entity_parser,
+                numbers=True, case=True, and_=True,
+                punctuation=True
         ):
-            return {variation.lower(), variation.title()}
+            return {string.lower(), string.title()}
 
         mocked_get_string_variations.side_effect = mock_get_string_variations
         dataset = {
@@ -875,10 +881,11 @@ class TestDatasetValidation(SnipsTest):
         # Given
         # pylint: disable=unused-argument
         def mock_get_string_variations(
-                variation, language, builtin_entity_parser,
-                number_variations
+                string, language, builtin_entity_parser,
+                numbers=True, case=True, and_=True,
+                punctuation=True
         ):
-            return {variation.lower(), variation.title()}
+            return {string.lower(), string.title()}
 
         mocked_get_string_variations.side_effect = mock_get_string_variations
         dataset = {
@@ -1004,7 +1011,7 @@ class TestDatasetValidation(SnipsTest):
             self.assertGreater(mocked_string_variations.call_count, 0)
             for call in mocked_string_variations.mock_calls:
                 kwargs = call[2]
-                self.assertTrue(kwargs["number_variations"])
+                self.assertTrue(kwargs["numbers"])
 
     def test_should_not_create_number_variation(self):
         # Given
@@ -1029,4 +1036,4 @@ class TestDatasetValidation(SnipsTest):
             self.assertGreater(mocked_string_variations.call_count, 0)
             for call in mocked_string_variations.mock_calls:
                 kwargs = call[2]
-                self.assertFalse(kwargs["number_variations"])
+                self.assertFalse(kwargs["numbers"])

--- a/snips_nlu/tests/test_string_variations.py
+++ b/snips_nlu/tests/test_string_variations.py
@@ -174,9 +174,8 @@ class TestStringVariations(SnipsTest):
         builtin_entity_parser.parse = mocked_parse
 
         # When/Then
-        get_string_variations("", "en", builtin_entity_parser,
-                              number_variations=False)
+        get_string_variations("", "en", builtin_entity_parser, numbers=False)
         mocked_parse.assert_not_called()
         get_string_variations(
-            "", "en", builtin_entity_parser, number_variations=True)
+            "", "en", builtin_entity_parser, numbers=True)
         self.assertGreater(mocked_parse.call_count, 0)


### PR DESCRIPTION
# Initial behavior

When training the NLU on assistant that have an entity with a large number of values, we noticed the the training time / inference time of the NLU could be majorly impacted.

There were 2 reason for that:
- first, the `CustomEntityParser` which is using a `snips_nlu_parser.GazetteerEntityParser` under the hood, was not making use of `n_gazetteer_stop_words` configuration parameter. Using stopwords when matching value of the gazetteer parser can have a dramatic impact on performances
- secondly when validating the dataset, we generated way to many variations of the same entity value. On some gazetteer we were going from `50k` initial values to `800k` values. Generating a lot of variety in the entity values brings robustness but increase both training and inference time. Moreover the generating entity values variations when we already have a lot of values might have a limited effect on robustness

# Work done
- When building the `snips_nlu_parser.GazetteerEntityParser` we now use `n_gazetteer_stop_words`. We set `n_gazetteer_stop_words = len(entity_voca) * 0.001`  where `entity_voca` is the number of tokens in the entity vocabulary. This number was chosen after benchmarking several values and several entity data regime
- Now we also now generate 3 of string variations differently depending on the data regime:
    - if we have less than `1000` entity values, we generate all string variations
    - if we have less between `1000` and `10000` value, we generate all variation except the number variations (which are the longest to generate since we have to run Rustling on all entity values)
    - if we have more than `10000` entity value we only generate normalization variations

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
