### PR TITLE
Release/0.19.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,3 @@ script: tox
 after_success:
   - tox -e coverage-report
   - codecov
-
-cache: pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Changed
+- Re-score ambiguous `DeterministicIntentParser` results based on slots [#791](https://github.com/snipsco/snips-nlu/pull/791)
+
 ## [0.19.6]
 ### Fixed
 - Raise an error when using unknown intents in intents filter [#788](https://github.com/snipsco/snips-nlu/pull/788)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file.
 - Re-score ambiguous `DeterministicIntentParser` results based on slots [#791](https://github.com/snipsco/snips-nlu/pull/791)
 - Accept ambiguous results from `DeterministicIntentParser` when confidence score is above 0.5 [#797](https://github.com/snipsco/snips-nlu/pull/797)
 - Moved the NLU random state from the config to the shared resources [#801](https://github.com/snipsco/snips-nlu/pull/801)
-- Bumped `scikit-learn` to `>=0.21,<0.22` for `python>=3.5` and `>=0.20<0.21` for `python<3.5` [#801](https://github.com/snipsco/snips-nlu/pull/801) 
+- Bumped `scikit-learn` to `>=0.21,<0.22` for `python>=3.5` and `>=0.20<0.21` for `python<3.5` [#801](https://github.com/snipsco/snips-nlu/pull/801)
+- Update dependencies [#811](https://github.com/snipsco/snips-nlu/pull/811) 
 
 ### Fixed
 - Fixed a couple of bugs in the data augmentation which were making the NLU training non-deterministic [#801](https://github.com/snipsco/snips-nlu/pull/801)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,19 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.19.7]
 ### Changed
 - Re-score ambiguous `DeterministicIntentParser` results based on slots [#791](https://github.com/snipsco/snips-nlu/pull/791)
 - Accept ambiguous results from `DeterministicIntentParser` when confidence score is above 0.5 [#797](https://github.com/snipsco/snips-nlu/pull/797)
+- Avoid generating number variations when not needed [#799](https://github.com/snipsco/snips-nlu/pull/799)
 - Moved the NLU random state from the config to the shared resources [#801](https://github.com/snipsco/snips-nlu/pull/801)
+- Reduce custom entity parser footprint in training time [#804](https://github.com/snipsco/snips-nlu/pull/804)
 - Bumped `scikit-learn` to `>=0.21,<0.22` for `python>=3.5` and `>=0.20<0.21` for `python<3.5` [#801](https://github.com/snipsco/snips-nlu/pull/801)
 - Update dependencies [#811](https://github.com/snipsco/snips-nlu/pull/811) 
 
 ### Fixed
 - Fixed a couple of bugs in the data augmentation which were making the NLU training non-deterministic [#801](https://github.com/snipsco/snips-nlu/pull/801)
+- Remove deprecated code in dataset generation [#803](https://github.com/snipsco/snips-nlu/pull/803)
 - Fix possible override of entity values when generating variations [#808](https://github.com/snipsco/snips-nlu/pull/808)
 
 ## [0.19.6]
@@ -281,6 +284,7 @@ several commands.
 - Fix compiling issue with `bindgen` dependency when installing from source
 - Fix issue in `CRFSlotFiller` when handling builtin entities
 
+[0.19.7]: https://github.com/snipsco/snips-nlu/compare/0.19.6...0.19.7
 [0.19.6]: https://github.com/snipsco/snips-nlu/compare/0.19.5...0.19.6
 [0.19.5]: https://github.com/snipsco/snips-nlu/compare/0.19.4...0.19.5
 [0.19.4]: https://github.com/snipsco/snips-nlu/compare/0.19.3...0.19.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Changed
 - Re-score ambiguous `DeterministicIntentParser` results based on slots [#791](https://github.com/snipsco/snips-nlu/pull/791)
+- Accept ambiguous results from `DeterministicIntentParser` when confidence score is above 0.5 [#797](https://github.com/snipsco/snips-nlu/pull/797)
 
 ## [0.19.6]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Fixed a couple of bugs in the data augmentation which were making the NLU training non-deterministic [#801](https://github.com/snipsco/snips-nlu/pull/801)
+- Fix possible override of entity values when generating variations [#808](https://github.com/snipsco/snips-nlu/pull/808)
 
 ## [0.19.6]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Re-score ambiguous `DeterministicIntentParser` results based on slots [#791](https://github.com/snipsco/snips-nlu/pull/791)
 - Accept ambiguous results from `DeterministicIntentParser` when confidence score is above 0.5 [#797](https://github.com/snipsco/snips-nlu/pull/797)
+- Moved the NLU random state from the config to the shared resources [#801](https://github.com/snipsco/snips-nlu/pull/801)
+- Bumped `scikit-learn` to `>=0.21,<0.22` for `python>=3.5` and `>=0.20<0.21` for `python<3.5` [#801](https://github.com/snipsco/snips-nlu/pull/801) 
+
+### Fixed
+- Fixed a couple of bugs in the data augmentation which were making the NLU training non-deterministic [#801](https://github.com/snipsco/snips-nlu/pull/801)
 
 ## [0.19.6]
 ### Fixed

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -174,6 +174,26 @@ the dataset we generated earlier:
 
     engine.fit(dataset)
 
+Note that, by default, training of the NLU engine is non-deterministic:
+training and testing multiple times on the same data may produce different
+outputs.
+
+Reproducible trainings can be achieved by passing a **random seed** to the
+engine:
+
+.. code-block:: python
+
+    seed = 42
+    engine = SnipsNLUEngine(config=CONFIG_EN, random_state=seed)
+    engine.fit(dataset)
+
+
+.. note::
+
+    Due to a ``scikit-learn`` bug fixed in version ``0.21`` we can't guarantee
+    any deterministic behavior if you're using a Python version ``<3.5`` since
+    ``scikit-learn>=0.21`` is only available starting from Python ``>=3.5``
+
 
 Parsing
 -------

--- a/setup.py
+++ b/setup.py
@@ -17,23 +17,23 @@ with io.open(os.path.join(root, "README.rst"), encoding="utf8") as f:
     readme = f.read()
 
 required = [
+    "deprecation>=2.0,<3.0",
     "enum34>=1.1,<2.0; python_version<'3.4'",
-    "future>=0.16,<0.17",
-    "numpy>=1.15,<1.16",
-    "scipy>=1.0,<2.0",
-    "scikit-learn>=0.21.1,<0.22; python_version>='3.5'",
-    "scikit-learn>=0.20,<0.21; python_version<'3.5'",
-    "sklearn-crfsuite>=0.3.6,<0.4",
-    "semantic_version>=2.6,<3.0",
-    "snips-nlu-utils>=0.8,<0.9",
-    "snips-nlu-parsers>=0.2,<0.3",
+    "funcsigs>=1.0,<2.0; python_version<'3.4'",
+    "future>=0.16,<0.18",
     "num2words>=0.5.6,<0.6",
-    "plac>=0.9.6,<1.0",
+    "numpy>=1.15,<2.0",
+    "pathlib>=1.0,<2.0; python_version<'3.4'",
+    "plac>=0.9.6,<2.0",
+    "pyaml>=17.0,<20.0",
     "requests>=2.0,<3.0",
-    "pathlib==1.0.1; python_version<'3.4'",
-    "pyaml>=17,<18",
-    "deprecation>=2,<3",
-    "funcsigs>=1.0,<2.0; python_version<'3.4'"
+    "scikit-learn>=0.20,<0.21; python_version<'3.5'",
+    "scikit-learn>=0.21.1,<0.22; python_version>='3.5'",
+    "scipy>=1.0,<2.0",
+    "semantic_version>=2.6,<3.0",
+    "sklearn-crfsuite>=0.3.6,<0.4",
+    "snips-nlu-parsers>=0.2,<0.3",
+    "snips-nlu-utils>=0.8,<0.9",
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ required = [
     "future>=0.16,<0.17",
     "numpy>=1.15,<1.16",
     "scipy>=1.0,<2.0",
-    "scikit-learn>=0.19,<0.20",
+    "scikit-learn>=0.21.1,<0.22; python_version>='3.5'",
+    "scikit-learn>=0.20,<0.21; python_version<'3.5'",
     "sklearn-crfsuite>=0.3.6,<0.4",
     "semantic_version>=2.6,<3.0",
     "snips-nlu-utils>=0.8,<0.9",
@@ -29,10 +30,10 @@ required = [
     "num2words>=0.5.6,<0.6",
     "plac>=0.9.6,<1.0",
     "requests>=2.0,<3.0",
-    "pathlib==1.0.1; python_version < '3.4'",
+    "pathlib==1.0.1; python_version<'3.4'",
     "pyaml>=17,<18",
     "deprecation>=2,<3",
-    "funcsigs>=1.0,<2.0; python_version < '3.4'"
+    "funcsigs>=1.0,<2.0; python_version<'3.4'"
 ]
 
 extras_require = {

--- a/snips_nlu/__about__.py
+++ b/snips_nlu/__about__.py
@@ -13,7 +13,7 @@ __author__ = "Clement Doumouro, Adrien Ball"
 __email__ = "clement.doumouro@snips.ai, adrien.ball@snips.ai"
 __license__ = "Apache License, Version 2.0"
 
-__version__ = "0.19.6"
+__version__ = "0.19.7"
 __model_version__ = "0.19.0"
 
 __download_url__ = "https://github.com/snipsco/snips-nlu-language-resources/releases/download"

--- a/snips_nlu/cli/generate_dataset.py
+++ b/snips_nlu/cli/generate_dataset.py
@@ -8,13 +8,21 @@ from snips_nlu.common.utils import unicode_string, json_string
 
 @plac.annotations(
     language=("Language of the assistant", "positional", None, str),
-    files=("List of intent and entity files", "positional", None, str, None,
-           "filename"))
-def generate_dataset(language, *files):
-    """Create a Snips NLU dataset from text friendly files"""
+    yaml_files=("List of intent and entity yaml files", "positional", None,
+                str, None, "filename"))
+def generate_dataset(language, *yaml_files):
+    """Creates a Snips NLU dataset from YAML definition files
+
+    Check :meth:`.Intent.from_yaml` and :meth:`.Entity.from_yaml` for the
+    format of the YAML files.
+
+    Args:
+        language (str): language of the dataset (iso code)
+        *yaml_files: list of intent and entity definition files in YAML format.
+
+    Returns:
+        None. The json dataset output is printed out on stdout.
+    """
     language = unicode_string(language)
-    if any(f.endswith(".yml") or f.endswith(".yaml") for f in files):
-        dataset = Dataset.from_yaml_files(language, list(files))
-    else:
-        dataset = Dataset.from_files(language, list(files))
+    dataset = Dataset.from_yaml_files(language, list(yaml_files))
     print(json_string(dataset.json, indent=2, sort_keys=True))

--- a/snips_nlu/constants.py
+++ b/snips_nlu/constants.py
@@ -46,6 +46,7 @@ END = "end"
 BUILTIN_ENTITY_PARSER = "builtin_entity_parser"
 CUSTOM_ENTITY_PARSER = "custom_entity_parser"
 MATCHING_STRICTNESS = "matching_strictness"
+RANDOM_STATE = "random_state"
 
 # resources
 RESOURCES = "resources"

--- a/snips_nlu/data_augmentation.py
+++ b/snips_nlu/data_augmentation.py
@@ -69,10 +69,10 @@ def get_entities_iterators(intent_entities, language,
                            add_builtin_entities_examples, random_state):
     entities_its = dict()
     for entity_name, entity in iteritems(intent_entities):
-        utterance_values = random_state.permutation(list(entity[UTTERANCES]))
+        utterance_values = random_state.permutation(sorted(entity[UTTERANCES]))
         if add_builtin_entities_examples and is_builtin_entity(entity_name):
-            entity_examples = get_builtin_entity_examples(entity_name,
-                                                          language)
+            entity_examples = get_builtin_entity_examples(
+                entity_name, language)
             # Builtin entity examples must be kept first in the iterator to
             # ensure that they are used when augmenting data
             iterator_values = entity_examples + list(utterance_values)

--- a/snips_nlu/dataset/intent.py
+++ b/snips_nlu/dataset/intent.py
@@ -306,7 +306,8 @@ def capture_slot(state):
     next_colon_pos = state.find(':')
     next_square_bracket_pos = state.find(']')
     if next_square_bracket_pos < 0:
-        raise IntentFormatError("Missing ending ']' in annotated utterance")
+        raise IntentFormatError(
+            "Missing ending ']' in annotated utterance \"%s\"" % state.input)
     if next_colon_pos < 0 or next_square_bracket_pos < next_colon_pos:
         slot_name = state[:next_square_bracket_pos]
         state.move(next_square_bracket_pos)
@@ -327,7 +328,8 @@ def capture_slot(state):
 def capture_tagged(state):
     next_pos = state.find(')')
     if next_pos < 1:
-        raise IntentFormatError("Missing ending ')' in annotated utterance")
+        raise IntentFormatError(
+            "Missing ending ')' in annotated utterance \"%s\"" % state.input)
     else:
         tagged_text = state[:next_pos]
         state.add_tagged(tagged_text)

--- a/snips_nlu/dataset/validation.py
+++ b/snips_nlu/dataset/validation.py
@@ -8,6 +8,8 @@ from copy import deepcopy
 from future.utils import iteritems, itervalues
 from snips_nlu_parsers import get_all_languages
 
+from snips_nlu.common.dataset_utils import (validate_key, validate_keys,
+                                            validate_type)
 from snips_nlu.constants import (
     AUTOMATICALLY_EXTENSIBLE, CAPITALIZE, DATA, ENTITIES, ENTITY, INTENTS,
     LANGUAGE, MATCHING_STRICTNESS, SLOT_NAME, SYNONYMS, TEXT, USE_SYNONYMS,
@@ -18,10 +20,9 @@ from snips_nlu.entity_parser.builtin_entity_parser import (
 from snips_nlu.exceptions import DatasetFormatError
 from snips_nlu.preprocessing import tokenize_light
 from snips_nlu.string_variations import get_string_variations
-from snips_nlu.common.dataset_utils import (
-    validate_type, validate_key, validate_keys)
 
 NUMBER_VARIATIONS_THRESHOLD = 1e3
+VARIATIONS_GENERATION_THRESHOLD = 1e4
 
 
 def validate_and_format_dataset(dataset):
@@ -174,10 +175,25 @@ def _validate_and_format_custom_entity(entity, queries_entities, language,
     # value is parsed with the builtin entity parser before creating the
     # variations. We avoid generating these variations if there's enough entity
     # values
-    number_variations = len(entity[DATA]) < NUMBER_VARIATIONS_THRESHOLD
 
     # Add variations if not colliding
     all_original_values = _extract_entity_values(entity)
+    if len(entity[DATA]) < VARIATIONS_GENERATION_THRESHOLD:
+        variations_args = {
+            "case": True,
+            "and_": True,
+            "punctuation": True
+        }
+    else:
+        variations_args = {
+            "case": False,
+            "and_": False,
+            "punctuation": False
+        }
+
+    variations_args["numbers"] = (
+        len(entity[DATA]) < NUMBER_VARIATIONS_THRESHOLD)
+
     variations = dict()
     for data in entity[DATA]:
         ent_value = data[VALUE]
@@ -187,9 +203,7 @@ def _validate_and_format_custom_entity(entity, queries_entities, language,
         variations[ent_value] = set(
             v for value in values_to_variate
             for v in get_string_variations(
-                value, language, builtin_entity_parser,
-                number_variations=number_variations
-            )
+                value, language, builtin_entity_parser, **variations_args)
         )
     variation_counter = Counter(
         [v for variations_ in itervalues(variations) for v in variations_])
@@ -209,11 +223,10 @@ def _validate_and_format_custom_entity(entity, queries_entities, language,
     # Merge queries entities
     queries_entities_variations = {
         ent: get_string_variations(
-            ent, language, builtin_entity_parser,
-            number_variations=number_variations
-        )
+            ent, language, builtin_entity_parser, **variations_args)
         for ent in queries_entities
     }
+
     for original_ent, variations in iteritems(queries_entities_variations):
         if not original_ent or original_ent in validated_utterances:
             continue

--- a/snips_nlu/dataset/validation.py
+++ b/snips_nlu/dataset/validation.py
@@ -114,7 +114,7 @@ def _extract_entity_values(entity):
     return values
 
 
-def _validate_and_format_custom_entity(entity, queries_entities, language,
+def _validate_and_format_custom_entity(entity, utterance_entities, language,
                                        builtin_entity_parser):
     validate_type(entity, dict, object_label="entity")
 
@@ -149,26 +149,23 @@ def _validate_and_format_custom_entity(entity, queries_entities, language,
         if not entry[VALUE]:
             continue
         validate_type(entry[SYNONYMS], list, object_label="entity synonyms")
-        entry[SYNONYMS] = [s.strip() for s in entry[SYNONYMS]
-                           if len(s.strip()) > 0]
+        entry[SYNONYMS] = [s.strip() for s in entry[SYNONYMS] if s.strip()]
         valid_entity_data.append(entry)
     entity[DATA] = valid_entity_data
 
     # Compute capitalization before normalizing
     # Normalization lowercase and hence lead to bad capitalization calculation
-    formatted_entity[CAPITALIZE] = _has_any_capitalization(queries_entities,
+    formatted_entity[CAPITALIZE] = _has_any_capitalization(utterance_entities,
                                                            language)
 
     validated_utterances = dict()
     # Map original values an synonyms
     for data in entity[DATA]:
         ent_value = data[VALUE]
-        if not ent_value:
-            continue
         validated_utterances[ent_value] = ent_value
         if use_synonyms:
             for s in data[SYNONYMS]:
-                if s and s not in validated_utterances:
+                if s not in validated_utterances:
                     validated_utterances[s] = ent_value
 
     # Number variations in entities values are expensive since each entity
@@ -191,8 +188,8 @@ def _validate_and_format_custom_entity(entity, queries_entities, language,
             "punctuation": False
         }
 
-    variations_args["numbers"] = (
-        len(entity[DATA]) < NUMBER_VARIATIONS_THRESHOLD)
+    variations_args["numbers"] = len(
+        entity[DATA]) < NUMBER_VARIATIONS_THRESHOLD
 
     variations = dict()
     for data in entity[DATA]:
@@ -220,24 +217,25 @@ def _validate_and_format_custom_entity(entity, queries_entities, language,
         validated_utterances = _add_entity_variations(
             validated_utterances, non_colliding_variations, entry_value)
 
-    # Merge queries entities
-    queries_entities_variations = {
+    # Merge utterances entities
+    utterance_entities_variations = {
         ent: get_string_variations(
             ent, language, builtin_entity_parser, **variations_args)
-        for ent in queries_entities
+        for ent in utterance_entities
     }
 
-    for original_ent, variations in iteritems(queries_entities_variations):
+    for original_ent, variations in iteritems(utterance_entities_variations):
         if not original_ent or original_ent in validated_utterances:
             continue
         validated_utterances[original_ent] = original_ent
         for variation in variations:
-            if variation and variation not in validated_utterances:
+            if variation and variation not in validated_utterances \
+                    and variation not in utterance_entities:
                 validated_utterances[variation] = original_ent
     formatted_entity[UTTERANCES] = validated_utterances
     return formatted_entity
 
 
-def _validate_and_format_builtin_entity(entity, queries_entities):
+def _validate_and_format_builtin_entity(entity, utterance_entities):
     validate_type(entity, dict, object_label="builtin entity")
-    return {UTTERANCES: set(queries_entities)}
+    return {UTTERANCES: set(utterance_entities)}

--- a/snips_nlu/default_configs/config_de.py
+++ b/snips_nlu/default_configs/config_de.py
@@ -111,8 +111,7 @@ CONFIG = {
                     "min_utterances": 200,
                     "capitalization_ratio": 0.2,
                     "add_builtin_entities_examples": True
-                },
-                "random_seed": None
+                }
             },
             "intent_classifier_config": {
                 "unit_name": "log_reg_intent_classifier",
@@ -140,8 +139,7 @@ CONFIG = {
                         "unknown_words_replacement_string": None,
                         "keep_order": True
                     }
-                },
-                "random_seed": None
+                }
             }
         }
     ]

--- a/snips_nlu/default_configs/config_en.py
+++ b/snips_nlu/default_configs/config_en.py
@@ -97,8 +97,7 @@ CONFIG = {
                     "min_utterances": 200,
                     "capitalization_ratio": 0.2,
                     "add_builtin_entities_examples": True
-                },
-                "random_seed": None
+                }
             },
             "intent_classifier_config": {
                 "unit_name": "log_reg_intent_classifier",
@@ -126,8 +125,7 @@ CONFIG = {
                         "unknown_words_replacement_string": None,
                         "keep_order": True
                     }
-                },
-                "random_seed": None
+                }
             }
         }
     ]

--- a/snips_nlu/default_configs/config_es.py
+++ b/snips_nlu/default_configs/config_es.py
@@ -90,7 +90,7 @@ CONFIG = {
                     "capitalization_ratio": 0.2,
                     "add_builtin_entities_examples": True
                 },
-                "random_seed": None
+
             },
             "intent_classifier_config": {
                 "unit_name": "log_reg_intent_classifier",
@@ -118,8 +118,7 @@ CONFIG = {
                         "unknown_words_replacement_string": None,
                         "keep_order": True
                     }
-                },
-                "random_seed": None
+                }
             }
         }
     ]

--- a/snips_nlu/default_configs/config_fr.py
+++ b/snips_nlu/default_configs/config_fr.py
@@ -89,8 +89,7 @@ CONFIG = {
                     "min_utterances": 200,
                     "capitalization_ratio": 0.2,
                     "add_builtin_entities_examples": True
-                },
-                "random_seed": None
+                }
             },
             "intent_classifier_config": {
                 "unit_name": "log_reg_intent_classifier",
@@ -118,8 +117,7 @@ CONFIG = {
                         "unknown_words_replacement_string": None,
                         "keep_order": True
                     }
-                },
-                "random_seed": None
+                }
             }
         }
     ]

--- a/snips_nlu/default_configs/config_it.py
+++ b/snips_nlu/default_configs/config_it.py
@@ -89,8 +89,7 @@ CONFIG = {
                     "min_utterances": 200,
                     "capitalization_ratio": 0.2,
                     "add_builtin_entities_examples": True
-                },
-                "random_seed": None
+                }
             },
             "intent_classifier_config": {
                 "unit_name": "log_reg_intent_classifier",
@@ -118,8 +117,7 @@ CONFIG = {
                         "unknown_words_replacement_string": None,
                         "keep_order": True
                     }
-                },
-                "random_seed": None
+                }
             }
         }
     ]

--- a/snips_nlu/default_configs/config_ja.py
+++ b/snips_nlu/default_configs/config_ja.py
@@ -116,7 +116,7 @@ CONFIG = {
                     "capitalization_ratio": 0.2,
                     "add_builtin_entities_examples": True
                 },
-                "random_seed": None
+
             },
             "intent_classifier_config": {
                 "unit_name": "log_reg_intent_classifier",
@@ -144,8 +144,7 @@ CONFIG = {
                         "unknown_words_replacement_string": None,
                         "keep_order": True
                     }
-                },
-                "random_seed": None
+                }
             }
         }
     ]

--- a/snips_nlu/default_configs/config_ko.py
+++ b/snips_nlu/default_configs/config_ko.py
@@ -107,8 +107,7 @@ CONFIG = {
                     "min_utterances": 200,
                     "capitalization_ratio": 0.2,
                     "add_builtin_entities_examples": True
-                },
-                "random_seed": None
+                }
             },
             "intent_classifier_config": {
                 "unit_name": "log_reg_intent_classifier",
@@ -136,8 +135,7 @@ CONFIG = {
                         "unknown_words_replacement_string": None,
                         "keep_order": True
                     }
-                },
-                "random_seed": None
+                }
             }
         }
     ]

--- a/snips_nlu/entity_parser/custom_entity_parser.py
+++ b/snips_nlu/entity_parser/custom_entity_parser.py
@@ -16,8 +16,10 @@ from snips_nlu.entity_parser.builtin_entity_parser import is_builtin_entity
 from snips_nlu.entity_parser.custom_entity_parser_usage import (
     CustomEntityParserUsage)
 from snips_nlu.entity_parser.entity_parser import EntityParser
-from snips_nlu.preprocessing import stem, tokenize
+from snips_nlu.preprocessing import stem, tokenize, tokenize_light
 from snips_nlu.result import parsed_entity
+
+STOPWORDS_FRACTION = 1e-3
 
 
 class CustomEntityParser(EntityParser):
@@ -98,7 +100,10 @@ class CustomEntityParser(EntityParser):
             raise ValueError("A parser usage must be defined in order to fit "
                              "a CustomEntityParser")
         configuration = _create_custom_entity_parser_configuration(
-            custom_entities)
+            custom_entities,
+            language=dataset[LANGUAGE],
+            stopwords_fraction=STOPWORDS_FRACTION,
+        )
         parser = GazetteerEntityParser.build(configuration)
         return cls(parser, language, parser_usage)
 
@@ -123,23 +128,51 @@ def _merge_entity_utterances(raw_utterances, stemmed_utterances):
     return raw_utterances
 
 
-def _create_custom_entity_parser_configuration(entities):
-    return {
-        "entity_parsers": [
-            {
-                "entity_identifier": entity_name,
-                "entity_parser": {
-                    "threshold": entity[MATCHING_STRICTNESS],
-                    "gazetteer": [
-                        {
-                            "raw_value": k,
-                            "resolved_value": v
-                        } for k, v in sorted(iteritems(entity[UTTERANCES]))
-                    ]
-                }
-            } for entity_name, entity in sorted(iteritems(entities))
-        ]
+def _create_custom_entity_parser_configuration(
+        entities, stopwords_fraction, language):
+    """Dynamically creates the gazetteer parser configuration.
+
+    Args:
+        entities (dict): entity for the dataset
+        stopwords_fraction (float): fraction of the vocabulary of
+            the entity values that will be considered as stop words (
+            the top n_vocabulary * stopwords_fraction most frequent words will
+            be considered stop words)
+        language (str): language of the entities
+
+    Returns: the parser configuration as dictionary
+    """
+
+    if not 0 < stopwords_fraction < 1:
+        raise ValueError("stopwords_fraction must be in ]0.0, 1.0[")
+
+    parser_configurations = []
+    for entity_name, entity in sorted(iteritems(entities)):
+        vocabulary = set(
+            t for raw_value in entity[UTTERANCES]
+            for t in tokenize_light(raw_value, language)
+        )
+        num_stopwords = int(stopwords_fraction * len(vocabulary))
+        config = {
+            "entity_identifier": entity_name,
+            "entity_parser": {
+                "threshold": entity[MATCHING_STRICTNESS],
+                "n_gazetteer_stop_words": num_stopwords,
+                "gazetteer": [
+                    {
+                        "raw_value": k,
+                        "resolved_value": v
+                    } for k, v in sorted(iteritems(entity[UTTERANCES]))
+                ]
+            }
+        }
+        parser_configurations.append(config)
+
+    configuration = {
+        "entity_parsers": parser_configurations
     }
+
+    return configuration
 
 
 def _compute_char_shifts(tokens):
@@ -163,8 +196,8 @@ def _compute_char_shifts(tokens):
         else:
             previous_token_end = tokens[token_index - 1].end
             previous_space_len = 1
-        current_shift -= (token.start - previous_token_end) - \
-                         previous_space_len
+        offset = (token.start - previous_token_end) - previous_space_len
+        current_shift -= offset
         token_len = token.end - token.start
         index_shift = token_len + previous_space_len
         characters_shifts += [current_shift for _ in range(index_shift)]

--- a/snips_nlu/intent_classifier/featurizer.py
+++ b/snips_nlu/intent_classifier/featurizer.py
@@ -109,7 +109,9 @@ class Featurizer(ProcessingUnit):
             config=self.config.tfidf_vectorizer_config,
             builtin_entity_parser=self.builtin_entity_parser,
             custom_entity_parser=self.custom_entity_parser,
-            resources=self.resources)
+            resources=self.resources,
+            random_state=self.random_state,
+        )
         x_tfidf = self.tfidf_vectorizer.fit_transform(x, dataset)
 
         if not self.tfidf_vectorizer.vocabulary:
@@ -139,7 +141,9 @@ class Featurizer(ProcessingUnit):
             config=self.config.cooccurrence_vectorizer_config,
             builtin_entity_parser=self.builtin_entity_parser,
             custom_entity_parser=self.custom_entity_parser,
-            resources=self.resources)
+            resources=self.resources,
+            random_state=self.random_state,
+        )
         x_cooccurrence = self.cooccurrence_vectorizer.fit(
             non_null_x, dataset).transform(x)
         if not self.cooccurrence_vectorizer.word_pairs:

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -52,7 +52,7 @@ class LogRegIntentClassifier(IntentClassifier):
         """Whether or not the intent classifier has already been fitted"""
         return self.intent_list is not None
 
-    @log_elapsed_time(logger, logging.DEBUG,
+    @log_elapsed_time(logger, logging.INFO,
                       "LogRegIntentClassifier in {elapsed_time}")
     def fit(self, dataset):
         """Fits the intent classifier with a valid Snips dataset
@@ -60,7 +60,7 @@ class LogRegIntentClassifier(IntentClassifier):
         Returns:
             :class:`LogRegIntentClassifier`: The same instance, trained
         """
-        logger.debug("Fitting LogRegIntentClassifier...")
+        logger.info("Fitting LogRegIntentClassifier...")
         dataset = validate_and_format_dataset(dataset)
         self.load_resources_if_needed(dataset[LANGUAGE])
         self.fit_builtin_entity_parser_if_needed(dataset)

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -10,11 +10,10 @@ from sklearn.linear_model import SGDClassifier
 
 from snips_nlu.common.log_utils import DifferedLoggingMessage, log_elapsed_time
 from snips_nlu.common.utils import (
-    check_persisted_path, check_random_state,
-    fitted_required, json_string)
+    check_persisted_path, fitted_required, json_string)
 from snips_nlu.constants import LANGUAGE, RES_PROBA
 from snips_nlu.dataset import validate_and_format_dataset
-from snips_nlu.exceptions import _EmptyDatasetUtterancesError, LoadingError
+from snips_nlu.exceptions import LoadingError, _EmptyDatasetUtterancesError
 from snips_nlu.intent_classifier.featurizer import Featurizer
 from snips_nlu.intent_classifier.intent_classifier import IntentClassifier
 from snips_nlu.intent_classifier.log_reg_classifier_utils import (
@@ -24,11 +23,20 @@ from snips_nlu.result import intent_classification_result
 
 logger = logging.getLogger(__name__)
 
+# We set tol to 1e-3 to silence the following warning with Python 2 (
+# scikit-learn 0.20):
+#
+# FutureWarning: max_iter and tol parameters have been added in SGDClassifier
+# in 0.19. If max_iter is set but tol is left unset, the default value for tol
+# in 0.19 and 0.20 will be None (which is equivalent to -infinity, so it has no
+# effect) but will change in 0.21 to 1e-3. Specify tol to silence this warning.
+
 LOG_REG_ARGS = {
     "loss": "log",
     "penalty": "l2",
     "class_weight": "balanced",
-    "max_iter": 5,
+    "max_iter": 1000,
+    "tol": 1e-3,
     "n_jobs": -1
 }
 
@@ -66,12 +74,11 @@ class LogRegIntentClassifier(IntentClassifier):
         self.fit_builtin_entity_parser_if_needed(dataset)
         self.fit_custom_entity_parser_if_needed(dataset)
         language = dataset[LANGUAGE]
-        random_state = check_random_state(self.config.random_seed)
 
         data_augmentation_config = self.config.data_augmentation_config
         utterances, classes, intent_list = build_training_data(
             dataset, language, data_augmentation_config, self.resources,
-            random_state)
+            self.random_state)
 
         self.intent_list = intent_list
         if len(self.intent_list) <= 1:
@@ -81,7 +88,8 @@ class LogRegIntentClassifier(IntentClassifier):
             config=self.config.featurizer_config,
             builtin_entity_parser=self.builtin_entity_parser,
             custom_entity_parser=self.custom_entity_parser,
-            resources=self.resources
+            resources=self.resources,
+            random_state=self.random_state,
         )
         self.featurizer.language = language
 
@@ -94,8 +102,8 @@ class LogRegIntentClassifier(IntentClassifier):
             return self
 
         alpha = get_regularization_factor(dataset)
-        self.classifier = SGDClassifier(random_state=random_state,
-                                        alpha=alpha, **LOG_REG_ARGS)
+        self.classifier = SGDClassifier(
+            random_state=self.random_state, alpha=alpha, **LOG_REG_ARGS)
         self.classifier.fit(x, classes)
         logger.debug("%s", DifferedLoggingMessage(self.log_best_features))
         return self

--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -203,7 +203,7 @@ class DeterministicIntentParser(IntentParser):
             if top_intents:
                 intent = top_intents[0][RES_INTENT]
                 slots = top_intents[0][RES_SLOTS]
-                if intent[RES_PROBA] < 1.0:
+                if intent[RES_PROBA] <= 0.5:
                     # return None in case of ambiguity
                     return empty_result(text, probability=1.0)
                 return parsing_result(text, intent, slots)

--- a/snips_nlu/intent_parser/deterministic_intent_parser.py
+++ b/snips_nlu/intent_parser/deterministic_intent_parser.py
@@ -133,7 +133,7 @@ class DeterministicIntentParser(IntentParser):
         logger, logging.INFO, "Fitted deterministic parser in {elapsed_time}")
     def fit(self, dataset, force_retrain=True):
         """Fits the intent parser with a valid Snips dataset"""
-        logger.info("Fitting deterministic parser...")
+        logger.info("Fitting deterministic intent parser...")
         dataset = validate_and_format_dataset(dataset)
         self.load_resources_if_needed(dataset[LANGUAGE])
         self.fit_builtin_entity_parser_if_needed(dataset)

--- a/snips_nlu/intent_parser/probabilistic_intent_parser.py
+++ b/snips_nlu/intent_parser/probabilistic_intent_parser.py
@@ -69,7 +69,9 @@ class ProbabilisticIntentParser(IntentParser):
                 self.config.intent_classifier_config,
                 builtin_entity_parser=self.builtin_entity_parser,
                 custom_entity_parser=self.custom_entity_parser,
-                resources=self.resources)
+                resources=self.resources,
+                random_state=self.random_state,
+            )
 
         if force_retrain or not self.intent_classifier.fitted:
             self.intent_classifier.fit(dataset)
@@ -85,7 +87,9 @@ class ProbabilisticIntentParser(IntentParser):
                     slot_filler_config,
                     builtin_entity_parser=self.builtin_entity_parser,
                     custom_entity_parser=self.custom_entity_parser,
-                    resources=self.resources)
+                    resources=self.resources,
+                    random_state=self.random_state,
+                )
             if force_retrain or not self.slot_fillers[intent_name].fitted:
                 self.slot_fillers[intent_name].fit(dataset, intent_name)
         logger.debug("Fitted slot fillers in %s",

--- a/snips_nlu/nlu_engine/nlu_engine.py
+++ b/snips_nlu/nlu_engine/nlu_engine.py
@@ -23,8 +23,9 @@ from snips_nlu.default_configs import DEFAULT_CONFIGS
 from snips_nlu.entity_parser import CustomEntityParser
 from snips_nlu.entity_parser.builtin_entity_parser import (
     BuiltinEntityParser, is_builtin_entity)
-from snips_nlu.exceptions import InvalidInputError, IntentNotFoundError, \
-    LoadingError, IncompatibleModelError
+from snips_nlu.exceptions import (
+    InvalidInputError, IntentNotFoundError, LoadingError,
+    IncompatibleModelError)
 from snips_nlu.intent_parser import IntentParser
 from snips_nlu.pipeline.configs import NLUEngineConfig
 from snips_nlu.pipeline.processing_unit import ProcessingUnit
@@ -117,7 +118,9 @@ class SnipsNLUEngine(ProcessingUnit):
                     parser_config,
                     builtin_entity_parser=self.builtin_entity_parser,
                     custom_entity_parser=self.custom_entity_parser,
-                    resources=self.resources)
+                    resources=self.resources,
+                    random_state=self.random_state,
+                )
 
             if force_retrain or not recycled_parser.fitted:
                 recycled_parser.fit(dataset, force_retrain)

--- a/snips_nlu/pipeline/configs/intent_classifier.py
+++ b/snips_nlu/pipeline/configs/intent_classifier.py
@@ -13,16 +13,13 @@ class LogRegIntentClassifierConfig(FromDict, ProcessingUnitConfig):
     """Configuration of a :class:`.LogRegIntentClassifier`"""
 
     # pylint: disable=line-too-long
-    def __init__(self, data_augmentation_config=None, featurizer_config=None,
-                 random_seed=None):
+    def __init__(self, data_augmentation_config=None, featurizer_config=None):
         """
         Args:
             data_augmentation_config (:class:`IntentClassifierDataAugmentationConfig`):
                     Defines the strategy of the underlying data augmentation
             featurizer_config (:class:`FeaturizerConfig`): Configuration of the
                 :class:`.Featurizer` used underneath
-            random_seed (int, optional): Allows to fix the seed ot have
-                reproducible trainings
         """
         if data_augmentation_config is None:
             data_augmentation_config = IntentClassifierDataAugmentationConfig()
@@ -32,7 +29,6 @@ class LogRegIntentClassifierConfig(FromDict, ProcessingUnitConfig):
         self.data_augmentation_config = data_augmentation_config
         self._featurizer_config = None
         self.featurizer_config = featurizer_config
-        self.random_seed = random_seed
 
     # pylint: enable=line-too-long
 
@@ -83,8 +79,7 @@ class LogRegIntentClassifierConfig(FromDict, ProcessingUnitConfig):
             "unit_name": self.unit_name,
             "data_augmentation_config":
                 self.data_augmentation_config.to_dict(),
-            "featurizer_config": self.featurizer_config.to_dict(),
-            "random_seed": self.random_seed
+            "featurizer_config": self.featurizer_config.to_dict()
         }
 
 

--- a/snips_nlu/pipeline/configs/nlu_engine.py
+++ b/snips_nlu/pipeline/configs/nlu_engine.py
@@ -16,7 +16,7 @@ class NLUEngineConfig(FromDict, ProcessingUnitConfig):
             the order in which each parser will be called by the nlu engine.
     """
 
-    def __init__(self, intent_parsers_configs=None):
+    def __init__(self, intent_parsers_configs=None, random_seed=None):
         from snips_nlu.intent_parser import IntentParser
 
         if intent_parsers_configs is None:
@@ -29,6 +29,7 @@ class NLUEngineConfig(FromDict, ProcessingUnitConfig):
             ]
         self.intent_parsers_configs = [
             IntentParser.get_config(conf) for conf in intent_parsers_configs]
+        self.random_seed = random_seed
 
     @property
     def unit_name(self):

--- a/snips_nlu/pipeline/configs/slot_filler.py
+++ b/snips_nlu/pipeline/configs/slot_filler.py
@@ -30,7 +30,7 @@ class CRFSlotFillerConfig(FromDict, ProcessingUnitConfig):
 
     def __init__(self, feature_factory_configs=None,
                  tagging_scheme=None, crf_args=None,
-                 data_augmentation_config=None, random_seed=None):
+                 data_augmentation_config=None):
         if tagging_scheme is None:
             from snips_nlu.slot_filler.crf_utils import TaggingScheme
             tagging_scheme = TaggingScheme.BIO
@@ -46,7 +46,6 @@ class CRFSlotFillerConfig(FromDict, ProcessingUnitConfig):
         self.crf_args = crf_args
         self._data_augmentation_config = None
         self.data_augmentation_config = data_augmentation_config
-        self.random_seed = random_seed
 
     @property
     def tagging_scheme(self):
@@ -102,8 +101,7 @@ class CRFSlotFillerConfig(FromDict, ProcessingUnitConfig):
             "crf_args": self.crf_args,
             "tagging_scheme": self.tagging_scheme.value,
             "data_augmentation_config":
-                self.data_augmentation_config.to_dict(),
-            "random_seed": self.random_seed
+                self.data_augmentation_config.to_dict()
         }
 
 

--- a/snips_nlu/pipeline/processing_unit.py
+++ b/snips_nlu/pipeline/processing_unit.py
@@ -13,10 +13,10 @@ from snips_nlu.common.abc_utils import abstractclassmethod, classproperty
 from snips_nlu.common.io_utils import temp_dir, unzip_archive
 from snips_nlu.common.registrable import Registrable
 from snips_nlu.common.utils import (
-    json_string)
+    json_string, check_random_state)
 from snips_nlu.constants import (
     BUILTIN_ENTITY_PARSER, CUSTOM_ENTITY_PARSER, CUSTOM_ENTITY_PARSER_USAGE,
-    RESOURCES, LANGUAGE)
+    RESOURCES, LANGUAGE, RANDOM_STATE)
 from snips_nlu.entity_parser import (
     BuiltinEntityParser, CustomEntityParser, CustomEntityParserUsage)
 from snips_nlu.exceptions import LoadingError
@@ -49,6 +49,7 @@ class ProcessingUnit(with_metaclass(ABCMeta, Registrable)):
         self.builtin_entity_parser = shared.get(BUILTIN_ENTITY_PARSER)
         self.custom_entity_parser = shared.get(CUSTOM_ENTITY_PARSER)
         self.resources = shared.get(RESOURCES)
+        self.random_state = check_random_state(shared.get(RANDOM_STATE))
 
     @classproperty
     def config_type(cls):  # pylint:disable=no-self-argument

--- a/snips_nlu/slot_filler/crf_slot_filler.py
+++ b/snips_nlu/slot_filler/crf_slot_filler.py
@@ -18,15 +18,14 @@ from snips_nlu.common.dict_utils import UnupdatableDict
 from snips_nlu.common.io_utils import mkdir_p
 from snips_nlu.common.log_utils import DifferedLoggingMessage, log_elapsed_time
 from snips_nlu.common.utils import (
-    check_persisted_path,
-    check_random_state, fitted_required, json_string)
-from snips_nlu.constants import (
-    DATA, LANGUAGE)
+    check_persisted_path, fitted_required, json_string)
+from snips_nlu.constants import DATA, LANGUAGE
 from snips_nlu.data_augmentation import augment_utterances
 from snips_nlu.dataset import validate_and_format_dataset
 from snips_nlu.exceptions import LoadingError
 from snips_nlu.pipeline.configs import CRFSlotFillerConfig
 from snips_nlu.preprocessing import tokenize
+
 from snips_nlu.slot_filler.crf_utils import (
     OUTSIDE, TAGS, TOKENS, tags_to_slots, utterance_to_sample)
 from snips_nlu.slot_filler.feature import TOKEN_NAME
@@ -128,10 +127,9 @@ class CRFSlotFiller(SlotFiller):
             # No need to train the CRF if the intent has no slots
             return self
 
-        random_state = check_random_state(self.config.random_seed)
         augmented_intent_utterances = augment_utterances(
             dataset, self.intent, language=self.language,
-            resources=self.resources, random_state=random_state,
+            resources=self.resources, random_state=self.random_state,
             **self.config.data_augmentation_config.to_dict())
 
         crf_samples = [
@@ -201,12 +199,11 @@ class CRFSlotFiller(SlotFiller):
 
         cache = [{TOKEN_NAME: token} for token in tokens]
         features = []
-        random_state = check_random_state(self.config.random_seed)
         for i in range(len(tokens)):
             token_features = UnupdatableDict()
             for feature in self.features:
                 f_drop_out = feature.drop_out
-                if drop_out and random_state.rand() < f_drop_out:
+                if drop_out and self.random_state.rand() < f_drop_out:
                     continue
                 value = feature.compute(i, cache)
                 if value is not None:

--- a/snips_nlu/slot_filler/crf_slot_filler.py
+++ b/snips_nlu/slot_filler/crf_slot_filler.py
@@ -95,7 +95,7 @@ class CRFSlotFiller(SlotFiller):
         """Whether or not the slot filler has already been fitted"""
         return self.slot_name_mapping is not None
 
-    @log_elapsed_time(logger, logging.DEBUG,
+    @log_elapsed_time(logger, logging.INFO,
                       "Fitted CRFSlotFiller in {elapsed_time}")
     # pylint:disable=arguments-differ
     def fit(self, dataset, intent):
@@ -109,7 +109,7 @@ class CRFSlotFiller(SlotFiller):
         Returns:
             :class:`CRFSlotFiller`: The same instance, trained
         """
-        logger.debug("Fitting %s slot filler...", intent)
+        logger.info("Fitting %s slot filler...", intent)
         dataset = validate_and_format_dataset(dataset)
         self.load_resources_if_needed(dataset[LANGUAGE])
         self.fit_builtin_entity_parser_if_needed(dataset)

--- a/snips_nlu/slot_filler/feature_factory.py
+++ b/snips_nlu/slot_filler/feature_factory.py
@@ -9,15 +9,16 @@ from snips_nlu_utils import get_shape
 
 from snips_nlu.common.abc_utils import classproperty
 from snips_nlu.common.registrable import Registrable
+from snips_nlu.common.utils import check_random_state
 from snips_nlu.constants import (
     CUSTOM_ENTITY_PARSER_USAGE, END, GAZETTEERS, LANGUAGE, RES_MATCH_RANGE,
     START, STEMS, WORD_CLUSTERS, CUSTOM_ENTITY_PARSER, BUILTIN_ENTITY_PARSER,
-    RESOURCES)
+    RESOURCES, RANDOM_STATE)
 from snips_nlu.dataset import (
     extract_intent_entities, get_dataset_gazetteer_entities)
 from snips_nlu.entity_parser.builtin_entity_parser import is_builtin_entity
-from snips_nlu.entity_parser.custom_entity_parser import \
-    CustomEntityParserUsage
+from snips_nlu.entity_parser.custom_entity_parser import (
+    CustomEntityParserUsage)
 from snips_nlu.languages import get_default_sep
 from snips_nlu.preprocessing import Token, normalize_token, stem_token
 from snips_nlu.resources import get_gazetteer, get_word_cluster
@@ -47,6 +48,7 @@ class CRFFeatureFactory(with_metaclass(ABCMeta, Registrable)):
         self.resources = shared.get(RESOURCES)
         self.builtin_entity_parser = shared.get(BUILTIN_ENTITY_PARSER)
         self.custom_entity_parser = shared.get(CUSTOM_ENTITY_PARSER)
+        self.random_state = check_random_state(shared.get(RANDOM_STATE))
 
     @classmethod
     def from_config(cls, factory_config, **shared):

--- a/snips_nlu/string_variations.py
+++ b/snips_nlu/string_variations.py
@@ -10,8 +10,8 @@ from num2words import num2words
 from snips_nlu_utils import normalize
 
 from snips_nlu.constants import (
-    END, LANGUAGE_DE, LANGUAGE_EN, LANGUAGE_ES, LANGUAGE_FR, RES_MATCH_RANGE,
-    SNIPS_NUMBER, START, VALUE, RESOLVED_VALUE)
+    END, LANGUAGE_DE, LANGUAGE_EN, LANGUAGE_ES, LANGUAGE_FR, RESOLVED_VALUE,
+    RES_MATCH_RANGE, SNIPS_NUMBER, START, VALUE)
 from snips_nlu.languages import (
     get_default_sep, get_punctuation_regex, supports_num2words)
 from snips_nlu.preprocessing import tokenize_light
@@ -156,24 +156,32 @@ def flatten(results):
 
 
 def get_string_variations(string, language, builtin_entity_parser,
-                          number_variations=True):
+                          numbers=True, case=True, and_=True,
+                          punctuation=True):
     variations = {string}
-    variations.update(flatten(case_variations(v) for v in variations))
+    if case:
+        variations.update(flatten(case_variations(v) for v in variations))
+
     variations.update(flatten(normalization_variations(v) for v in variations))
     # We re-generate case variations as normalization can produce new
     # variations
-    variations.update(flatten(case_variations(v) for v in variations))
-    variations.update(flatten(and_variations(v, language) for v in variations))
-    variations.update(
-        flatten(punctuation_variations(v, language) for v in variations))
+    if case:
+        variations.update(flatten(case_variations(v) for v in variations))
+    if and_:
+        variations.update(
+            flatten(and_variations(v, language) for v in variations))
+    if punctuation:
+        variations.update(
+            flatten(punctuation_variations(v, language) for v in variations))
 
     # Special case of number variation which are long to generate due to the
     # BuilinEntityParser running on each variation
-    if number_variations:
+    if numbers:
         variations.update(
             flatten(numbers_variations(v, language, builtin_entity_parser)
                     for v in variations)
         )
+
     # Add single space variations
     single_space_variations = set(" ".join(v.split()) for v in variations)
     variations.update(single_space_variations)

--- a/snips_nlu/string_variations.py
+++ b/snips_nlu/string_variations.py
@@ -155,7 +155,8 @@ def flatten(results):
     return set(i for r in results for i in r)
 
 
-def get_string_variations(string, language, builtin_entity_parser):
+def get_string_variations(string, language, builtin_entity_parser,
+                          number_variations=True):
     variations = {string}
     variations.update(flatten(case_variations(v) for v in variations))
     variations.update(flatten(normalization_variations(v) for v in variations))
@@ -165,9 +166,14 @@ def get_string_variations(string, language, builtin_entity_parser):
     variations.update(flatten(and_variations(v, language) for v in variations))
     variations.update(
         flatten(punctuation_variations(v, language) for v in variations))
-    variations.update(
-        flatten(numbers_variations(v, language, builtin_entity_parser)
-                for v in variations))
+
+    # Special case of number variation which are long to generate due to the
+    # BuilinEntityParser running on each variation
+    if number_variations:
+        variations.update(
+            flatten(numbers_variations(v, language, builtin_entity_parser)
+                    for v in variations)
+        )
     # Add single space variations
     single_space_variations = set(" ".join(v.split()) for v in variations)
     variations.update(single_space_variations)

--- a/snips_nlu/tests/integration_test.py
+++ b/snips_nlu/tests/integration_test.py
@@ -1,6 +1,9 @@
 # coding=utf-8
 from __future__ import print_function, unicode_literals
 
+import json
+from builtins import range, str
+
 from future.utils import iteritems
 from snips_nlu_metrics import compute_cross_val_metrics
 
@@ -48,6 +51,33 @@ class IntegrationTestSnipsNLUEngine(SnipsTest):
                     "Slot f1 score is too low (%.3f) for slot '%s' of intent "
                     "'%s'" % (slot_f1, slot_name, intent_name))
 
+    def test_nlu_engine_training_is_deterministic(self):
+        # We can't write a test to ensure the NLU training is always the same
+        # instead we train the NLU 10 times and check the learnt parameters.
+        # It does not bring any guarantee but it might alert us once in a while
+
+        # Given
+        num_runs = 10
+        random_state = 42
+
+        with PERFORMANCE_DATASET_PATH.open("r") as f:
+            dataset = json.load(f)
+
+        ref_log_reg, ref_crfs = None, None
+        for _ in range(num_runs):
+            # When
+            engine = TrainingEngine(random_state=random_state).fit(dataset)
+            log_reg = _extract_log_reg(engine)
+            crfs = _extract_crfs(engine)
+
+            if ref_log_reg is None:
+                ref_log_reg = log_reg
+                ref_crfs = crfs
+            else:
+                # Then
+                self.assertDictEqual(ref_log_reg, log_reg)
+                self.assertDictEqual(ref_crfs, crfs)
+
 
 def _slot_matching_lambda(lhs_slot, rhs_slot):
     lhs_value = lhs_slot["text"]
@@ -63,3 +93,24 @@ def _slot_matching_lambda(lhs_slot, rhs_slot):
         if rhs_tokens and rhs_tokens[0].lower() in SKIPPED_DATE_PREFIXES:
             rhs_tokens = rhs_tokens[1:]
         return lhs_tokens == rhs_tokens
+
+
+def _extract_log_reg(engine):
+    log_reg = dict()
+    intent_classifier = engine.intent_parsers[1].intent_classifier
+    log_reg["intent_list"] = intent_classifier.intent_list
+    log_reg["coef"] = intent_classifier.classifier.coef_.tolist()
+    log_reg["intercept"] = intent_classifier.classifier.intercept_.tolist()
+    log_reg["t_"] = intent_classifier.classifier.t_
+    return log_reg
+
+
+def _extract_crfs(engine):
+    crfs = dict()
+    slot_fillers = engine.intent_parsers[1].slot_fillers
+    for intent, slot_filler in iteritems(slot_fillers):
+        crfs[intent] = {
+            "state_features": slot_filler.crf_model.state_features_,
+            "transition_features": slot_filler.crf_model.transition_features_
+        }
+    return crfs

--- a/snips_nlu/tests/test_config.py
+++ b/snips_nlu/tests/test_config.py
@@ -112,8 +112,7 @@ class TestConfig(SnipsTest):
             "unit_name": LogRegIntentClassifier.unit_name,
             "data_augmentation_config":
                 IntentClassifierDataAugmentationConfig().to_dict(),
-            "featurizer_config": FeaturizerConfig().to_dict(),
-            "random_seed": 42
+            "featurizer_config": FeaturizerConfig().to_dict()
         }
 
         # When
@@ -151,8 +150,7 @@ class TestConfig(SnipsTest):
                 "algorithm": "lbfgs"
             },
             "data_augmentation_config":
-                SlotFillerDataAugmentationConfig().to_dict(),
-            "random_seed": 43
+                SlotFillerDataAugmentationConfig().to_dict()
         }
 
         # When

--- a/snips_nlu/tests/test_custom_entity_parser.py
+++ b/snips_nlu/tests/test_custom_entity_parser.py
@@ -9,7 +9,8 @@ from snips_nlu.constants import STEMS
 from snips_nlu.dataset import validate_and_format_dataset
 from snips_nlu.entity_parser import CustomEntityParser
 from snips_nlu.entity_parser.custom_entity_parser import (
-    CustomEntityParserUsage, _compute_char_shifts)
+    CustomEntityParserUsage, _compute_char_shifts,
+    _create_custom_entity_parser_configuration)
 from snips_nlu.preprocessing import tokenize
 from snips_nlu.tests.utils import FixtureTest
 
@@ -272,6 +273,70 @@ class TestCustomEntityParser(FixtureTest):
         expected_shifts = [-2, -2, -2, -2, -2, -1, -1, -3, -3, -3, -3, -3, -3]
         self.assertListEqual(expected_shifts, shifts)
 
+    def test_create_custom_entity_parser_configuration(self):
+        # Given
+        entities = {
+            "a": {
+                "utterances":
+                    {
+                        "a a": "a",
+                        "aa": "a",
+                        "c": "c"
+                    },
+                "matching_strictness": 1.0
+            },
+            "b": {
+                "utterances":{
+                    "b": "b"
+                },
+                "matching_strictness": 1.0
+            },
+        }
+
+        # When
+        config = _create_custom_entity_parser_configuration(
+            entities, stopwords_fraction=.5, language="en")
+
+        # Then
+        expected_dict = {
+            "entity_parsers": [
+                {
+                    "entity_identifier": "a",
+                    "entity_parser": {
+                        "threshold": 1.0,
+                        "n_gazetteer_stop_words": 1,
+                        "gazetteer": [
+                            {
+                                "raw_value": "a a",
+                                "resolved_value": "a",
+                            },
+                            {
+                                "raw_value": "aa",
+                                "resolved_value": "a",
+                            },
+                            {
+                                "raw_value": "c",
+                                "resolved_value": "c",
+                            },
+                        ]
+                    }
+                },
+                {
+                    "entity_identifier": "b",
+                    "entity_parser": {
+                        "threshold": 1.0,
+                        "n_gazetteer_stop_words": 0,
+                        "gazetteer": [
+                            {
+                                "raw_value": "b",
+                                "resolved_value": "b",
+                            },
+                        ]
+                    }
+                }
+            ]
+        }
+        self.assertDictEqual(expected_dict, config)
 
 # pylint: disable=unused-argument
 def _persist_parser(path):

--- a/snips_nlu/tests/test_dataset_validation.py
+++ b/snips_nlu/tests/test_dataset_validation.py
@@ -1033,3 +1033,99 @@ class TestDatasetValidation(SnipsTest):
                     kwargs = call[2]
                     for k in expected_args:
                         self.assertEqual(expected_args[k], kwargs[k])
+
+    def test_should_not_collapse_utterance_entity_variations(self):
+        # Given
+        dataset = {
+            "language": "en",
+            "intents": {
+                "verify_length": {
+                    "utterances": [
+                        {
+                            "data": [
+                                {
+                                    "text": "hello "
+                                },
+                                {
+                                    "text": "9",
+                                    "slot_name": "expected",
+                                    "entity": "expected"
+                                }
+                            ]
+                        },
+                        {
+                            "data": [
+                                {
+                                    "text": "hello "
+                                },
+                                {
+                                    "text": "nine",
+                                    "slot_name": "expected",
+                                    "entity": "expected"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "entities": {
+                "expected": {
+                    "automatically_extensible": True,
+                    "use_synonyms": True,
+                    "data": [],
+                    "matching_strictness": 1.0
+                }
+            }
+        }
+
+        # When
+        validated_dataset = validate_and_format_dataset(dataset)
+
+        # Then
+        expected_dataset = {
+            "language": "en",
+            "intents": {
+                "verify_length": {
+                    "utterances": [
+                        {
+                            "data": [
+                                {
+                                    "text": "hello "
+                                },
+                                {
+                                    "text": "9",
+                                    "slot_name": "expected",
+                                    "entity": "expected"
+                                }
+                            ]
+                        },
+                        {
+                            "data": [
+                                {
+                                    "text": "hello "
+                                },
+                                {
+                                    "text": "nine",
+                                    "slot_name": "expected",
+                                    "entity": "expected"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "entities": {
+                "expected": {
+                    "automatically_extensible": True,
+                    "matching_strictness": 1.0,
+                    "capitalize": False,
+                    "utterances": {
+                        "nine": "nine",
+                        "Nine": "nine",
+                        "9": "9"
+                    }
+                }
+            },
+            "validated": True
+        }
+        self.assertDictEqual(expected_dataset, validated_dataset)

--- a/snips_nlu/tests/test_dataset_validation.py
+++ b/snips_nlu/tests/test_dataset_validation.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from builtins import range, str
 
+from future.utils import iteritems
 from mock import mock, patch
 
 from snips_nlu.constants import ENTITIES, SNIPS_DATETIME
@@ -191,10 +192,11 @@ class TestDatasetValidation(SnipsTest):
         # Given
         # pylint: disable=unused-argument
         def mock_get_string_variations(
-                variation, language, builtin_entity_parser,
-                number_variations
+                string, language, builtin_entity_parser,
+                numbers=True, case=True, and_=True,
+                punctuation=True
         ):
-            return {variation.lower(), variation.title()}
+            return {string.lower(), string.title()}
 
         mocked_get_string_variations.side_effect = mock_get_string_variations
         dataset = {
@@ -246,10 +248,11 @@ class TestDatasetValidation(SnipsTest):
         # Given
         # pylint: disable=unused-argument
         def mock_get_string_variations(
-                variation, language, builtin_entity_parser,
-                number_variations
+                string, language, builtin_entity_parser,
+                numbers=True, case=True, and_=True,
+                punctuation=True
         ):
-            return {variation, variation.title()}
+            return {string, string.title()}
 
         mocked_get_string_variations.side_effect = mock_get_string_variations
         dataset = {
@@ -361,10 +364,11 @@ class TestDatasetValidation(SnipsTest):
         # Given
         # pylint: disable=unused-argument
         def mock_get_string_variations(
-                variation, language, builtin_entity_parser,
-                number_variations
+                string, language, builtin_entity_parser,
+                numbers=True, case=True, and_=True,
+                punctuation=True
         ):
-            return {variation}
+            return {string}
 
         mocked_get_string_variations.side_effect = mock_get_string_variations
         dataset = {
@@ -504,10 +508,11 @@ class TestDatasetValidation(SnipsTest):
         # Given
         # pylint: disable=unused-argument
         def mock_get_string_variations(
-                variation, language, builtin_entity_parser,
-                number_variations
+                string, language, builtin_entity_parser,
+                numbers=True, case=True, and_=True,
+                punctuation=True
         ):
-            return {variation, variation.title()}
+            return {string, string.title()}
 
         mocked_get_string_variations.side_effect = mock_get_string_variations
         dataset = {
@@ -620,10 +625,11 @@ class TestDatasetValidation(SnipsTest):
         # Given
         # pylint: disable=unused-argument
         def mock_get_string_variations(
-                variation, language, builtin_entity_parser,
-                number_variations
+                string, language, builtin_entity_parser,
+                numbers=True, case=True, and_=True,
+                punctuation=True
         ):
-            return {variation, variation.title()}
+            return {string, string.title()}
 
         mocked_get_string_variations.side_effect = mock_get_string_variations
         dataset = {
@@ -798,10 +804,11 @@ class TestDatasetValidation(SnipsTest):
         # Given
         # pylint: disable=unused-argument
         def mock_get_string_variations(
-                variation, language, builtin_entity_parser,
-                number_variations
+                string, language, builtin_entity_parser,
+                numbers=True, case=True, and_=True,
+                punctuation=True
         ):
-            return {variation.lower(), variation.title()}
+            return {string.lower(), string.title()}
 
         mocked_get_string_variations.side_effect = mock_get_string_variations
         dataset = {
@@ -875,10 +882,11 @@ class TestDatasetValidation(SnipsTest):
         # Given
         # pylint: disable=unused-argument
         def mock_get_string_variations(
-                variation, language, builtin_entity_parser,
-                number_variations
+                string, language, builtin_entity_parser,
+                numbers=True, case=True, and_=True,
+                punctuation=True
         ):
-            return {variation.lower(), variation.title()}
+            return {string.lower(), string.title()}
 
         mocked_get_string_variations.side_effect = mock_get_string_variations
         dataset = {
@@ -983,50 +991,45 @@ class TestDatasetValidation(SnipsTest):
 
     def test_should_create_number_variation(self):
         # Given
-        num_values = 1
-        entity = {
-            "matching_strictness": 1.0,
-            "use_synonyms": False,
-            "automatically_extensible": False,
-            "data": [
-                {"value": str(i), "synonyms": []}
-                for i in range(num_values)]
+        args = {
+            1: {
+                "numbers": True,
+                "and_": True,
+                "case": True,
+                "punctuation": True,
+            },
+            1001: {
+                "numbers": False,
+                "and_": True,
+                "case": True,
+                "punctuation": True,
+            },
+            10001: {
+                "numbers": False,
+                "and_": False,
+                "case": False,
+                "punctuation": False,
+            }
         }
-        builtin_entity_parser = EntityParserMock(dict())
 
-        # When
-        with patch("snips_nlu.dataset.validation"
-                   ".get_string_variations") as mocked_string_variations:
-            mocked_string_variations.return_value = []
-            _validate_and_format_custom_entity(
-                entity, [], "en", builtin_entity_parser)
-            # Then
-            self.assertGreater(mocked_string_variations.call_count, 0)
-            for call in mocked_string_variations.mock_calls:
-                kwargs = call[2]
-                self.assertTrue(kwargs["number_variations"])
-
-    def test_should_not_create_number_variation(self):
-        # Given
-        num_values = 1001
-        entity = {
-            "matching_strictness": 1.0,
-            "use_synonyms": False,
-            "automatically_extensible": False,
-            "data": [
-                {"value": str(i), "synonyms": []}
-                for i in range(num_values)]
-        }
-        builtin_entity_parser = EntityParserMock(dict())
-
-        # When
-        with patch("snips_nlu.dataset.validation"
-                   ".get_string_variations") as mocked_string_variations:
-            mocked_string_variations.return_value = []
-            _validate_and_format_custom_entity(
-                entity, [], "en", builtin_entity_parser)
-            # Then
-            self.assertGreater(mocked_string_variations.call_count, 0)
-            for call in mocked_string_variations.mock_calls:
-                kwargs = call[2]
-                self.assertFalse(kwargs["number_variations"])
+        for num_ents, expected_args in iteritems(args):
+            entity = {
+                "matching_strictness": 1.0,
+                "use_synonyms": False,
+                "automatically_extensible": False,
+                "data": [
+                    {"value": str(i), "synonyms": []}
+                    for i in range(num_ents)]
+            }
+            builtin_entity_parser = EntityParserMock(dict())
+            with patch("snips_nlu.dataset.validation"
+                       ".get_string_variations") as mocked_string_variations:
+                mocked_string_variations.return_value = []
+                # When
+                _validate_and_format_custom_entity(
+                    entity, [], "en", builtin_entity_parser)
+                # Then
+                for call in mocked_string_variations.mock_calls:
+                    kwargs = call[2]
+                    for k in expected_args:
+                        self.assertEqual(expected_args[k], kwargs[k])

--- a/snips_nlu/tests/test_log_reg_intent_classifier.py
+++ b/snips_nlu/tests/test_log_reg_intent_classifier.py
@@ -50,8 +50,7 @@ utterances:
 - does it rain
 - will it rain tomorrow""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        config = LogRegIntentClassifierConfig(random_seed=42)
-        classifier = LogRegIntentClassifier(config).fit(dataset)
+        classifier = LogRegIntentClassifier(random_state=42).fit(dataset)
         text = "hey how are you doing ?"
 
         # When
@@ -108,8 +107,7 @@ utterances:
 - brew two cups of coffee
 - can you prepare one cup of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        config = LogRegIntentClassifierConfig(random_seed=42)
-        classifier = LogRegIntentClassifier(config).fit(dataset)
+        classifier = LogRegIntentClassifier(random_state=42).fit(dataset)
 
         # When
         text1 = "Make me two cups of tea"
@@ -169,8 +167,7 @@ name: intent3
 utterances:
   - yili yulu yele""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        config = LogRegIntentClassifierConfig(random_seed=42)
-        classifier = LogRegIntentClassifier(config).fit(dataset)
+        classifier = LogRegIntentClassifier(random_state=42).fit(dataset)
         text = "yala yili yulu"
 
         # When
@@ -239,9 +236,11 @@ name: intent2
 utterances:
   - lorem ipsum""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        intent_classifier = LogRegIntentClassifier().fit(dataset)
+        intent_classifier = LogRegIntentClassifier(
+            random_state=42).fit(dataset)
         coeffs = intent_classifier.classifier.coef_.tolist()
         intercept = intent_classifier.classifier.intercept_.tolist()
+        t_ = intent_classifier.classifier.t_
 
         # When
         intent_classifier.persist(self.tmp_file_path)
@@ -252,7 +251,7 @@ utterances:
             "config": LogRegIntentClassifierConfig().to_dict(),
             "coeffs": coeffs,
             "intercept": intercept,
-            "t_": 701.0,
+            "t_": t_,
             "intent_list": intent_list,
             "featurizer": "featurizer"
         }

--- a/snips_nlu/tests/test_probabilistic_intent_parser.py
+++ b/snips_nlu/tests/test_probabilistic_intent_parser.py
@@ -6,7 +6,8 @@ from future.utils import itervalues
 from mock import patch
 
 from snips_nlu.constants import (
-    RES_ENTITY, RES_INTENT, RES_INTENT_NAME, RES_SLOTS, RES_VALUE)
+    RES_ENTITY, RES_INTENT, RES_INTENT_NAME, RES_SLOTS, RES_VALUE,
+    RANDOM_STATE)
 from snips_nlu.dataset import Dataset
 from snips_nlu.exceptions import IntentNotFoundError, NotTrained
 from snips_nlu.intent_classifier import (
@@ -42,11 +43,9 @@ name: intent3
 utterances:
   - foz for [slot3:entity3](baz)""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        classifier_config = LogRegIntentClassifierConfig(random_seed=42)
-        slot_filler_config = CRFSlotFillerConfig(random_seed=42)
-        parser_config = ProbabilisticIntentParserConfig(
-            classifier_config, slot_filler_config)
-        parser = ProbabilisticIntentParser(parser_config)
+        shared = self.get_shared_data(dataset)
+        shared[RANDOM_STATE] = 42
+        parser = ProbabilisticIntentParser(**shared)
         parser.fit(dataset)
         text = "foo bar baz"
 
@@ -81,11 +80,9 @@ name: intent3
 utterances:
   - foz for [slot3:entity3](baz)""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        classifier_config = LogRegIntentClassifierConfig(random_seed=42)
-        slot_filler_config = CRFSlotFillerConfig(random_seed=42)
-        parser_config = ProbabilisticIntentParserConfig(
-            classifier_config, slot_filler_config)
-        parser = ProbabilisticIntentParser(parser_config)
+        shared = self.get_shared_data(dataset)
+        shared[RANDOM_STATE] = 42
+        parser = ProbabilisticIntentParser(**shared)
         parser.fit(dataset)
         text = "foo bar baz"
 
@@ -121,11 +118,9 @@ name: intent3
 utterances:
   - foz for [entity3](baz)""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        classifier_config = LogRegIntentClassifierConfig(random_seed=42)
-        slot_filler_config = CRFSlotFillerConfig(random_seed=42)
-        parser_config = ProbabilisticIntentParserConfig(
-            classifier_config, slot_filler_config)
-        parser = ProbabilisticIntentParser(parser_config)
+        shared = self.get_shared_data(dataset)
+        shared[RANDOM_STATE] = 42
+        parser = ProbabilisticIntentParser(**shared)
         parser.fit(dataset)
         text = "foo bar baz"
 
@@ -162,9 +157,9 @@ name: intent3
 utterances:
   - yili yulu yele""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        classifier_config = LogRegIntentClassifierConfig(random_seed=42)
-        parser_config = ProbabilisticIntentParserConfig(classifier_config)
-        parser = ProbabilisticIntentParser(parser_config).fit(dataset)
+        shared = self.get_shared_data(dataset)
+        shared[RANDOM_STATE] = 42
+        parser = ProbabilisticIntentParser(**shared).fit(dataset)
         text = "yala yili yulu"
 
         # When
@@ -678,15 +673,10 @@ utterances:
 - brew [number_of_cups] cups of coffee""")
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
 
-        seed1 = 666
-        seed2 = 42
-        config = ProbabilisticIntentParserConfig(
-            intent_classifier_config=LogRegIntentClassifierConfig(
-                random_seed=seed1),
-            slot_filler_config=CRFSlotFillerConfig(random_seed=seed2)
-        )
+        seed = 666
         shared = self.get_shared_data(dataset)
-        parser = ProbabilisticIntentParser(config, **shared)
+        shared[RANDOM_STATE] = seed
+        parser = ProbabilisticIntentParser(**shared)
         parser.persist(self.tmp_file_path)
 
         # When

--- a/snips_nlu/tests/test_processing_unit.py
+++ b/snips_nlu/tests/test_processing_unit.py
@@ -1,0 +1,35 @@
+from snips_nlu.pipeline.processing_unit import ProcessingUnit
+from snips_nlu.tests.utils import FixtureTest
+
+
+class DummyProcessingUnit(ProcessingUnit):
+    unit_name = "dummy_processing_unit"
+
+    def persist(self, path):
+        pass
+
+    @classmethod
+    def from_path(cls, path, **shared):
+        return cls(config=None, **shared)
+
+    @property
+    def fitted(self):
+        return True
+
+
+class TestProcessingUnit(FixtureTest):
+
+    def test_from_path_with_seed(self):
+        # Given
+        max_int = 1e6
+        seed = 1
+
+        # When
+        unit_0 = DummyProcessingUnit.from_path(None, random_state=seed)
+        int_0 = unit_0.random_state.randint(max_int)
+
+        unit_1 = DummyProcessingUnit.from_path(None, random_state=seed)
+        int_1 = unit_1.random_state.randint(max_int)
+
+        # Then
+        self.assertEqual(int_0, int_1)

--- a/snips_nlu/tests/test_string_variations.py
+++ b/snips_nlu/tests/test_string_variations.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 from __future__ import unicode_literals
 
+from mock import MagicMock
+
 from snips_nlu.constants import (LANGUAGE_EN, LANGUAGE_FR, RES_MATCH_RANGE,
                                  SNIPS_NUMBER, START)
 from snips_nlu.entity_parser import BuiltinEntityParser
@@ -164,3 +166,17 @@ class TestStringVariations(SnipsTest):
             "7.62 mm caliber two and 6",
         }
         self.assertSetEqual(variations, expected_variations)
+
+    def test_get_string_variations_should_not_generate_number_variations(self):
+        # Given
+        builtin_entity_parser = MagicMock()
+        mocked_parse = MagicMock(return_value=[])
+        builtin_entity_parser.parse = mocked_parse
+
+        # When/Then
+        get_string_variations("", "en", builtin_entity_parser,
+                              number_variations=False)
+        mocked_parse.assert_not_called()
+        get_string_variations(
+            "", "en", builtin_entity_parser, number_variations=True)
+        self.assertGreater(mocked_parse.call_count, 0)

--- a/snips_nlu/tests/test_string_variations.py
+++ b/snips_nlu/tests/test_string_variations.py
@@ -174,9 +174,8 @@ class TestStringVariations(SnipsTest):
         builtin_entity_parser.parse = mocked_parse
 
         # When/Then
-        get_string_variations("", "en", builtin_entity_parser,
-                              number_variations=False)
+        get_string_variations("", "en", builtin_entity_parser, numbers=False)
         mocked_parse.assert_not_called()
         get_string_variations(
-            "", "en", builtin_entity_parser, number_variations=True)
+            "", "en", builtin_entity_parser, numbers=True)
         self.assertGreater(mocked_parse.call_count, 0)

--- a/snips_nlu/tests/utils.py
+++ b/snips_nlu/tests/utils.py
@@ -47,7 +47,8 @@ class SnipsTest(TestCase):
         return {
             "resources": resources,
             "builtin_entity_parser": builtin_entity_parser,
-            "custom_entity_parser": custom_entity_parser
+            "custom_entity_parser": custom_entity_parser,
+            "random_state": 1
         }
 
     @contextmanager

--- a/snips_nlu/tests/utils.py
+++ b/snips_nlu/tests/utils.py
@@ -221,4 +221,4 @@ class EntityParserMock(EntityParser):
         return cls(entities)
 
     def _parse(self, text, scope=None):
-        return self.entities.get(text)
+        return self.entities.get(text, [])


### PR DESCRIPTION
## [0.19.7]
### Changed
- Re-score ambiguous `DeterministicIntentParser` results based on slots [#791](https://github.com/snipsco/snips-nlu/pull/791)
- Accept ambiguous results from `DeterministicIntentParser` when confidence score is above 0.5 [#797](https://github.com/snipsco/snips-nlu/pull/797)
- Avoid generating number variations when not needed [#799](https://github.com/snipsco/snips-nlu/pull/799)
- Moved the NLU random state from the config to the shared resources [#801](https://github.com/snipsco/snips-nlu/pull/801)
- Reduce custom entity parser footprint in training time [#804](https://github.com/snipsco/snips-nlu/pull/804)
- Bumped `scikit-learn` to `>=0.21,<0.22` for `python>=3.5` and `>=0.20<0.21` for `python<3.5` [#801](https://github.com/snipsco/snips-nlu/pull/801)
- Update dependencies [#811](https://github.com/snipsco/snips-nlu/pull/811) 

### Fixed
- Fixed a couple of bugs in the data augmentation which were making the NLU training non-deterministic [#801](https://github.com/snipsco/snips-nlu/pull/801)
- Remove deprecated code in dataset generation [#803](https://github.com/snipsco/snips-nlu/pull/803)
- Fix possible override of entity values when generating variations [#808](https://github.com/snipsco/snips-nlu/pull/808)
