### PR TITLE
Handle license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added
 - Allow to bypass the model version check [#830](https://github.com/snipsco/snips-nlu/pull/830)
+- Persist `CustomEntityParser` license when needed [#832](https://github.com/snipsco/snips-nlu/pull/832)
 
 ## [0.20.0]
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ required = [
     "scikit-learn>=0.21.1,<0.22; python_version>='3.5'",
     "scipy>=1.0,<2.0",
     "sklearn-crfsuite>=0.3.6,<0.4",
-    "snips-nlu-parsers>=0.3.1,<0.4",
+    "snips-nlu-parsers>=0.3,<0.4",
     "snips_nlu_utils>=0.9,<0.10",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ required = [
     "scikit-learn>=0.21.1,<0.22; python_version>='3.5'",
     "scipy>=1.0,<2.0",
     "sklearn-crfsuite>=0.3.6,<0.4",
-    "snips-nlu-parsers>=0.3,<0.4",
+    "snips-nlu-parsers>=0.3.1,<0.4",
     "snips_nlu_utils>=0.9,<0.10",
 ]
 

--- a/snips_nlu/constants.py
+++ b/snips_nlu/constants.py
@@ -46,6 +46,7 @@ END = "end"
 BUILTIN_ENTITY_PARSER = "builtin_entity_parser"
 CUSTOM_ENTITY_PARSER = "custom_entity_parser"
 MATCHING_STRICTNESS = "matching_strictness"
+LICENSE_INFO = "license_info"
 RANDOM_STATE = "random_state"
 BYPASS_VERSION_CHECK = "bypass_version_check"
 

--- a/snips_nlu/dataset/validation.py
+++ b/snips_nlu/dataset/validation.py
@@ -12,7 +12,7 @@ from snips_nlu.common.dataset_utils import (validate_key, validate_keys,
 from snips_nlu.constants import (
     AUTOMATICALLY_EXTENSIBLE, CAPITALIZE, DATA, ENTITIES, ENTITY, INTENTS,
     LANGUAGE, MATCHING_STRICTNESS, SLOT_NAME, SYNONYMS, TEXT, USE_SYNONYMS,
-    UTTERANCES, VALIDATED, VALUE)
+    UTTERANCES, VALIDATED, VALUE, LICENSE_INFO)
 from snips_nlu.dataset import extract_utterance_entities
 from snips_nlu.entity_parser.builtin_entity_parser import (
     BuiltinEntityParser, is_builtin_entity)
@@ -146,6 +146,8 @@ def _validate_and_format_custom_entity(entity, utterance_entities, language,
     formatted_entity[AUTOMATICALLY_EXTENSIBLE] = entity[
         AUTOMATICALLY_EXTENSIBLE]
     formatted_entity[MATCHING_STRICTNESS] = entity[MATCHING_STRICTNESS]
+    if LICENSE_INFO in entity:
+        formatted_entity[LICENSE_INFO] = entity[LICENSE_INFO]
     use_synonyms = entity[USE_SYNONYMS]
 
     # Validate format and filter out unused data

--- a/snips_nlu/entity_parser/custom_entity_parser.py
+++ b/snips_nlu/entity_parser/custom_entity_parser.py
@@ -10,7 +10,8 @@ from future.utils import iteritems, viewvalues
 
 from snips_nlu.common.utils import json_string
 from snips_nlu.constants import (
-    END, ENTITIES, LANGUAGE, MATCHING_STRICTNESS, START, UTTERANCES)
+    END, ENTITIES, LANGUAGE, MATCHING_STRICTNESS, START, UTTERANCES,
+    LICENSE_INFO)
 from snips_nlu.entity_parser.builtin_entity_parser import is_builtin_entity
 from snips_nlu.entity_parser.custom_entity_parser_usage import (
     CustomEntityParserUsage)
@@ -168,9 +169,8 @@ def _create_custom_entity_parser_configuration(
                 ]
             }
         }
-        license_info = entity.get("license_info")
-        if license_info is not None:
-            config["entity_parser"]["license_info"] = license_info
+        if LICENSE_INFO in entity:
+            config["entity_parser"][LICENSE_INFO] = entity[LICENSE_INFO]
         parser_configurations.append(config)
 
     configuration = {

--- a/snips_nlu/entity_parser/custom_entity_parser.py
+++ b/snips_nlu/entity_parser/custom_entity_parser.py
@@ -168,6 +168,9 @@ def _create_custom_entity_parser_configuration(
                 ]
             }
         }
+        license_info = entity.get("license_info")
+        if license_info is not None:
+            config["entity_parser"]["license_info"] = license_info
         parser_configurations.append(config)
 
     configuration = {

--- a/snips_nlu/tests/test_custom_entity_parser.py
+++ b/snips_nlu/tests/test_custom_entity_parser.py
@@ -3,10 +3,8 @@ from __future__ import unicode_literals
 
 from pathlib import Path
 
-import snips_nlu_parsers
 from mock import patch
 
-from snips_nlu.common.utils import parse_version
 from snips_nlu.constants import STEMS
 from snips_nlu.dataset import validate_and_format_dataset
 from snips_nlu.entity_parser import CustomEntityParser
@@ -231,7 +229,6 @@ class TestCustomEntityParser(FixtureTest):
         self.assertEqual(1, mocked_parse.call_count)
 
     def test_should_be_serializable(self):
-        import pkg_resources
         # Given
         parser = CustomEntityParser.build(
             DATASET, CustomEntityParserUsage.WITHOUT_STEMS, resources=dict())
@@ -239,9 +236,6 @@ class TestCustomEntityParser(FixtureTest):
         parser_path = self.tmp_file_path / "custom_entity_parser"
         parser.persist(parser_path)
         loaded_parser = CustomEntityParser.from_path(parser_path)
-
-        expected_license_path = parser_path / "parser_1" / "LICENSE"
-        self.assertTrue(expected_license_path.exists())
 
         # When
         scope = ["dummy_entity_1"]
@@ -270,6 +264,11 @@ class TestCustomEntityParser(FixtureTest):
             }
         ]
         self.assertListEqual(expected_entities, result)
+        license_path = parser_path / "parser" / "parser_1" / "LICENSE"
+        self.assertTrue(license_path.exists())
+        with license_path.open(encoding="utf8") as f:
+            license_content = f.read()
+        self.assertEqual("some license content here", license_content)
 
     def test_should_compute_tokenization_shift(self):
         # Given
@@ -296,7 +295,7 @@ class TestCustomEntityParser(FixtureTest):
                 "matching_strictness": 1.0
             },
             "b": {
-                "utterances":{
+                "utterances": {
                     "b": "b"
                 },
                 "matching_strictness": 1.0
@@ -347,6 +346,7 @@ class TestCustomEntityParser(FixtureTest):
             ]
         }
         self.assertDictEqual(expected_dict, config)
+
 
 # pylint: disable=unused-argument
 def _persist_parser(path):

--- a/snips_nlu/tests/test_custom_entity_parser.py
+++ b/snips_nlu/tests/test_custom_entity_parser.py
@@ -3,8 +3,10 @@ from __future__ import unicode_literals
 
 from pathlib import Path
 
+import snips_nlu_parsers
 from mock import patch
 
+from snips_nlu.common.utils import parse_version
 from snips_nlu.constants import STEMS
 from snips_nlu.dataset import validate_and_format_dataset
 from snips_nlu.entity_parser import CustomEntityParser
@@ -28,7 +30,11 @@ DATASET = validate_and_format_dataset({
             ],
             "use_synonyms": True,
             "automatically_extensible": True,
-            "matching_strictness": 1.0
+            "matching_strictness": 1.0,
+            "license_info": {
+                "filename": "LICENSE",
+                "content": "some license content here"
+            }
         },
         "dummy_entity_2": {
             "data": [
@@ -225,6 +231,7 @@ class TestCustomEntityParser(FixtureTest):
         self.assertEqual(1, mocked_parse.call_count)
 
     def test_should_be_serializable(self):
+        import pkg_resources
         # Given
         parser = CustomEntityParser.build(
             DATASET, CustomEntityParserUsage.WITHOUT_STEMS, resources=dict())
@@ -232,6 +239,9 @@ class TestCustomEntityParser(FixtureTest):
         parser_path = self.tmp_file_path / "custom_entity_parser"
         parser.persist(parser_path)
         loaded_parser = CustomEntityParser.from_path(parser_path)
+
+        expected_license_path = parser_path / "parser_1" / "LICENSE"
+        self.assertTrue(expected_license_path.exists())
 
         # When
         scope = ["dummy_entity_1"]

--- a/snips_nlu/tests/test_dataset_validation.py
+++ b/snips_nlu/tests/test_dataset_validation.py
@@ -1129,3 +1129,48 @@ class TestDatasetValidation(SnipsTest):
             "validated": True
         }
         self.assertDictEqual(expected_dataset, validated_dataset)
+
+    def test_should_keep_license_info(self):
+        # Given
+        dataset = {
+            "intents": {},
+            "entities": {
+                "my_entity": {
+                    "data": [{"value": "foo", "synonyms": []}],
+                    "use_synonyms": True,
+                    "automatically_extensible": True,
+                    "matching_strictness": 1.0,
+                    "license_info": {
+                        "filename": "LICENSE",
+                        "content": "some license content here"
+                    }
+                },
+            },
+            "language": "en"
+        }
+
+        # When
+        validated_dataset = validate_and_format_dataset(dataset)
+
+        # Then
+        expected_dataset = {
+            "entities": {
+                "my_entity": {
+                    "automatically_extensible": True,
+                    "capitalize": False,
+                    "matching_strictness": 1.0,
+                    "utterances": {
+                        "Foo": "foo",
+                        "foo": "foo"
+                    },
+                    "license_info": {
+                        "filename": "LICENSE",
+                        "content": "some license content here"
+                    }
+                }
+            },
+            "intents": {},
+            "language": "en",
+            "validated": True
+        }
+        self.assertDictEqual(expected_dataset, validated_dataset)


### PR DESCRIPTION
**Description**:
In some case the dataset might contain data subject to license terms that need to be placed next to the parsers built from this data.

When fitting the custom entity parser, if the dataset contains license information, the gazetteer entity parser are build with `license_info` (`snips-nlu-parser>=0.3.1`) which ensure that the license will be persisted at the right location when persisting the engine


**Checklist**:
- [x] My PR is ready for code review
- [x] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [ ] I have updated the documentation, if applicable
