### PR TITLE
Filter for entity match feature

### DIFF
--- a/snips_nlu/default_configs/config_de.py
+++ b/snips_nlu/default_configs/config_de.py
@@ -90,7 +90,7 @@ CONFIG = {
                         "args": {
                             "use_stemming": True,
                             "tagging_scheme_code": 2,
-                            "filter": {
+                            "entity_filter": {
                                 "automatically_extensible": False
                             }
                         },
@@ -101,7 +101,7 @@ CONFIG = {
                         "args": {
                             "use_stemming": True,
                             "tagging_scheme_code": 2,
-                            "filter": {
+                            "entity_filter": {
                                 "automatically_extensible": True
                             }
                         },

--- a/snips_nlu/default_configs/config_de.py
+++ b/snips_nlu/default_configs/config_de.py
@@ -89,7 +89,21 @@ CONFIG = {
                     {
                         "args": {
                             "use_stemming": True,
-                            "tagging_scheme_code": 2
+                            "tagging_scheme_code": 2,
+                            "filter": {
+                                "automatically_extensible": False
+                            }
+                        },
+                        "factory_name": "entity_match",
+                        "offsets": [-2, -1, 0]
+                    },
+                    {
+                        "args": {
+                            "use_stemming": True,
+                            "tagging_scheme_code": 2,
+                            "filter": {
+                                "automatically_extensible": True
+                            }
                         },
                         "factory_name": "entity_match",
                         "offsets": [-2, -1, 0],

--- a/snips_nlu/default_configs/config_en.py
+++ b/snips_nlu/default_configs/config_en.py
@@ -68,7 +68,7 @@ CONFIG = {
                         "args": {
                             "use_stemming": True,
                             "tagging_scheme_code": 2,
-                            "filter": {
+                            "entity_filter": {
                                 "automatically_extensible": False
                             }
                         },
@@ -79,7 +79,7 @@ CONFIG = {
                         "args": {
                             "use_stemming": True,
                             "tagging_scheme_code": 2,
-                            "filter": {
+                            "entity_filter": {
                                 "automatically_extensible": True
                             }
                         },

--- a/snips_nlu/default_configs/config_en.py
+++ b/snips_nlu/default_configs/config_en.py
@@ -67,7 +67,21 @@ CONFIG = {
                     {
                         "args": {
                             "use_stemming": True,
-                            "tagging_scheme_code": 2
+                            "tagging_scheme_code": 2,
+                            "filter": {
+                                "automatically_extensible": False
+                            }
+                        },
+                        "factory_name": "entity_match",
+                        "offsets": [-2, -1, 0]
+                    },
+                    {
+                        "args": {
+                            "use_stemming": True,
+                            "tagging_scheme_code": 2,
+                            "filter": {
+                                "automatically_extensible": True
+                            }
                         },
                         "factory_name": "entity_match",
                         "offsets": [-2, -1, 0],

--- a/snips_nlu/default_configs/config_es.py
+++ b/snips_nlu/default_configs/config_es.py
@@ -68,7 +68,7 @@ CONFIG = {
                         "args": {
                             "use_stemming": True,
                             "tagging_scheme_code": 2,
-                            "filter": {
+                            "entity_filter": {
                                 "automatically_extensible": False
                             }
                         },
@@ -79,7 +79,7 @@ CONFIG = {
                         "args": {
                             "use_stemming": True,
                             "tagging_scheme_code": 2,
-                            "filter": {
+                            "entity_filter": {
                                 "automatically_extensible": True
                             }
                         },

--- a/snips_nlu/default_configs/config_es.py
+++ b/snips_nlu/default_configs/config_es.py
@@ -67,7 +67,21 @@ CONFIG = {
                     {
                         "args": {
                             "use_stemming": True,
-                            "tagging_scheme_code": 2
+                            "tagging_scheme_code": 2,
+                            "filter": {
+                                "automatically_extensible": False
+                            }
+                        },
+                        "factory_name": "entity_match",
+                        "offsets": [-2, -1, 0]
+                    },
+                    {
+                        "args": {
+                            "use_stemming": True,
+                            "tagging_scheme_code": 2,
+                            "filter": {
+                                "automatically_extensible": True
+                            }
                         },
                         "factory_name": "entity_match",
                         "offsets": [-2, -1, 0],

--- a/snips_nlu/default_configs/config_fr.py
+++ b/snips_nlu/default_configs/config_fr.py
@@ -68,7 +68,7 @@ CONFIG = {
                         "args": {
                             "use_stemming": True,
                             "tagging_scheme_code": 2,
-                            "filter": {
+                            "entity_filter": {
                                 "automatically_extensible": False
                             }
                         },
@@ -79,7 +79,7 @@ CONFIG = {
                         "args": {
                             "use_stemming": True,
                             "tagging_scheme_code": 2,
-                            "filter": {
+                            "entity_filter": {
                                 "automatically_extensible": True
                             }
                         },

--- a/snips_nlu/default_configs/config_fr.py
+++ b/snips_nlu/default_configs/config_fr.py
@@ -67,7 +67,21 @@ CONFIG = {
                     {
                         "args": {
                             "use_stemming": True,
-                            "tagging_scheme_code": 2
+                            "tagging_scheme_code": 2,
+                            "filter": {
+                                "automatically_extensible": False
+                            }
+                        },
+                        "factory_name": "entity_match",
+                        "offsets": [-2, -1, 0]
+                    },
+                    {
+                        "args": {
+                            "use_stemming": True,
+                            "tagging_scheme_code": 2,
+                            "filter": {
+                                "automatically_extensible": True
+                            }
                         },
                         "factory_name": "entity_match",
                         "offsets": [-2, -1, 0],

--- a/snips_nlu/default_configs/config_it.py
+++ b/snips_nlu/default_configs/config_it.py
@@ -68,7 +68,7 @@ CONFIG = {
                         "args": {
                             "use_stemming": True,
                             "tagging_scheme_code": 2,
-                            "filter": {
+                            "entity_filter": {
                                 "automatically_extensible": False
                             }
                         },
@@ -79,7 +79,7 @@ CONFIG = {
                         "args": {
                             "use_stemming": True,
                             "tagging_scheme_code": 2,
-                            "filter": {
+                            "entity_filter": {
                                 "automatically_extensible": True
                             }
                         },

--- a/snips_nlu/default_configs/config_it.py
+++ b/snips_nlu/default_configs/config_it.py
@@ -67,7 +67,21 @@ CONFIG = {
                     {
                         "args": {
                             "use_stemming": True,
-                            "tagging_scheme_code": 2
+                            "tagging_scheme_code": 2,
+                            "filter": {
+                                "automatically_extensible": False
+                            }
+                        },
+                        "factory_name": "entity_match",
+                        "offsets": [-2, -1, 0]
+                    },
+                    {
+                        "args": {
+                            "use_stemming": True,
+                            "tagging_scheme_code": 2,
+                            "filter": {
+                                "automatically_extensible": True
+                            }
                         },
                         "factory_name": "entity_match",
                         "offsets": [-2, -1, 0],

--- a/snips_nlu/default_configs/config_ja.py
+++ b/snips_nlu/default_configs/config_ja.py
@@ -85,10 +85,10 @@ CONFIG = {
                     {
                         "args": {
                             "use_stemming": False,
-                            "tagging_scheme_code": 2
-                        },
-                        "filter": {
-                            "automatically_extensible": False
+                            "tagging_scheme_code": 2,
+                            "entity_filter": {
+                                "automatically_extensible": False
+                            }
                         },
                         "factory_name": "entity_match",
                         "offsets": [-1, 0, 1, 2],
@@ -96,10 +96,10 @@ CONFIG = {
                     {
                         "args": {
                             "use_stemming": False,
-                            "tagging_scheme_code": 2
-                        },
-                        "filter": {
-                            "automatically_extensible": True
+                            "tagging_scheme_code": 2,
+                            "entity_filter": {
+                                "automatically_extensible": False
+                            }
                         },
                         "factory_name": "entity_match",
                         "offsets": [-1, 0, 1, 2],

--- a/snips_nlu/default_configs/config_ja.py
+++ b/snips_nlu/default_configs/config_ja.py
@@ -87,6 +87,20 @@ CONFIG = {
                             "use_stemming": False,
                             "tagging_scheme_code": 2
                         },
+                        "filter": {
+                            "automatically_extensible": False
+                        },
+                        "factory_name": "entity_match",
+                        "offsets": [-1, 0, 1, 2],
+                    },
+                    {
+                        "args": {
+                            "use_stemming": False,
+                            "tagging_scheme_code": 2
+                        },
+                        "filter": {
+                            "automatically_extensible": True
+                        },
                         "factory_name": "entity_match",
                         "offsets": [-1, 0, 1, 2],
                         "drop_out": 0.5

--- a/snips_nlu/default_configs/config_ko.py
+++ b/snips_nlu/default_configs/config_ko.py
@@ -84,8 +84,22 @@ CONFIG = {
                     },
                     {
                         "args": {
-                            "use_stemming": False,
-                            "tagging_scheme_code": 2
+                            "use_stemming": True,
+                            "tagging_scheme_code": 2,
+                            "filter": {
+                                "automatically_extensible": False
+                            }
+                        },
+                        "factory_name": "entity_match",
+                        "offsets": [-2, -1, 0]
+                    },
+                    {
+                        "args": {
+                            "use_stemming": True,
+                            "tagging_scheme_code": 2,
+                            "filter": {
+                                "automatically_extensible": True
+                            }
                         },
                         "factory_name": "entity_match",
                         "offsets": [-2, -1, 0],

--- a/snips_nlu/default_configs/config_ko.py
+++ b/snips_nlu/default_configs/config_ko.py
@@ -84,9 +84,9 @@ CONFIG = {
                     },
                     {
                         "args": {
-                            "use_stemming": True,
+                            "use_stemming": False,
                             "tagging_scheme_code": 2,
-                            "filter": {
+                            "entity_filter": {
                                 "automatically_extensible": False
                             }
                         },
@@ -95,9 +95,9 @@ CONFIG = {
                     },
                     {
                         "args": {
-                            "use_stemming": True,
+                            "use_stemming": False,
                             "tagging_scheme_code": 2,
-                            "filter": {
+                            "entity_filter": {
                                 "automatically_extensible": True
                             }
                         },

--- a/snips_nlu/default_configs/config_pt_br.py
+++ b/snips_nlu/default_configs/config_pt_br.py
@@ -68,7 +68,7 @@ CONFIG = {
                         "args": {
                             "use_stemming": True,
                             "tagging_scheme_code": 2,
-                            "filter": {
+                            "entity_filter": {
                                 "automatically_extensible": False
                             }
                         },
@@ -79,7 +79,7 @@ CONFIG = {
                         "args": {
                             "use_stemming": True,
                             "tagging_scheme_code": 2,
-                            "filter": {
+                            "entity_filter": {
                                 "automatically_extensible": True
                             }
                         },

--- a/snips_nlu/default_configs/config_pt_br.py
+++ b/snips_nlu/default_configs/config_pt_br.py
@@ -67,7 +67,21 @@ CONFIG = {
                     {
                         "args": {
                             "use_stemming": True,
-                            "tagging_scheme_code": 2
+                            "tagging_scheme_code": 2,
+                            "filter": {
+                                "automatically_extensible": False
+                            }
+                        },
+                        "factory_name": "entity_match",
+                        "offsets": [-2, -1, 0]
+                    },
+                    {
+                        "args": {
+                            "use_stemming": True,
+                            "tagging_scheme_code": 2,
+                            "filter": {
+                                "automatically_extensible": True
+                            }
                         },
                         "factory_name": "entity_match",
                         "offsets": [-2, -1, 0],

--- a/snips_nlu/default_configs/config_pt_pt.py
+++ b/snips_nlu/default_configs/config_pt_pt.py
@@ -68,7 +68,7 @@ CONFIG = {
                         "args": {
                             "use_stemming": True,
                             "tagging_scheme_code": 2,
-                            "filter": {
+                            "entity_filter": {
                                 "automatically_extensible": False
                             }
                         },
@@ -79,7 +79,7 @@ CONFIG = {
                         "args": {
                             "use_stemming": True,
                             "tagging_scheme_code": 2,
-                            "filter": {
+                            "entity_filter": {
                                 "automatically_extensible": True
                             }
                         },

--- a/snips_nlu/default_configs/config_pt_pt.py
+++ b/snips_nlu/default_configs/config_pt_pt.py
@@ -67,7 +67,21 @@ CONFIG = {
                     {
                         "args": {
                             "use_stemming": True,
-                            "tagging_scheme_code": 2
+                            "tagging_scheme_code": 2,
+                            "filter": {
+                                "automatically_extensible": False
+                            }
+                        },
+                        "factory_name": "entity_match",
+                        "offsets": [-2, -1, 0]
+                    },
+                    {
+                        "args": {
+                            "use_stemming": True,
+                            "tagging_scheme_code": 2,
+                            "filter": {
+                                "automatically_extensible": True
+                            }
                         },
                         "factory_name": "entity_match",
                         "offsets": [-2, -1, 0],

--- a/snips_nlu/slot_filler/feature_factory.py
+++ b/snips_nlu/slot_filler/feature_factory.py
@@ -31,20 +31,6 @@ from snips_nlu.slot_filler.features_utils import (
 
 logger = logging.getLogger(__name__)
 
-class _InvalidCustomEntityFilter(ValueError):
-    pass
-
-
-CUSTOM_ENTITIES_FILTER_KEYS = {"automatically_extensible"}
-
-
-def _check_custom_entity_filter(entity_filter):
-    for k in entity_filter:
-        if k not in CUSTOM_ENTITIES_FILTER_KEYS:
-            msg = "Invalid custom entity filter key '%s'. Accepted filter " \
-                  "keys are %s" % (k, list(CUSTOM_ENTITIES_FILTER_KEYS))
-            raise _InvalidCustomEntityFilter(msg)
-
 
 class CRFFeatureFactory(with_metaclass(ABCMeta, Registrable)):
     """Abstraction to implement to build CRF features
@@ -520,6 +506,22 @@ class CustomEntityMatchFactory(CRFFeatureFactory):
             CUSTOM_ENTITY_PARSER_USAGE:
                 CustomEntityParserUsage.WITHOUT_STEMS
         }
+
+
+class _InvalidCustomEntityFilter(ValueError):
+    pass
+
+
+CUSTOM_ENTITIES_FILTER_KEYS = {"automatically_extensible"}
+
+
+# pylint: disable=redefined-outer-name
+def _check_custom_entity_filter(entity_filter):
+    for k in entity_filter:
+        if k not in CUSTOM_ENTITIES_FILTER_KEYS:
+            msg = "Invalid custom entity filter key '%s'. Accepted filter " \
+                  "keys are %s" % (k, list(CUSTOM_ENTITIES_FILTER_KEYS))
+            raise _InvalidCustomEntityFilter(msg)
 
 
 @CRFFeatureFactory.register("builtin_entity_match")

--- a/snips_nlu/slot_filler/feature_factory.py
+++ b/snips_nlu/slot_filler/feature_factory.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 
-from abc import abstractmethod, ABCMeta
+import logging
+
+from abc import ABCMeta, abstractmethod
 from builtins import str
 
 from future.utils import with_metaclass
@@ -13,7 +15,7 @@ from snips_nlu.common.utils import check_random_state
 from snips_nlu.constants import (
     CUSTOM_ENTITY_PARSER_USAGE, END, GAZETTEERS, LANGUAGE, RES_MATCH_RANGE,
     START, STEMS, WORD_CLUSTERS, CUSTOM_ENTITY_PARSER, BUILTIN_ENTITY_PARSER,
-    RESOURCES, RANDOM_STATE)
+    RESOURCES, RANDOM_STATE, AUTOMATICALLY_EXTENSIBLE, ENTITIES)
 from snips_nlu.dataset import (
     extract_intent_entities, get_dataset_gazetteer_entities)
 from snips_nlu.entity_parser.builtin_entity_parser import is_builtin_entity
@@ -26,6 +28,22 @@ from snips_nlu.slot_filler.crf_utils import TaggingScheme, get_scheme_prefix
 from snips_nlu.slot_filler.feature import Feature
 from snips_nlu.slot_filler.features_utils import (
     entity_filter, get_word_chunk, initial_string_from_tokens)
+
+logger = logging.getLogger(__name__)
+
+class _InvalidCustomEntityFilter(ValueError):
+    pass
+
+
+CUSTOM_ENTITIES_FILTER_KEYS = {"automatically_extensible"}
+
+
+def _check_custom_entity_filter(entity_filter):
+    for k in entity_filter:
+        if k not in CUSTOM_ENTITIES_FILTER_KEYS:
+            msg = "Invalid custom entity filter key '%s'. Accepted filter " \
+                  "keys are %s" % (k, list(CUSTOM_ENTITIES_FILTER_KEYS))
+            raise _InvalidCustomEntityFilter(msg)
 
 
 class CRFFeatureFactory(with_metaclass(ABCMeta, Registrable)):
@@ -386,6 +404,12 @@ class CustomEntityMatchFactory(CRFFeatureFactory):
         for it among the (stemmed) entity values
     -   'tagging_scheme_code' (int): Represents a :class:`.TaggingScheme`. This
         allows to give more information about the match.
+    -   'entity_filter' (dict): a filter applied to select the custom entities
+        for which the custom match feature should be applied. Available
+        filters:
+            - 'automatically_extensible': if True, selects automatically
+             extensible entities only, if False selects non automatically
+             extensible entities only
     """
 
     def __init__(self, factory_config, **shared):
@@ -396,6 +420,16 @@ class CustomEntityMatchFactory(CRFFeatureFactory):
             self.args["tagging_scheme_code"])
         self._entities = None
         self.entities = self.args.get("entities")
+        entity_filter = self.args.get("entity_filter")
+        if entity_filter:
+            try:
+                _check_custom_entity_filter(entity_filter)
+            except _InvalidCustomEntityFilter as e:
+                logger.warning(
+                    "Invalid filter '%s', invalid arguments have been ignored:"
+                    " %s", entity_filter, e,
+                )
+        self.entity_filter = entity_filter
 
     @property
     def entities(self):
@@ -408,9 +442,15 @@ class CustomEntityMatchFactory(CRFFeatureFactory):
             self.args["entities"] = value
 
     def fit(self, dataset, intent):
-        self.entities = extract_intent_entities(
+        entities_names = extract_intent_entities(
             dataset, lambda e: not is_builtin_entity(e))[intent]
-        self.entities = list(self.entities)
+        extensible = self.entity_filter.get(AUTOMATICALLY_EXTENSIBLE)
+        if extensible is not None:
+            entities_names = [
+                e for e in entities_names
+                if dataset[ENTITIES][e][AUTOMATICALLY_EXTENSIBLE] == extensible
+            ]
+        self.entities = entities_names
         return self
 
     def _transform(self, tokens):

--- a/snips_nlu/slot_filler/feature_factory.py
+++ b/snips_nlu/slot_filler/feature_factory.py
@@ -405,7 +405,7 @@ class CustomEntityMatchFactory(CRFFeatureFactory):
     -   'tagging_scheme_code' (int): Represents a :class:`.TaggingScheme`. This
         allows to give more information about the match.
     -   'entity_filter' (dict): a filter applied to select the custom entities
-        for which the custom match feature should be applied. Available
+        for which the custom match feature will be computed. Available
         filters:
             - 'automatically_extensible': if True, selects automatically
              extensible entities only, if False selects non automatically

--- a/snips_nlu/slot_filler/feature_factory.py
+++ b/snips_nlu/slot_filler/feature_factory.py
@@ -420,16 +420,16 @@ class CustomEntityMatchFactory(CRFFeatureFactory):
             self.args["tagging_scheme_code"])
         self._entities = None
         self.entities = self.args.get("entities")
-        entity_filter = self.args.get("entity_filter")
-        if entity_filter:
+        ent_filter = self.args.get("entity_filter")
+        if ent_filter:
             try:
-                _check_custom_entity_filter(entity_filter)
+                _check_custom_entity_filter(ent_filter)
             except _InvalidCustomEntityFilter as e:
                 logger.warning(
                     "Invalid filter '%s', invalid arguments have been ignored:"
-                    " %s", entity_filter, e,
+                    " %s", ent_filter, e,
                 )
-        self.entity_filter = entity_filter or dict()
+        self.entity_filter = ent_filter or dict()
 
     @property
     def entities(self):

--- a/snips_nlu/slot_filler/feature_factory.py
+++ b/snips_nlu/slot_filler/feature_factory.py
@@ -429,7 +429,7 @@ class CustomEntityMatchFactory(CRFFeatureFactory):
                     "Invalid filter '%s', invalid arguments have been ignored:"
                     " %s", entity_filter, e,
                 )
-        self.entity_filter = entity_filter
+        self.entity_filter = entity_filter or dict()
 
     @property
     def entities(self):
@@ -450,7 +450,7 @@ class CustomEntityMatchFactory(CRFFeatureFactory):
                 e for e in entities_names
                 if dataset[ENTITIES][e][AUTOMATICALLY_EXTENSIBLE] == extensible
             ]
-        self.entities = entities_names
+        self.entities = list(entities_names)
         return self
 
     def _transform(self, tokens):

--- a/snips_nlu/slot_filler/feature_factory.py
+++ b/snips_nlu/slot_filler/feature_factory.py
@@ -407,9 +407,9 @@ class CustomEntityMatchFactory(CRFFeatureFactory):
     -   'entity_filter' (dict): a filter applied to select the custom entities
         for which the custom match feature will be computed. Available
         filters:
-            - 'automatically_extensible': if True, selects automatically
-             extensible entities only, if False selects non automatically
-             extensible entities only
+        - 'automatically_extensible': if True, selects automatically
+        extensible entities only, if False selects non automatically
+        extensible entities only
     """
 
     def __init__(self, factory_config, **shared):

--- a/snips_nlu/tests/test_crf_features.py
+++ b/snips_nlu/tests/test_crf_features.py
@@ -406,20 +406,26 @@ type: intent
 name: my_intent
 utterances:
 - this is [entity1](my first entity)
-- this is [entity2](second_entity)""")
+- this is [entity2](second_entity)
+- this is [entity3](third_entity)""")
 
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
+        dataset["entities"]["entity3"]["automatically_extensible"] = False
 
         config = {
             "factory_name": "entity_match",
             "args": {
                 "tagging_scheme_code": TaggingScheme.BILOU.value,
-                "use_stemming": True
+                "use_stemming": True,
+                "entity_filter": {
+                    "automatically_extensible": True,
+                }
             },
             "offsets": [0]
         }
 
-        tokens = tokenize("my first entity and second_entity", LANGUAGE_EN)
+        tokens = tokenize(
+            "my first entity and second_entity and third_entity", LANGUAGE_EN)
         cache = [{TOKEN_NAME: token} for token in tokens]
         resources = {STEMS: dict()}
         custom_entity_parser = CustomEntityParser.build(

--- a/snips_nlu/tests/test_crf_features.py
+++ b/snips_nlu/tests/test_crf_features.py
@@ -407,10 +407,14 @@ name: my_intent
 utterances:
 - this is [entity1](my first entity)
 - this is [entity2](second_entity)
-- this is [entity3](third_entity)""")
+- this is [entity3](third_entity)
+
+---
+type: entity
+name: entity3
+automatically_extensible: false""")
 
         dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
-        dataset["entities"]["entity3"]["automatically_extensible"] = False
 
         config = {
             "factory_name": "entity_match",

--- a/snips_nlu/tests/test_crf_features.py
+++ b/snips_nlu/tests/test_crf_features.py
@@ -414,10 +414,7 @@ utterances:
             "factory_name": "entity_match",
             "args": {
                 "tagging_scheme_code": TaggingScheme.BILOU.value,
-                "use_stemming": True,
-                "entity_filter": {
-                    "automatically_extensible": True,
-                }
+                "use_stemming": True
             },
             "offsets": [0]
         }
@@ -491,6 +488,7 @@ automatically_extensible: false""")
                 "use_stemming": True,
                 "entity_filter": {
                     "automatically_extensible": True,
+                    "invalid_filter": "i'm invalid"  # Should be ignored
                 }
             },
             "offsets": [0]


### PR DESCRIPTION
**Description**:
## Initial use case
When fitting the `CRFSlotFiller` on a intent, dropout is set once for all entities. However in practice we'd like to have a high dropout for `automatically_extensible` entities (since at inference time, we'll try to parse unseen entity values) and a lower dropout for non `automatically_extensible` entities (since we've seen all of them at training time)

## Work done
Added the ability to filter entity to which the `CustomEntityMatchFactory` is applied.
This `entity_filter` argument is passed as `args` in the `CustomEntityMatchFactory` configuration.

Currently only one flag can be set in the filter: `automatically_extensible`:
- if `True` then the feature will be computed only for `automatically_extensible` entities
- if `False` the  the feature will be computed only for non `automatically_extensible` entities

Updated the default language configuration accordingly.

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [x] I have updated the documentation, if applicable
