### PR TITLE
Add noise re-weight factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Add filter for entity match feature [#814](https://github.com/snipsco/snips-nlu/pull/815)
+- Add noise re-weight factor in `LogRegIntentClassifier` [#815](https://github.com/snipsco/snips-nlu/pull/815)
+
 ## [0.19.7]
 ### Changed
 - Re-score ambiguous `DeterministicIntentParser` results based on slots [#791](https://github.com/snipsco/snips-nlu/pull/791)
@@ -284,6 +289,7 @@ several commands.
 - Fix compiling issue with `bindgen` dependency when installing from source
 - Fix issue in `CRFSlotFiller` when handling builtin entities
 
+[Unreleased]: https://github.com/snipsco/snips-nlu/compare/0.19.7...HEAD
 [0.19.7]: https://github.com/snipsco/snips-nlu/compare/0.19.6...0.19.7
 [0.19.6]: https://github.com/snipsco/snips-nlu/compare/0.19.5...0.19.6
 [0.19.5]: https://github.com/snipsco/snips-nlu/compare/0.19.4...0.19.5

--- a/snips_nlu/default_configs/config_de.py
+++ b/snips_nlu/default_configs/config_de.py
@@ -153,7 +153,8 @@ CONFIG = {
                         "unknown_words_replacement_string": None,
                         "keep_order": True
                     }
-                }
+                },
+                "noise_reweight_factor": 1,
             }
         }
     ]

--- a/snips_nlu/default_configs/config_en.py
+++ b/snips_nlu/default_configs/config_en.py
@@ -139,7 +139,8 @@ CONFIG = {
                         "unknown_words_replacement_string": None,
                         "keep_order": True
                     }
-                }
+                },
+                "noise_reweight_factor": 1,
             }
         }
     ]

--- a/snips_nlu/default_configs/config_es.py
+++ b/snips_nlu/default_configs/config_es.py
@@ -132,7 +132,8 @@ CONFIG = {
                         "unknown_words_replacement_string": None,
                         "keep_order": True
                     }
-                }
+                },
+                "noise_reweight_factor": 1,
             }
         }
     ]

--- a/snips_nlu/default_configs/config_fr.py
+++ b/snips_nlu/default_configs/config_fr.py
@@ -131,7 +131,8 @@ CONFIG = {
                         "unknown_words_replacement_string": None,
                         "keep_order": True
                     }
-                }
+                },
+                "noise_reweight_factor": 1,
             }
         }
     ]

--- a/snips_nlu/default_configs/config_it.py
+++ b/snips_nlu/default_configs/config_it.py
@@ -131,7 +131,8 @@ CONFIG = {
                         "unknown_words_replacement_string": None,
                         "keep_order": True
                     }
-                }
+                },
+                "noise_reweight_factor": 1,
             }
         }
     ]

--- a/snips_nlu/default_configs/config_ja.py
+++ b/snips_nlu/default_configs/config_ja.py
@@ -158,7 +158,8 @@ CONFIG = {
                         "unknown_words_replacement_string": None,
                         "keep_order": True
                     }
-                }
+                },
+                "noise_reweight_factor": 1,
             }
         }
     ]

--- a/snips_nlu/default_configs/config_ko.py
+++ b/snips_nlu/default_configs/config_ko.py
@@ -149,7 +149,8 @@ CONFIG = {
                         "unknown_words_replacement_string": None,
                         "keep_order": True
                     }
-                }
+                },
+                "noise_reweight_factor": 1,
             }
         }
     ]

--- a/snips_nlu/default_configs/config_pt_br.py
+++ b/snips_nlu/default_configs/config_pt_br.py
@@ -104,7 +104,6 @@ CONFIG = {
                     "capitalization_ratio": 0.2,
                     "add_builtin_entities_examples": True
                 },
-                "random_seed": None
             },
             "intent_classifier_config": {
                 "unit_name": "log_reg_intent_classifier",
@@ -133,8 +132,8 @@ CONFIG = {
                         "keep_order": True
                     }
                 },
-                "random_seed": None
-            }
+            },
+            "noise_reweight_factor": 1,
         }
     ]
 }

--- a/snips_nlu/default_configs/config_pt_pt.py
+++ b/snips_nlu/default_configs/config_pt_pt.py
@@ -104,7 +104,6 @@ CONFIG = {
                     "capitalization_ratio": 0.2,
                     "add_builtin_entities_examples": True
                 },
-                "random_seed": None
             },
             "intent_classifier_config": {
                 "unit_name": "log_reg_intent_classifier",
@@ -133,8 +132,8 @@ CONFIG = {
                         "keep_order": True
                     }
                 },
-                "random_seed": None
-            }
+            },
+            "noise_reweight_factor": 1,
         }
     ]
 }

--- a/snips_nlu/intent_classifier/log_reg_classifier.py
+++ b/snips_nlu/intent_classifier/log_reg_classifier.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import numpy as np
 from sklearn.linear_model import SGDClassifier
+from sklearn.utils import compute_class_weight
 
 from snips_nlu.common.log_utils import DifferedLoggingMessage, log_elapsed_time
 from snips_nlu.common.utils import (
@@ -34,7 +35,6 @@ logger = logging.getLogger(__name__)
 LOG_REG_ARGS = {
     "loss": "log",
     "penalty": "l2",
-    "class_weight": "balanced",
     "max_iter": 1000,
     "tol": 1e-3,
     "n_jobs": -1
@@ -102,8 +102,16 @@ class LogRegIntentClassifier(IntentClassifier):
             return self
 
         alpha = get_regularization_factor(dataset)
+
+        class_weights_arr = compute_class_weight(
+            "balanced", range(none_class + 1), classes)
+        # Re-weight the noise class
+        class_weights_arr[-1] *= self.config.noise_reweight_factor
+        class_weight = {idx: w for idx, w in enumerate(class_weights_arr)}
+
         self.classifier = SGDClassifier(
-            random_state=self.random_state, alpha=alpha, **LOG_REG_ARGS)
+            random_state=self.random_state, alpha=alpha,
+            class_weight=class_weight, **LOG_REG_ARGS)
         self.classifier.fit(x, classes)
         logger.debug("%s", DifferedLoggingMessage(self.log_best_features))
         return self

--- a/snips_nlu/pipeline/configs/intent_classifier.py
+++ b/snips_nlu/pipeline/configs/intent_classifier.py
@@ -14,13 +14,17 @@ class LogRegIntentClassifierConfig(FromDict, ProcessingUnitConfig):
 
     # pylint: disable=line-too-long
     def __init__(self, data_augmentation_config=None, featurizer_config=None,
-                 noise_reweight_factor=None):
+                 noise_reweight_factor=1.0):
         """
         Args:
             data_augmentation_config (:class:`IntentClassifierDataAugmentationConfig`):
                     Defines the strategy of the underlying data augmentation
             featurizer_config (:class:`FeaturizerConfig`): Configuration of the
                 :class:`.Featurizer` used underneath
+            noise_reweight_factor (float, optional): this parameter allows to
+                change the weight of the None class. By default, the class
+                weights are computed using a "balanced" strategy. The
+                noise_reweight_factor allows to deviate from this strategy.
         """
         if data_augmentation_config is None:
             data_augmentation_config = IntentClassifierDataAugmentationConfig()
@@ -30,8 +34,6 @@ class LogRegIntentClassifierConfig(FromDict, ProcessingUnitConfig):
         self.data_augmentation_config = data_augmentation_config
         self._featurizer_config = None
         self.featurizer_config = featurizer_config
-        if noise_reweight_factor is None:
-            noise_reweight_factor = 1
         self.noise_reweight_factor = noise_reweight_factor
 
     # pylint: enable=line-too-long

--- a/snips_nlu/pipeline/configs/intent_classifier.py
+++ b/snips_nlu/pipeline/configs/intent_classifier.py
@@ -13,7 +13,8 @@ class LogRegIntentClassifierConfig(FromDict, ProcessingUnitConfig):
     """Configuration of a :class:`.LogRegIntentClassifier`"""
 
     # pylint: disable=line-too-long
-    def __init__(self, data_augmentation_config=None, featurizer_config=None):
+    def __init__(self, data_augmentation_config=None, featurizer_config=None,
+                 noise_reweight_factor=None):
         """
         Args:
             data_augmentation_config (:class:`IntentClassifierDataAugmentationConfig`):
@@ -29,6 +30,9 @@ class LogRegIntentClassifierConfig(FromDict, ProcessingUnitConfig):
         self.data_augmentation_config = data_augmentation_config
         self._featurizer_config = None
         self.featurizer_config = featurizer_config
+        if noise_reweight_factor is None:
+            noise_reweight_factor = 1
+        self.noise_reweight_factor = noise_reweight_factor
 
     # pylint: enable=line-too-long
 
@@ -79,7 +83,8 @@ class LogRegIntentClassifierConfig(FromDict, ProcessingUnitConfig):
             "unit_name": self.unit_name,
             "data_augmentation_config":
                 self.data_augmentation_config.to_dict(),
-            "featurizer_config": self.featurizer_config.to_dict()
+            "featurizer_config": self.featurizer_config.to_dict(),
+            "noise_reweight_factor": self.noise_reweight_factor,
         }
 
 

--- a/snips_nlu/tests/test_config.py
+++ b/snips_nlu/tests/test_config.py
@@ -112,7 +112,8 @@ class TestConfig(SnipsTest):
             "unit_name": LogRegIntentClassifier.unit_name,
             "data_augmentation_config":
                 IntentClassifierDataAugmentationConfig().to_dict(),
-            "featurizer_config": FeaturizerConfig().to_dict()
+            "featurizer_config": FeaturizerConfig().to_dict(),
+            "noise_reweight_factor": 5,
         }
 
         # When


### PR DESCRIPTION
**Description**:
This PR introduces a new parameter in the `LogRegIntentClassifierConfig` which is named `noise_reweight_factor`.
This parameter allows to deviate from the default "balanced" class weight strategy by multiplying the Noise class weight by a given factor.
Typically, using `noise_reweight_factor > 1` will end up in a more conservative engine, meaning that it will predict `None` more often, and vice versa.

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [ ] I have updated the documentation, if applicable
