### PR TITLE
Allow to bypass version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Allow to bypass the model version check [#830](https://github.com/snipsco/snips-nlu/pull/830)
+
 ## [0.20.0]
 ### Added
 - Add new intent parser: `LookupIntentParser` [#759](https://github.com/snipsco/snips-nlu/pull/759)
@@ -312,6 +316,7 @@ several commands.
 - Fix compiling issue with `bindgen` dependency when installing from source
 - Fix issue in `CRFSlotFiller` when handling builtin entities
 
+[Unreleased]: https://github.com/snipsco/snips-nlu/compare/0.20.0...HEAD
 [0.20.0]: https://github.com/snipsco/snips-nlu/compare/0.19.8...0.20.0
 [0.19.8]: https://github.com/snipsco/snips-nlu/compare/0.19.7...0.19.8
 [0.19.7]: https://github.com/snipsco/snips-nlu/compare/0.19.6...0.19.7

--- a/snips_nlu/constants.py
+++ b/snips_nlu/constants.py
@@ -47,6 +47,7 @@ BUILTIN_ENTITY_PARSER = "builtin_entity_parser"
 CUSTOM_ENTITY_PARSER = "custom_entity_parser"
 MATCHING_STRICTNESS = "matching_strictness"
 RANDOM_STATE = "random_state"
+BYPASS_VERSION_CHECK = "bypass_version_check"
 
 # resources
 RESOURCES = "resources"

--- a/snips_nlu/nlu_engine/nlu_engine.py
+++ b/snips_nlu/nlu_engine/nlu_engine.py
@@ -17,7 +17,7 @@ from snips_nlu.constants import (
     AUTOMATICALLY_EXTENSIBLE, BUILTIN_ENTITY_PARSER, CUSTOM_ENTITY_PARSER,
     ENTITIES, ENTITY_KIND, LANGUAGE, RESOLVED_VALUE, RES_ENTITY,
     RES_INTENT, RES_INTENT_NAME, RES_MATCH_RANGE, RES_PROBA, RES_SLOTS,
-    RES_VALUE, RESOURCES)
+    RES_VALUE, RESOURCES, BYPASS_VERSION_CHECK)
 from snips_nlu.dataset import validate_and_format_dataset
 from snips_nlu.default_configs import DEFAULT_CONFIGS
 from snips_nlu.entity_parser import CustomEntityParser
@@ -349,7 +349,14 @@ class SnipsNLUEngine(ProcessingUnit):
             model = json.load(f)
         model_version = model.get("model_version")
         if model_version is None or model_version != __model_version__:
-            raise IncompatibleModelError(model_version)
+            bypass_version_check = shared.get(BYPASS_VERSION_CHECK, False)
+            if bypass_version_check:
+                logger.warning(
+                    "Incompatible model version found. The library expected "
+                    "'%s' but the loaded engine is '%s'. The NLU engine may "
+                    "not load correctly.", __model_version__, model_version)
+            else:
+                raise IncompatibleModelError(model_version)
 
         dataset_metadata = model["dataset_metadata"]
         if shared.get(RESOURCES) is None and dataset_metadata is not None:

--- a/snips_nlu/tests/test_nlu_engine.py
+++ b/snips_nlu/tests/test_nlu_engine.py
@@ -745,6 +745,24 @@ utterances:
         with self.assertRaises(IncompatibleModelError):
             SnipsNLUEngine.from_path(self.tmp_file_path)
 
+    def test_should_bypass_model_version_check_when_specified(self):
+        # Given
+        dataset_stream = io.StringIO("""
+---
+type: intent
+name: Greeting
+utterances:
+- hello world""")
+        dataset = Dataset.from_yaml_files("en", [dataset_stream]).json
+
+        with patch("snips_nlu.nlu_engine.nlu_engine.__model_version__",
+                   "0.1.0"):
+            engine = SnipsNLUEngine().fit(dataset)
+            engine.persist(self.tmp_file_path)
+
+        # When / Then
+        SnipsNLUEngine.from_path(self.tmp_file_path, bypass_version_check=True)
+
     def test_should_raise_when_persisting_at_existing_path(self):
         # Given
         self.tmp_file_path.mkdir()


### PR DESCRIPTION
**Description**:
This PR adds the ability to bypass the model version check which is performed when loading an nlu engine with the `from_path` API:
```python
from snips_nlu import SnipsNLUEngine

engine = SnipsNLUEngine.from_path("path/to/nlu_engine", bypass_version_check=True)
```

The version check is there to ensure compatibility between the loader (the library itself) and the loaded (the trained engine directory/bytes). If the two versions don't match, then an error is raised and the loading is stopped.
The actual incompatibility often depends on the NLU configuration used, which is why it can be useful to disable this check for cases where the trained data is known to be compatible with the new version of the library. In such cases, a warning log will be emitted.

**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [ ] I have updated the documentation, if applicable
