### PR TITLE
 Fix possible override of entity values when generating variations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Fixed a couple of bugs in the data augmentation which were making the NLU training non-deterministic [#801](https://github.com/snipsco/snips-nlu/pull/801)
+- Fix possible override of entity values when generating variations [#808](https://github.com/snipsco/snips-nlu/pull/808)
 
 ## [0.19.6]
 ### Fixed

--- a/snips_nlu/dataset/validation.py
+++ b/snips_nlu/dataset/validation.py
@@ -188,8 +188,8 @@ def _validate_and_format_custom_entity(entity, utterance_entities, language,
             "punctuation": False
         }
 
-    variations_args["numbers"] = (
-            len(entity[DATA]) < NUMBER_VARIATIONS_THRESHOLD)
+    variations_args["numbers"] = len(
+        entity[DATA]) < NUMBER_VARIATIONS_THRESHOLD
 
     variations = dict()
     for data in entity[DATA]:

--- a/snips_nlu/dataset/validation.py
+++ b/snips_nlu/dataset/validation.py
@@ -232,7 +232,8 @@ def _validate_and_format_custom_entity(entity, queries_entities, language,
             continue
         validated_utterances[original_ent] = original_ent
         for variation in variations:
-            if variation and variation not in validated_utterances:
+            if variation and variation not in validated_utterances \
+                    and variation not in queries_entities:
                 validated_utterances[variation] = original_ent
     formatted_entity[UTTERANCES] = validated_utterances
     return formatted_entity

--- a/snips_nlu/tests/test_dataset_validation.py
+++ b/snips_nlu/tests/test_dataset_validation.py
@@ -1033,3 +1033,99 @@ class TestDatasetValidation(SnipsTest):
                     kwargs = call[2]
                     for k in expected_args:
                         self.assertEqual(expected_args[k], kwargs[k])
+
+    def test_should_not_collapse_utterance_entity_variations(self):
+        # Given
+        dataset = {
+            "language": "en",
+            "intents": {
+                "verify_length": {
+                    "utterances": [
+                        {
+                            "data": [
+                                {
+                                    "text": "hello "
+                                },
+                                {
+                                    "text": "9",
+                                    "slot_name": "expected",
+                                    "entity": "expected"
+                                }
+                            ]
+                        },
+                        {
+                            "data": [
+                                {
+                                    "text": "hello "
+                                },
+                                {
+                                    "text": "nine",
+                                    "slot_name": "expected",
+                                    "entity": "expected"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "entities": {
+                "expected": {
+                    "automatically_extensible": True,
+                    "use_synonyms": True,
+                    "data": [],
+                    "matching_strictness": 1.0
+                }
+            }
+        }
+
+        # When
+        validated_dataset = validate_and_format_dataset(dataset)
+
+        # Then
+        expected_dataset = {
+            "language": "en",
+            "intents": {
+                "verify_length": {
+                    "utterances": [
+                        {
+                            "data": [
+                                {
+                                    "text": "hello "
+                                },
+                                {
+                                    "text": "9",
+                                    "slot_name": "expected",
+                                    "entity": "expected"
+                                }
+                            ]
+                        },
+                        {
+                            "data": [
+                                {
+                                    "text": "hello "
+                                },
+                                {
+                                    "text": "nine",
+                                    "slot_name": "expected",
+                                    "entity": "expected"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "entities": {
+                "expected": {
+                    "automatically_extensible": True,
+                    "matching_strictness": 1.0,
+                    "capitalize": False,
+                    "utterances": {
+                        "nine": "nine",
+                        "Nine": "nine",
+                        "9": "9"
+                    }
+                }
+            },
+            "validated": True
+        }
+        self.assertDictEqual(expected_dataset, validated_dataset)


### PR DESCRIPTION
**Description**:
When augmenting the dataset, variations of utterance entity values were added without checking possible collisions with other utterance entity values.

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [ ] I have updated the documentation, if applicable
