### PR TITLE
Invalidate importlib caches after dynamically installing module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 - Allow to bypass the model version check [#830](https://github.com/snipsco/snips-nlu/pull/830)
 - Persist `CustomEntityParser` license when needed [#832](https://github.com/snipsco/snips-nlu/pull/832)
 
+### Fixed
+- Invalidate importlib caches after dynamically installing module [#838](https://github.com/snipsco/snips-nlu/pull/838)
+
 ## [0.20.0] - 2019-07-16
 ### Added
 - Add new intent parser: `LookupIntentParser` [#759](https://github.com/snipsco/snips-nlu/pull/759)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ required = [
     "scikit-learn>=0.21.1,<0.22; python_version>='3.5'",
     "scipy>=1.0,<2.0",
     "sklearn-crfsuite>=0.3.6,<0.4",
-    "snips-nlu-parsers>=0.3,<0.4",
+    "snips-nlu-parsers>=0.3.1,<0.4",
     "snips_nlu_utils>=0.9,<0.10",
 ]
 

--- a/snips_nlu/cli/utils.py
+++ b/snips_nlu/cli/utils.py
@@ -12,6 +12,13 @@ import snips_nlu
 from snips_nlu import __about__
 from snips_nlu.common.utils import parse_version
 
+try:
+    from importlib import invalidate_caches
+except ImportError:
+    def invalidate_caches():
+        from time import sleep
+        sleep(1)
+
 
 @unique
 class PrettyPrintLevel(Enum):
@@ -97,7 +104,11 @@ def install_remote_package(download_url, user_pip_args=None):
     if user_pip_args:
         pip_args.extend(user_pip_args)
     cmd = [sys.executable, '-m', 'pip', 'install'] + pip_args + [download_url]
-    return subprocess.call(cmd, env=os.environ.copy())
+    exit_code = subprocess.call(cmd, env=os.environ.copy())
+    # Don't forget to invalidate caches after dynamically installing modules
+    # https://docs.python.org/3/library/importlib.html#importlib.import_module
+    invalidate_caches()
+    return exit_code
 
 
 def check_resources_alias(resource_name, shortcuts):


### PR DESCRIPTION
**Description**:
As specified in the [importlib documentation](https://docs.python.org/3/library/importlib.html#importlib.import_module), the importlib caches must be invalidated after dynamically installing a module.

**Checklist**:
- [x] My PR is ready for code review
- [ ] I have added some tests, if applicable, and run the whole test suite, including [linting tests](../linting_test.py)
- [ ] I have updated the documentation, if applicable
